### PR TITLE
feat(filter): Parent process filters

### DIFF
--- a/pkg/filter/accessor.go
+++ b/pkg/filter/accessor.go
@@ -27,7 +27,6 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/network"
 	"github.com/rabbitstack/fibratus/pkg/pe"
 	pstypes "github.com/rabbitstack/fibratus/pkg/ps/types"
-	"math"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -346,19 +345,19 @@ func (ps *psAccessor) get(f fields.Field, kevt *kevent.Kevent) (kparams.Value, e
 
 		case strings.HasPrefix(field, fields.PsParentSequence):
 			key, segment := captureInBrackets(field)
-			depth, err := strconv.Atoi(key)
+			depth, err := strconv.Atoi(strings.TrimSpace(key))
 			if err != nil {
-				// we got the last key
-				depth = math.MaxUint32
+				// we got the `root` key
+				depth = -1
 			}
+
 			var (
 				dp int
 				ps *pstypes.PS
 			)
-
 			pstypes.Visit(func(proc *pstypes.PS) {
 				dp++
-				if dp == depth || depth == math.MaxUint32 {
+				if dp == depth || depth == -1 {
 					ps = proc
 				}
 			}, kevt.PS)
@@ -370,6 +369,20 @@ func (ps *psAccessor) get(f fields.Field, kevt *kevent.Kevent) (kparams.Value, e
 			switch segment {
 			case fields.ProcessName:
 				return ps.Name, nil
+			case fields.ProcessID:
+				return ps.PID, nil
+			case fields.ProcessSID:
+				return ps.SID, nil
+			case fields.ProcessSessionID:
+				return ps.SessionID, nil
+			case fields.ProcessCwd:
+				return ps.Cwd, nil
+			case fields.ProcessComm:
+				return ps.Comm, nil
+			case fields.ProcessArgs:
+				return ps.Args, nil
+			case fields.ProcessExe:
+				return ps.Exe, nil
 			}
 		}
 

--- a/pkg/filter/fields/fields.go
+++ b/pkg/filter/fields/fields.go
@@ -24,6 +24,8 @@ import (
 	"sort"
 )
 
+// pathRegexp splits the provided path into different components. The first capture
+// contains the indexed field name. Next is the indexed key and, finally the segment.
 var pathRegexp = regexp.MustCompile(`(pe.sections|pe.resources|ps.envs|ps.modules|ps.parent)\[.+\s*].?(.*)`)
 
 // Field represents the type alias for the field
@@ -231,27 +233,28 @@ const (
 // String casts the field type to string.
 func (f Field) String() string { return string(f) }
 
-// Subfield represents the type alias for the subfield.
-type Subfield string
+// Segment represents the type alias for the segment. Segment
+// denotes the location of the value within an indexed field.
+type Segment string
 
 const (
 	// SectionEntropy is the entropy value of the specific PE section
-	SectionEntropy Subfield = "entropy"
+	SectionEntropy Segment = "entropy"
 	// SectionMD5Hash refers to the section md5 sum
-	SectionMD5Hash Subfield = "md5"
+	SectionMD5Hash Segment = "md5"
 	// SectionSize is the section size
-	SectionSize Subfield = "size"
+	SectionSize Segment = "size"
 
 	// ModuleSize is the module size
-	ModuleSize Subfield = "size"
+	ModuleSize Segment = "size"
 	// ModuleChecksum is the module checksum
-	ModuleChecksum Subfield = "checksum"
+	ModuleChecksum Segment = "checksum"
 	// ModuleLocation is the module location
-	ModuleLocation Subfield = "location"
+	ModuleLocation Segment = "location"
 	// ModuleBaseAddress is the module base address
-	ModuleBaseAddress Subfield = "address.base"
+	ModuleBaseAddress Segment = "address.base"
 	// ModuleDefaultAddress is the module address
-	ModuleDefaultAddress Subfield = "address.default"
+	ModuleDefaultAddress Segment = "address.default"
 )
 
 const (
@@ -393,11 +396,11 @@ func Lookup(name string) Field {
 	}
 
 	field := groups[1]
-	subfield := groups[2]
+	segment := groups[2]
 
 	switch Field(field) {
 	case PeSections:
-		switch Subfield(subfield) {
+		switch Segment(segment) {
 		case SectionEntropy:
 			return Field(name)
 		case SectionMD5Hash:
@@ -410,7 +413,7 @@ func Lookup(name string) Field {
 	case PsEnvs:
 		return Field(name)
 	case PsModules:
-		switch Subfield(subfield) {
+		switch Segment(segment) {
 		case ModuleSize:
 			return Field(ModuleSize)
 		case ModuleChecksum:
@@ -423,6 +426,9 @@ func Lookup(name string) Field {
 			return Field(ModuleLocation)
 		}
 	case PsParent:
+		if segment == "" {
+			return None
+		}
 		return Field(name)
 	}
 	return None

--- a/pkg/filter/fields/fields.go
+++ b/pkg/filter/fields/fields.go
@@ -267,8 +267,22 @@ const (
 	// ModuleDefaultAddress is the module address
 	ModuleDefaultAddress Segment = "address.default"
 
+	// ProcessID represents the process id
+	ProcessID Segment = "pid"
 	// ProcessName represents the process name
 	ProcessName Segment = "name"
+	// PsComm represents the process command line
+	ProcessComm Segment = "comm"
+	// ProcessExe represents the process image path
+	ProcessExe Segment = "exe"
+	// ProcessArgs represents the process command line arguments
+	ProcessArgs Segment = "args"
+	// ProcessCwd represents the process current working directory
+	ProcessCwd Segment = "cwd"
+	// ProcessSID represents the process security identifier
+	ProcessSID Segment = "sid"
+	// ProcessSessionID represents the session id bound to the process
+	ProcessSessionID Segment = "sessionid"
 )
 
 const (
@@ -469,8 +483,21 @@ func Lookup(name string) Field {
 		switch Segment(segment) {
 		case ProcessName:
 			return Field(name)
+		case ProcessID:
+			return Field(name)
+		case ProcessArgs:
+			return Field(name)
+		case ProcessComm:
+			return Field(name)
+		case ProcessCwd:
+			return Field(name)
+		case ProcessExe:
+			return Field(name)
+		case ProcessSID:
+			return Field(name)
+		case ProcessSessionID:
+			return Field(name)
 		}
-
 	case PeResources:
 		if segment == "" {
 			return Field(name)

--- a/pkg/filter/fields/fields_test.go
+++ b/pkg/filter/fields/fields_test.go
@@ -26,6 +26,7 @@ import (
 func TestLookup(t *testing.T) {
 	assert.Equal(t, PsPid, Lookup("ps.pid"))
 	assert.Equal(t, Field("ps.envs[ALLUSERSPROFILE]"), Lookup("ps.envs[ALLUSERSPROFILE]"))
+	assert.Empty(t, Lookup("ps.envs[ALLUSERSPROFILE].env"))
 	assert.Empty(t, Lookup("ps.envs[ALLUSERSPROFILE"))
 	assert.Empty(t, Lookup("ps.envs["))
 	assert.Empty(t, Lookup("ps.envs[]"))
@@ -36,6 +37,6 @@ func TestLookup(t *testing.T) {
 	assert.Empty(t, Lookup("ps.pe.sections[.debug$S]."))
 	assert.Empty(t, Lookup("ps.pe.sections[.debug$S].e"))
 	assert.Equal(t, Field("ps.parent[1].name"), Lookup("ps.parent[1].name"))
-	assert.Equal(t, Field("ps.parent[*].name"), Lookup("ps.parent[*].name"))
-	assert.Equal(t, Field("ps.parent[*]"), Lookup("ps.parent[*]"))
+	assert.Equal(t, Field("ps.parent[root].name"), Lookup("ps.parent[root].name"))
+	assert.Empty(t, Lookup("ps.parent[ro].name"))
 }

--- a/pkg/filter/fields/fields_test.go
+++ b/pkg/filter/fields/fields_test.go
@@ -35,4 +35,6 @@ func TestLookup(t *testing.T) {
 	assert.Empty(t, Lookup("ps.pe.sections[.debug$S]"))
 	assert.Empty(t, Lookup("ps.pe.sections[.debug$S]."))
 	assert.Empty(t, Lookup("ps.pe.sections[.debug$S].e"))
+	assert.Equal(t, Field("ps.parent[1].name"), Lookup("ps.parent[1].name"))
+	assert.Equal(t, Field("ps.parent[*].name"), Lookup("ps.parent[*].name"))
 }

--- a/pkg/filter/fields/fields_test.go
+++ b/pkg/filter/fields/fields_test.go
@@ -38,5 +38,6 @@ func TestLookup(t *testing.T) {
 	assert.Empty(t, Lookup("ps.pe.sections[.debug$S].e"))
 	assert.Equal(t, Field("ps.parent[1].name"), Lookup("ps.parent[1].name"))
 	assert.Equal(t, Field("ps.parent[root].name"), Lookup("ps.parent[root].name"))
+	assert.Equal(t, Field("ps.parent[2].sid"), Lookup("ps.parent[2].sid"))
 	assert.Empty(t, Lookup("ps.parent[ro].name"))
 }

--- a/pkg/filter/fields/fields_test.go
+++ b/pkg/filter/fields/fields_test.go
@@ -37,4 +37,5 @@ func TestLookup(t *testing.T) {
 	assert.Empty(t, Lookup("ps.pe.sections[.debug$S].e"))
 	assert.Equal(t, Field("ps.parent[1].name"), Lookup("ps.parent[1].name"))
 	assert.Equal(t, Field("ps.parent[*].name"), Lookup("ps.parent[*].name"))
+	assert.Equal(t, Field("ps.parent[*]"), Lookup("ps.parent[*]"))
 }

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -61,12 +61,22 @@ func TestFilterRunProcessKevent(t *testing.T) {
 		kparams.ProcessID:       {Name: kparams.ProcessID, Type: kparams.PID, Value: uint32(1234)},
 		kparams.ProcessParentID: {Name: kparams.ProcessParentID, Type: kparams.PID, Value: uint32(345)},
 	}
+
+	ps1 := &pstypes.PS{
+		Name: "wininit.exe",
+		Parent: &pstypes.PS{
+			Name: "services.exe",
+		},
+	}
+
 	kevt := &kevent.Kevent{
 		Type:    ktypes.CreateProcess,
 		Kparams: kpars,
 		Name:    "CreateProcess",
 		PID:     1023,
 		PS: &pstypes.PS{
+			Name: "svchost.exe",
+			Parent: ps1,
 			Ppid: 345,
 			Envs: map[string]string{"ALLUSERSPROFILE": "C:\\ProgramData", "OS": "Windows_NT", "ProgramFiles(x86)": "C:\\Program Files (x86)"},
 			Modules: []pstypes.Module{
@@ -96,6 +106,7 @@ func TestFilterRunProcessKevent(t *testing.T) {
 		{`ps.modules[kernel32.dll].location = 'C:\\Windows\\System32'`, true},
 		{`ps.modules[xul.dll].size = 12354`, false},
 		{`kevt.name = 'CreateProcess' and kevt.pid != ps.ppid`, true},
+		{`ps.parent[1].name = 'wininit.exe'`, true},
 	}
 
 	for i, tt := range tests {

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -75,10 +75,10 @@ func TestFilterRunProcessKevent(t *testing.T) {
 		Name:    "CreateProcess",
 		PID:     1023,
 		PS: &pstypes.PS{
-			Name: "svchost.exe",
+			Name:   "svchost.exe",
 			Parent: ps1,
-			Ppid: 345,
-			Envs: map[string]string{"ALLUSERSPROFILE": "C:\\ProgramData", "OS": "Windows_NT", "ProgramFiles(x86)": "C:\\Program Files (x86)"},
+			Ppid:   345,
+			Envs:   map[string]string{"ALLUSERSPROFILE": "C:\\ProgramData", "OS": "Windows_NT", "ProgramFiles(x86)": "C:\\Program Files (x86)"},
 			Modules: []pstypes.Module{
 				{Name: "C:\\Windows\\System32\\kernel32.dll", Size: 12354, Checksum: 23123343, BaseAddress: kparams.Hex("fff23fff"), DefaultBaseAddress: kparams.Hex("fff124fd")},
 				{Name: "C:\\Windows\\System32\\user32.dll", Size: 212354, Checksum: 33123343, BaseAddress: kparams.Hex("fef23fff"), DefaultBaseAddress: kparams.Hex("fff124fd")},
@@ -107,6 +107,7 @@ func TestFilterRunProcessKevent(t *testing.T) {
 		{`ps.modules[xul.dll].size = 12354`, false},
 		{`kevt.name = 'CreateProcess' and kevt.pid != ps.ppid`, true},
 		{`ps.parent[1].name = 'wininit.exe'`, true},
+		{`ps.parent[root].name = 'services.exe'`, true},
 	}
 
 	for i, tt := range tests {

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -66,6 +66,10 @@ func TestFilterRunProcessKevent(t *testing.T) {
 		Name: "wininit.exe",
 		Parent: &pstypes.PS{
 			Name: "services.exe",
+			SID:  "administrator/SYSTEM",
+			Parent: &pstypes.PS{
+				Name: "System",
+			},
 		},
 	}
 
@@ -106,8 +110,11 @@ func TestFilterRunProcessKevent(t *testing.T) {
 		{`ps.modules[kernel32.dll].location = 'C:\\Windows\\System32'`, true},
 		{`ps.modules[xul.dll].size = 12354`, false},
 		{`kevt.name = 'CreateProcess' and kevt.pid != ps.ppid`, true},
+		{`ps.parent.name = 'wininit.exe'`, true},
 		{`ps.parent[1].name = 'wininit.exe'`, true},
-		{`ps.parent[root].name = 'services.exe'`, true},
+		{`ps.parent[2].name = 'services.exe'`, true},
+		{`ps.parent[2].sid = 'administrator/SYSTEM'`, true},
+		{`ps.parent[root].name = 'System'`, true},
 	}
 
 	for i, tt := range tests {

--- a/pkg/handle/types/types.go
+++ b/pkg/handle/types/types.go
@@ -35,7 +35,7 @@ type Handle struct {
 	// Num represents the internal handle identifier.
 	Num handle.Handle `json:"id"`
 	// Object is the kernel address that this handle references.
-	Object uint64 `json:"object"`
+	Object uint64 `json:"-"`
 	// Pid represents the process's identifier that owns the handle.
 	Pid uint32 `json:"-"`
 	// Type is the type of this handle (e.g. File, Key, Mutant, Section)

--- a/pkg/kevent/formatter.go
+++ b/pkg/kevent/formatter.go
@@ -38,6 +38,8 @@ const (
 	ts            = ".Timestamp"
 	pid           = ".Pid"
 	ppid          = ".Ppid"
+	pexe          = ".Pexe"
+	pcomm         = ".Pcomm"
 	cwd           = ".Cwd"
 	exe           = ".Exe"
 	comm          = ".Comm"
@@ -213,6 +215,11 @@ func (f *Formatter) Format(kevt *Kevent) []byte {
 		values[exe] = ps.Exe
 		values[comm] = ps.Comm
 		values[sid] = ps.SID
+		parent := ps.Parent
+		if parent != nil {
+			values[pexe] = parent.Exe
+			values[pcomm] = parent.Comm
+		}
 		if ps.PE != nil {
 			values[pe] = ps.PE.String()
 		}

--- a/pkg/kevent/formatter.go
+++ b/pkg/kevent/formatter.go
@@ -40,6 +40,7 @@ const (
 	ppid          = ".Ppid"
 	pexe          = ".Pexe"
 	pcomm         = ".Pcomm"
+	pproc         = ".Pname"
 	cwd           = ".Cwd"
 	exe           = ".Exe"
 	comm          = ".Comm"
@@ -72,6 +73,9 @@ var kfields = map[string]bool{
 	ts:          true,
 	pid:         true,
 	ppid:        true,
+	pexe:        true,
+	pcomm:       true,
+	pproc:       true,
 	cwd:         true,
 	exe:         true,
 	comm:        true,
@@ -217,6 +221,7 @@ func (f *Formatter) Format(kevt *Kevent) []byte {
 		values[sid] = ps.SID
 		parent := ps.Parent
 		if parent != nil {
+			values[pproc] = parent.Name
 			values[pexe] = parent.Exe
 			values[pcomm] = parent.Comm
 		}

--- a/pkg/kevent/marshaller.go
+++ b/pkg/kevent/marshaller.go
@@ -574,6 +574,21 @@ func (kevt *Kevent) MarshalJSON() []byte {
 
 		js.writeObjectField("sessionid").writeUint8(ps.SessionID)
 
+		parent := ps.Parent
+		if parent != nil {
+			js.writeMore()
+			js.writeObjectField("parent")
+			js.writeObjectStart()
+
+			js.writeObjectField("name").writeString(parent.Name).writeMore()
+			js.writeObjectField("comm").writeEscapeString(parent.Comm).writeMore()
+			js.writeObjectField("exe").writeEscapeString(parent.Exe).writeMore()
+			js.writeObjectField("cwd").writeEscapeString(parent.Cwd).writeMore()
+			js.writeObjectField("sid").writeEscapeString(parent.SID)
+
+			js.writeObjectEnd()
+		}
+
 		if SerializeEnvs {
 			js.writeMore()
 			js.writeObjectField("envs")

--- a/pkg/kevent/marshaller_test.go
+++ b/pkg/kevent/marshaller_test.go
@@ -126,8 +126,14 @@ func TestKeventMarshalJSON(t *testing.T) {
 		},
 		Metadata: map[string]string{"foo": "bar", "fooz": "baarz"},
 		PS: &pstypes.PS{
-			PID:       2436,
-			Ppid:      6304,
+			PID:  2436,
+			Ppid: 6304,
+			Parent: &pstypes.PS{
+				Name: "explorer.exe",
+				Exe:  `C:\Windows\System32\explorer.exe`,
+				Cwd:  `C:\Windows\System32`,
+				SID:  "admin\\SYSTEM",
+			},
 			Name:      "firefox.exe",
 			Exe:       `C:\Program Files\Mozilla Firefox\firefox.exe`,
 			Comm:      `C:\Program Files\Mozilla Firefox\firefox.exe -contentproc --channel="6304.3.1055809391\1014207667" -childID 1 -isForBrowser -prefsHandle 2584 -prefMapHandle 2580 -prefsLen 70 -prefMapSize 216993 -parentBuildID 20200107212822 -greomni "C:\Program Files\Mozilla Firefox\omni.ja" -appomni "C:\Program Files\Mozilla Firefox\browser\omni.ja" -appdir "C:\Program Files\Mozilla Firefox\browser" - 6304 "\\.\pipe\gecko-crash-server-pipe.6304" 2596 tab`,
@@ -198,6 +204,7 @@ func TestKeventMarshalJSON(t *testing.T) {
 	assert.Len(t, newKevt.PS.Handles, 3)
 
 	assert.NotNil(t, newKevt.PS.PE)
+	assert.Equal(t, "explorer.exe", newKevt.PS.Parent.Name)
 	assert.Equal(t, uint32(10), newKevt.PS.PE.NumberOfSymbols)
 	assert.Equal(t, uint16(2), newKevt.PS.PE.NumberOfSections)
 	assert.Len(t, newKevt.PS.PE.Sections, 2)

--- a/pkg/ps/snapshotter.go
+++ b/pkg/ps/snapshotter.go
@@ -135,6 +135,7 @@ func (s *snapshotter) WriteFromKcap(kevt *kevent.Kevent) error {
 		if ps.PID == winerrno.InvalidPID {
 			return nil
 		}
+		ps.Parent = s.procs[ps.Ppid]
 		s.procs[ps.PID] = ps
 
 	case ktypes.CreateThread, ktypes.EnumThread:
@@ -146,6 +147,7 @@ func (s *snapshotter) WriteFromKcap(kevt *kevent.Kevent) error {
 		thread := pstypes.ThreadFromKevent(unwrapThreadParams(pid, kevt))
 		if ps, ok := s.procs[pid]; ok {
 			ps.AddThread(thread)
+			ps.Parent = s.procs[ps.Ppid]
 		}
 
 	case ktypes.LoadImage, ktypes.EnumImage:

--- a/pkg/ps/snapshotter.go
+++ b/pkg/ps/snapshotter.go
@@ -98,7 +98,7 @@ func NewSnapshotter(handleSnap handle.Snapshotter, config *config.Config) Snapsh
 	s.handleSnap.RegisterCreateCallback(s.onHandleCreated)
 	s.handleSnap.RegisterDestroyCallback(s.onHandleDestroyed)
 
-	go s.reapDeadProcesses()
+	go s.gcDeadProcesses()
 
 	return s
 }
@@ -188,6 +188,7 @@ func (s *snapshotter) Write(kevt *kevent.Kevent) error {
 		if err != nil {
 			log.Warnf("couldn't enumerate handles for pid (%d): %v", pid, err)
 		}
+		ps.Parent = s.procs[ps.Ppid]
 		ps.Handles = handles
 
 		// inspect PE metadata and attach corresponding headers
@@ -241,6 +242,7 @@ func (s *snapshotter) Write(kevt *kevent.Kevent) error {
 		if err != nil {
 			log.Warnf("couldn't enumerate handles for pid (%d): %v", pid, err)
 		}
+		ps.Parent = s.procs[ps.Ppid]
 		ps.Handles = handles
 
 		s.procs[pid] = ps
@@ -265,10 +267,10 @@ func (s *snapshotter) Close() error {
 	return nil
 }
 
-// reapDeadProcesses periodically scans the map of the snapshot's processes and removes
+// gcDeadProcesses periodically scans the map of the snapshot's processes and removes
 // any terminated processes from it. This guarantees that any leftovers are cleaned-up
 // in case we miss process' terminate events.
-func (s *snapshotter) reapDeadProcesses() {
+func (s *snapshotter) gcDeadProcesses() {
 	tick := time.NewTicker(reapPeriod)
 	for {
 		select {
@@ -367,9 +369,7 @@ func (s *snapshotter) findProcess(pid uint32, thread pstypes.Thread) *pstypes.PS
 		}
 		return pstypes.NewPS(pid, pid, image, "", image, thread, nil)
 	}
-	ppid := process.GetParentPID(h)
-
-	return fromPEB(pid, ppid, peb, thread)
+	return fromPEB(pid, process.GetParentPID(h), peb, thread)
 }
 
 func (s *snapshotter) readPE(ps *pstypes.PS) {

--- a/pkg/ps/snapshotter_test.go
+++ b/pkg/ps/snapshotter_test.go
@@ -45,7 +45,7 @@ func TestSnapshotterWrite(t *testing.T) {
 			kparams.ProcessParentID: {Name: kparams.ProcessParentID, Type: kparams.PID, Value: uint32(8390)},
 			kparams.ProcessName:     {Name: kparams.ProcessName, Type: kparams.UnicodeString, Value: "spotify.exe"},
 			kparams.Comm:            {Name: kparams.Comm, Type: kparams.UnicodeString, Value: `C:\Users\admin\AppData\Roaming\Spotify\Spotify.exe --type=crashpad-handler /prefetch:7 --max-uploads=5 --max-db-size=20 --max-db-age=5 --monitor-self-annotation=ptype=crashpad-handler "--metrics-dir=C:\Users\admin\AppData\Local\Spotify\User Data" --url=https://crashdump.spotify.com:443/ --annotation=platform=win32 --annotation=product=spotify --annotation=version=1.1.4.197 --initial-client-data=0x5a4,0x5a0,0x5a8,0x59c,0x5ac,0x6edcbf60,0x6edcbf70,0x6edcbf7c`},
-			kparams.Exe:             {Name: kparams.Exe, Type: kparams.UnicodeString, Value: `C:\Users\admin\AppData\Roaming\Spotify\Spotify.exe`},
+			kparams.Exe:             {Name: kparams.Exe, Type: kparams.UnicodeString, Value: `C:\Users\admin\AppData\Roaming\Spotify\Spotify.exe --parent`},
 			kparams.UserSID:         {Name: kparams.UserSID, Type: kparams.UnicodeString, Value: `admin\SYSTEM`},
 		},
 	}
@@ -60,12 +60,32 @@ func TestSnapshotterWrite(t *testing.T) {
 	assert.Equal(t, uint32(8390), ps.Ppid)
 	assert.Equal(t, "spotify.exe", ps.Name)
 	assert.Equal(t, `C:\Users\admin\AppData\Roaming\Spotify\Spotify.exe --type=crashpad-handler /prefetch:7 --max-uploads=5 --max-db-size=20 --max-db-age=5 --monitor-self-annotation=ptype=crashpad-handler "--metrics-dir=C:\Users\admin\AppData\Local\Spotify\User Data" --url=https://crashdump.spotify.com:443/ --annotation=platform=win32 --annotation=product=spotify --annotation=version=1.1.4.197 --initial-client-data=0x5a4,0x5a0,0x5a8,0x59c,0x5ac,0x6edcbf60,0x6edcbf70,0x6edcbf7c`, ps.Comm)
-	assert.Equal(t, `C:\Users\admin\AppData\Roaming\Spotify\Spotify.exe`, ps.Exe)
+	assert.Equal(t, `C:\Users\admin\AppData\Roaming\Spotify\Spotify.exe --parent`, ps.Exe)
 	assert.Equal(t, `admin\SYSTEM`, ps.SID)
 	assert.Len(t, ps.Args, 13)
 	assert.Equal(t, "--type=crashpad-handler", ps.Args[0])
 	assert.Equal(t, "ps", filepath.Base(ps.Cwd))
 	assert.True(t, len(ps.Envs) > 0)
+
+	kevt = &kevent.Kevent{
+		Type: ktypes.CreateProcess,
+		Kparams: kevent.Kparams{
+			kparams.ProcessID:       {Name: kparams.ProcessID, Type: kparams.PID, Value: uint32(1232)},
+			kparams.ProcessParentID: {Name: kparams.ProcessParentID, Type: kparams.PID, Value: pid},
+			kparams.ProcessName:     {Name: kparams.ProcessName, Type: kparams.UnicodeString, Value: "spotify.exe"},
+			kparams.Comm:            {Name: kparams.Comm, Type: kparams.UnicodeString, Value: `C:\Users\admin\AppData\Roaming\Spotify\Spotify.exe --type=crashpad-handler /prefetch:7 --max-uploads=5 --max-db-size=20 --max-db-age=5 --monitor-self-annotation=ptype=crashpad-handler "--metrics-dir=C:\Users\admin\AppData\Local\Spotify\User Data" --url=https://crashdump.spotify.com:443/ --annotation=platform=win32 --annotation=product=spotify --annotation=version=1.1.4.197 --initial-client-data=0x5a4,0x5a0,0x5a8,0x59c,0x5ac,0x6edcbf60,0x6edcbf70,0x6edcbf7c`},
+			kparams.Exe:             {Name: kparams.Exe, Type: kparams.UnicodeString, Value: `C:\Users\admin\AppData\Roaming\Spotify\Spotify.exe`},
+			kparams.UserSID:         {Name: kparams.UserSID, Type: kparams.UnicodeString, Value: `admin\SYSTEM`},
+		},
+	}
+
+	err = psnap.Write(kevt)
+	require.NoError(t, err)
+
+	ps = psnap.Find(1232)
+	require.NotNil(t, ps)
+	require.NotNil(t, ps.Parent)
+	assert.Equal(t, `C:\Users\admin\AppData\Roaming\Spotify\Spotify.exe --parent`, ps.Parent.Exe)
 }
 
 func TestSnapshotterWriteNoPIDInParams(t *testing.T) {

--- a/pkg/ps/types/types.go
+++ b/pkg/ps/types/types.go
@@ -63,6 +63,27 @@ type PS struct {
 	Handles htypes.Handles `json:"handles"`
 	// PE stores the PE (Portable Executable) metadata.
 	PE *pe.PE `json:"pe"`
+	// Parent represents the reference to the parent process.
+	Parent *PS `json:"parent"`
+}
+
+// Visitor is the type definition for the function that is
+// invoked on each parent visit walk.
+type Visitor func(*PS)
+
+// Visit recursively visits all parents of the given process
+// and invokes the visitor function on each parent process.
+func Visit(v Visitor, ps *PS) {
+	if ps == nil {
+		return
+	}
+	if ps.Parent == nil {
+		return
+	}
+	v(ps.Parent)
+	if ps.Parent != nil {
+		Visit(v, ps.Parent)
+	}
 }
 
 // String returns a string representation of the process' state.

--- a/pkg/ps/types/types_test.go
+++ b/pkg/ps/types/types_test.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020-2021 by Nedim Sabic Sabic
+ * https://www.fibratus.io
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package types
+
+import (
+	"github.com/magiconair/properties/assert"
+	"testing"
+)
+
+func TestVisit(t *testing.T) {
+	ps1 := &PS{
+		Name: "cmd.exe",
+	}
+	ps2 := &PS{
+		Name: "powershell.exe",
+		Parent: ps1,
+	}
+	ps3 := &PS{
+		Name: "winword.exe",
+		Parent: ps2,
+	}
+
+	expected := []string{"powershell.exe", "cmd.exe"}
+	parents := make([]string, 0)
+
+	Visit(func(ps *PS) { parents = append(parents, ps.Name)}, ps3)
+
+	assert.Equal(t, expected, parents)
+
+
+	ps4 := &PS{
+		Name: "iexplorer.exe",
+		Parent: ps3,
+	}
+	ps5 := &PS {
+		Name: "dropper.exe",
+		Parent: ps4,
+	}
+
+	expected = []string{"iexplorer.exe", "winword.exe", "powershell.exe", "cmd.exe"}
+	parents = make([]string, 0)
+
+	Visit(func(ps *PS) { parents = append(parents, ps.Name)}, ps5)
+}

--- a/pkg/ps/types/types_test.go
+++ b/pkg/ps/types/types_test.go
@@ -28,33 +28,32 @@ func TestVisit(t *testing.T) {
 		Name: "cmd.exe",
 	}
 	ps2 := &PS{
-		Name: "powershell.exe",
+		Name:   "powershell.exe",
 		Parent: ps1,
 	}
 	ps3 := &PS{
-		Name: "winword.exe",
+		Name:   "winword.exe",
 		Parent: ps2,
 	}
 
 	expected := []string{"powershell.exe", "cmd.exe"}
 	parents := make([]string, 0)
 
-	Visit(func(ps *PS) { parents = append(parents, ps.Name)}, ps3)
+	Visit(func(ps *PS) { parents = append(parents, ps.Name) }, ps3)
 
 	assert.Equal(t, expected, parents)
 
-
 	ps4 := &PS{
-		Name: "iexplorer.exe",
+		Name:   "iexplorer.exe",
 		Parent: ps3,
 	}
-	ps5 := &PS {
-		Name: "dropper.exe",
+	ps5 := &PS{
+		Name:   "dropper.exe",
 		Parent: ps4,
 	}
 
 	expected = []string{"iexplorer.exe", "winword.exe", "powershell.exe", "cmd.exe"}
 	parents = make([]string, 0)
 
-	Visit(func(ps *PS) { parents = append(parents, ps.Name)}, ps5)
+	Visit(func(ps *PS) { parents = append(parents, ps.Name) }, ps5)
 }

--- a/pkg/ps/types/types_test.go
+++ b/pkg/ps/types/types_test.go
@@ -52,8 +52,10 @@ func TestVisit(t *testing.T) {
 		Parent: ps4,
 	}
 
-	expected = []string{"iexplorer.exe", "winword.exe", "powershell.exe", "cmd.exe"}
-	parents = make([]string, 0)
+	expected1 := []string{"iexplorer.exe", "winword.exe", "powershell.exe", "cmd.exe"}
+	parents1 := make([]string, 0)
 
-	Visit(func(ps *PS) { parents = append(parents, ps.Name) }, ps5)
+	Visit(func(ps *PS) { parents1 = append(parents1, ps.Name) }, ps5)
+
+	assert.Equal(t, expected1, parents1)
 }


### PR DESCRIPTION
Filter fields for creating expressions that evaluate parent process attributes such as parent process name, sid, command line, and so on. Besides this, it is also possible to obtain the `nth` parent process in the process ancestry by using the field path syntax.

Example:

```
ps.parent[2].name = 'powershell.exe'
```
This filter would match all events where the process grandparent name is `powershell.exe`.