### PR TITLE
feat(filter): Any parent filters for ancestry traversing

### DIFF
--- a/pkg/filter/fields/fields.go
+++ b/pkg/filter/fields/fields.go
@@ -478,8 +478,11 @@ func Lookup(name string) Field {
 		// that represents the depth of
 		// the parent process node or the
 		// `root` keyword to designate the
-		// root process node
-		var keyRegexp = regexp.MustCompile(`[1-9]+|root`)
+		// root process node. Additionally,
+		// we can also get the `any` keyword
+		// that collects the fields of all
+		// ancestor processes
+		var keyRegexp = regexp.MustCompile(`[1-9]+|root|any`)
 		if !keyRegexp.MatchString(key) {
 			return None
 		}

--- a/pkg/filter/fields/fields_test.go
+++ b/pkg/filter/fields/fields_test.go
@@ -38,6 +38,7 @@ func TestLookup(t *testing.T) {
 	assert.Empty(t, Lookup("ps.pe.sections[.debug$S].e"))
 	assert.Equal(t, Field("ps.parent[1].name"), Lookup("ps.parent[1].name"))
 	assert.Equal(t, Field("ps.parent[root].name"), Lookup("ps.parent[root].name"))
+	assert.Equal(t, Field("ps.parent[any].pid"), Lookup("ps.parent[any].pid"))
 	assert.Equal(t, Field("ps.parent[2].sid"), Lookup("ps.parent[2].sid"))
 	assert.Empty(t, Lookup("ps.parent[ro].name"))
 }

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -67,6 +67,7 @@ func TestFilterRunProcessKevent(t *testing.T) {
 		Parent: &pstypes.PS{
 			Name: "services.exe",
 			SID:  "administrator/SYSTEM",
+			PID:  2034,
 			Parent: &pstypes.PS{
 				Name: "System",
 			},
@@ -115,6 +116,10 @@ func TestFilterRunProcessKevent(t *testing.T) {
 		{`ps.parent[2].name = 'services.exe'`, true},
 		{`ps.parent[2].sid = 'administrator/SYSTEM'`, true},
 		{`ps.parent[root].name = 'System'`, true},
+		{`ps.parent[any].name in ('services.exe', 'System')`, true},
+		{`ps.parent[any].name not in ('svchost.exe')`, true},
+		{`ps.parent[any].name icontains ('system')`, true},
+		{`ps.parent[any].pid in (2034, 343)`, true},
 	}
 
 	for i, tt := range tests {

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -118,7 +118,12 @@ func TestFilterRunProcessKevent(t *testing.T) {
 		{`ps.parent[root].name = 'System'`, true},
 		{`ps.parent[any].name in ('services.exe', 'System')`, true},
 		{`ps.parent[any].name not in ('svchost.exe')`, true},
-		{`ps.parent[any].name icontains ('system')`, true},
+		{`ps.parent[any].name endswith ('ices.exe')`, true},
+		{`ps.parent[any].name iendswith ('TeM')`, true},
+		{`ps.parent[any].name startswith ('serv')`, true},
+		{`ps.parent[any].name istartswith ('Serv')`, true},
+		{`ps.parent[any].name contains ('Sys')`, true},
+		{`ps.parent[any].name icontains ('sys')`, true},
 		{`ps.parent[any].pid in (2034, 343)`, true},
 	}
 

--- a/pkg/filter/ql/ast.go
+++ b/pkg/filter/ql/ast.go
@@ -912,12 +912,23 @@ func (v *ValuerEval) evalBinaryExpr(expr *BinaryExpr) interface{} {
 	case []string:
 		switch expr.Op {
 		case contains:
-			rhs, ok := rhs.(string)
+			s, ok := rhs.(string)
 			if !ok {
+				rhs, ok := rhs.([]string)
+				if !ok {
+					return false
+				}
+				for _, s1 := range rhs {
+					for _, s2 := range lhs {
+						if strings.Contains(s2, s1) {
+							return true
+						}
+					}
+				}
 				return false
 			}
-			for _, s := range lhs {
-				if strings.Contains(rhs, s) {
+			for _, val := range lhs {
+				if strings.Contains(val, s) {
 					return true
 				}
 			}
@@ -927,9 +938,9 @@ func (v *ValuerEval) evalBinaryExpr(expr *BinaryExpr) interface{} {
 			if !ok {
 				return false
 			}
-			for _, i := range lhs {
-				for _, j := range rhs {
-					if strings.Contains(strings.ToLower(i), strings.ToLower(j)) {
+			for _, s1 := range lhs {
+				for _, s2 := range rhs {
+					if strings.Contains(strings.ToLower(s1), strings.ToLower(s2)) {
 						return true
 					}
 				}
@@ -943,6 +954,58 @@ func (v *ValuerEval) evalBinaryExpr(expr *BinaryExpr) interface{} {
 			for _, i := range lhs {
 				for _, j := range rhs {
 					if i == j {
+						return true
+					}
+				}
+			}
+			return false
+		case startswith:
+			rhs, ok := rhs.([]string)
+			if !ok {
+				return false
+			}
+			for _, s1 := range rhs {
+				for _, s2 := range lhs {
+					if strings.HasPrefix(s2, s1) {
+						return true
+					}
+				}
+			}
+			return false
+		case istartswith:
+			rhs, ok := rhs.([]string)
+			if !ok {
+				return false
+			}
+			for _, s1 := range rhs {
+				for _, s2 := range lhs {
+					if strings.HasPrefix(strings.ToLower(s2), strings.ToLower(s1)) {
+						return true
+					}
+				}
+			}
+			return false
+		case endswith:
+			rhs, ok := rhs.([]string)
+			if !ok {
+				return false
+			}
+			for _, s1 := range rhs {
+				for _, s2 := range lhs {
+					if strings.HasSuffix(s2, s1) {
+						return true
+					}
+				}
+			}
+			return false
+		case iendswith:
+			rhs, ok := rhs.([]string)
+			if !ok {
+				return false
+			}
+			for _, s1 := range rhs {
+				for _, s2 := range lhs {
+					if strings.HasSuffix(strings.ToLower(s2), strings.ToLower(s1)) {
 						return true
 					}
 				}
@@ -975,27 +1038,6 @@ func (v *ValuerEval) evalBinaryExpr(expr *BinaryExpr) interface{} {
 			}
 			return false
 		}
-	case []uint32:
-		switch expr.Op {
-		case in:
-			rhs, ok := rhs.([]string)
-			if !ok {
-				return false
-			}
-			for _, i := range lhs {
-				for _, j := range rhs {
-					n, err := strconv.Atoi(j)
-					if err != nil {
-						continue
-					}
-					if i == uint32(n) {
-						return true
-					}
-				}
-			}
-			return false
-		}
-
 	}
 
 	// the types were not comparable. If our operation was an equality operation,

--- a/pkg/filter/ql/ast.go
+++ b/pkg/filter/ql/ast.go
@@ -917,7 +917,7 @@ func (v *ValuerEval) evalBinaryExpr(expr *BinaryExpr) interface{} {
 				return false
 			}
 			for _, s := range lhs {
-				if s == rhs {
+				if strings.Contains(rhs, s) {
 					return true
 				}
 			}
@@ -929,7 +929,7 @@ func (v *ValuerEval) evalBinaryExpr(expr *BinaryExpr) interface{} {
 			}
 			for _, i := range lhs {
 				for _, j := range rhs {
-					if strings.EqualFold(i, j) {
+					if strings.Contains(strings.ToLower(i), strings.ToLower(j)) {
 						return true
 					}
 				}

--- a/pkg/filter/ql/ast.go
+++ b/pkg/filter/ql/ast.go
@@ -922,6 +922,19 @@ func (v *ValuerEval) evalBinaryExpr(expr *BinaryExpr) interface{} {
 				}
 			}
 			return false
+		case icontains:
+			rhs, ok := rhs.([]string)
+			if !ok {
+				return false
+			}
+			for _, i := range lhs {
+				for _, j := range rhs {
+					if strings.EqualFold(i, j) {
+						return true
+					}
+				}
+			}
+			return false
 		case in:
 			rhs, ok := rhs.([]string)
 			if !ok {
@@ -962,6 +975,27 @@ func (v *ValuerEval) evalBinaryExpr(expr *BinaryExpr) interface{} {
 			}
 			return false
 		}
+	case []uint32:
+		switch expr.Op {
+		case in:
+			rhs, ok := rhs.([]string)
+			if !ok {
+				return false
+			}
+			for _, i := range lhs {
+				for _, j := range rhs {
+					n, err := strconv.Atoi(j)
+					if err != nil {
+						continue
+					}
+					if i == uint32(n) {
+						return true
+					}
+				}
+			}
+			return false
+		}
+
 	}
 
 	// the types were not comparable. If our operation was an equality operation,

--- a/pkg/ps/types/types.go
+++ b/pkg/ps/types/types.go
@@ -71,9 +71,9 @@ type PS struct {
 // invoked on each parent visit walk.
 type Visitor func(*PS)
 
-// Visit recursively visits all parents of the given process
+// Walk recursively visits all parents of the given process
 // and invokes the visitor function on each parent process.
-func Visit(v Visitor, ps *PS) {
+func Walk(v Visitor, ps *PS) {
 	if ps == nil {
 		return
 	}
@@ -82,7 +82,7 @@ func Visit(v Visitor, ps *PS) {
 	}
 	v(ps.Parent)
 	if ps.Parent != nil {
-		Visit(v, ps.Parent)
+		Walk(v, ps.Parent)
 	}
 }
 

--- a/pkg/ps/types/types_test.go
+++ b/pkg/ps/types/types_test.go
@@ -39,7 +39,7 @@ func TestVisit(t *testing.T) {
 	expected := []string{"powershell.exe", "cmd.exe"}
 	parents := make([]string, 0)
 
-	Visit(func(ps *PS) { parents = append(parents, ps.Name) }, ps3)
+	Walk(func(ps *PS) { parents = append(parents, ps.Name) }, ps3)
 
 	assert.Equal(t, expected, parents)
 
@@ -55,7 +55,7 @@ func TestVisit(t *testing.T) {
 	expected1 := []string{"iexplorer.exe", "winword.exe", "powershell.exe", "cmd.exe"}
 	parents1 := make([]string, 0)
 
-	Visit(func(ps *PS) { parents1 = append(parents1, ps.Name) }, ps5)
+	Walk(func(ps *PS) { parents1 = append(parents1, ps.Name) }, ps5)
 
 	assert.Equal(t, expected1, parents1)
 }


### PR DESCRIPTION
In light of #71, this PR further expands the ancestry traversing. It is possible to use the `ps.parent[any].*` field path to return process values of all ancestor processes.

Example:

```
$ fibratus run ps.parent[any].name in ('powershell.exe', 'winword.exe')
```

Would match all events where any of its ancestors is `powershell.exe` or `winword.exe` process.