### PR TITLE
feat(rules): add include group rules in event metadata

### DIFF
--- a/pkg/filter/rules.go
+++ b/pkg/filter/rules.go
@@ -32,6 +32,14 @@ import (
 	"text/template"
 )
 
+
+const (
+	// ruleNameMeta identifies the rule that was triggered by the event
+	ruleNameMeta = "rule.name"
+	// ruleGroupMeta identifies the group to which the triggered rule pertains
+	ruleGroupMeta = "rule.group"
+)
+
 var (
 	excludeOrFilterMatches  = expvar.NewMap("filter.chain.exclude.or.matches")
 	excludeAndFilterMatches = expvar.NewMap("filter.chain.exclude.and.matches")
@@ -219,6 +227,9 @@ nextGroup:
 						if err != nil {
 							log.Warnf("unable to execute %q rule action: %v", f.config.Name, err)
 						}
+						// attach rule and group meta
+						kevt.AddMeta(ruleNameMeta, f.config.Name)
+						kevt.AddMeta(ruleGroupMeta, g.group.Name)
 						return true
 					}
 				case config.AndRelation:
@@ -242,7 +253,7 @@ nextGroup:
 					includeAndFilterMatches.Add(f.config.Name, 1)
 					err := runFilterAction(kevt, g.group, f.config)
 					if err != nil {
-						log.Warnf("unable to execute %q filter action: %v", f.config.Name, err)
+						log.Warnf("unable to execute %q rule action: %v", f.config.Name, err)
 					}
 				}
 			}

--- a/pkg/filter/rules_test.go
+++ b/pkg/filter/rules_test.go
@@ -175,6 +175,7 @@ func TestFilterActionEmitAlert(t *testing.T) {
 			kparams.NetSIP:   {Name: kparams.NetSIP, Type: kparams.IPv4, Value: net.ParseIP("127.0.0.1")},
 			kparams.NetDIP:   {Name: kparams.NetDIP, Type: kparams.IPv4, Value: net.ParseIP("216.58.201.174")},
 		},
+		Metadata: make(map[string]string),
 	}
 
 	require.True(t, rules.Fire(kevt))
@@ -207,6 +208,7 @@ func BenchmarkChainRun(b *testing.B) {
 				kparams.NetSIP:   {Name: kparams.NetSIP, Type: kparams.IPv4, Value: net.ParseIP("127.0.0.1")},
 				kparams.NetDIP:   {Name: kparams.NetDIP, Type: kparams.IPv4, Value: net.ParseIP("216.58.201.174")},
 			},
+			Metadata: make(map[string]string),
 		},
 		{
 			Type: ktypes.CreateProcess,
@@ -224,6 +226,7 @@ func BenchmarkChainRun(b *testing.B) {
 				kparams.Exe:             {Name: kparams.Exe, Type: kparams.UnicodeString, Value: `C:\Users\admin\AppData\Roaming\Spotify\Spotify.exe`},
 				kparams.UserSID:         {Name: kparams.UserSID, Type: kparams.UnicodeString, Value: `admin\SYSTEM`},
 			},
+			Metadata: make(map[string]string),
 		},
 	}
 

--- a/pkg/filter/rules_test.go
+++ b/pkg/filter/rules_test.go
@@ -19,6 +19,9 @@
 package filter
 
 import (
+	"net"
+	"testing"
+
 	"github.com/rabbitstack/fibratus/pkg/alertsender"
 	"github.com/rabbitstack/fibratus/pkg/config"
 	"github.com/rabbitstack/fibratus/pkg/kevent"
@@ -27,8 +30,6 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/ps/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"net"
-	"testing"
 )
 
 type mockSender struct{}
@@ -62,6 +63,7 @@ func fireRules(t *testing.T, c *config.Config) bool {
 			kparams.NetSIP:   {Name: kparams.NetSIP, Type: kparams.IPv4, Value: net.ParseIP("127.0.0.1")},
 			kparams.NetDIP:   {Name: kparams.NetDIP, Type: kparams.IPv4, Value: net.ParseIP("216.58.201.174")},
 		},
+		Metadata: make(map[string]string),
 	}
 
 	require.NoError(t, rules.Compile())

--- a/pkg/kevent/formatter_test.go
+++ b/pkg/kevent/formatter_test.go
@@ -58,7 +58,7 @@ func TestFormat(t *testing.T) {
 		kpars.ProcessID: {Name: kpars.ProcessID, Type: kpars.HexInt32, Value: kpars.Hex("0x36c")},
 	}
 	s := f.Format(&Kevent{CPU: uint8(4), Name: "CreateProcess", Seq: uint64(1999), Kparams: params, Metadata: map[string]string{"key1": "value1"}})
-	assert.Equal(t, "1999 4 -  (CreateProcess) -- pid: 0x36c (pid➜ 0x36c) key1:value1", string(s))
+	assert.Equal(t, "1999 4 -  (CreateProcess) -- pid: 0x36c (pid➜ 0x36c) key1: value1", string(s))
 }
 
 func TestFormatPS(t *testing.T) {

--- a/pkg/kevent/kevent.go
+++ b/pkg/kevent/kevent.go
@@ -46,7 +46,7 @@ type Metadata map[string]string
 func (md Metadata) String() string {
 	var sb strings.Builder
 	for k, v := range md {
-		sb.WriteString(k + ":" + v + ", ")
+		sb.WriteString(k + ": " + v + ", ")
 	}
 	return strings.TrimSuffix(sb.String(), ", ")
 }


### PR DESCRIPTION
When a rule is triggered, the rule and group name to which it pertains are pushed into event's metadata.