### PR TITLE
feat(yara): Rule matches as tags in event metadata

### DIFF
--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -4,7 +4,7 @@
   <img src='logo.png'></img>
 </div>
 
-# fibratus <small>1.4.1</small>
+# fibratus <small>1.4.2</small>
 
 > A modern tool for the Windows kernel exploration and observability
 

--- a/docs/yara/alerts.md
+++ b/docs/yara/alerts.md
@@ -104,3 +104,40 @@ Resources:
   ProductName: Microsoft® Windows® Operating System
   ProductVersion: 10.0.18362.693
 ```
+
+##  Event metadata {docsify-ignore}
+
+When the event triggers a specific YARA rule, its metadata is automatically decorated with the rule matches. 
+The`yara.matches` tag contains the JSON array payload where each object represents the YARA rule match. For example:
+
+```json
+[
+  {
+    "Rule": "AnglerEKredirector ",
+    "Namespace": "EK",
+    "Tags": null,
+    "Metas": [
+      {
+        "Identifier": "description",
+        "Value": "Angler Exploit Kit Redirector"
+      }
+    ],
+    "Strings": "..."
+  },
+  {
+    "Rule": "angler_flash_uncompressed ",
+    "Namespace": "EK",
+    "Tags": [
+      "exploitkit"
+    ],
+    "Metas": [
+      {
+        "Identifier": "description",
+        "Value": "Angler Exploit Kit Detection"
+      }
+    ],
+    "Strings": "..."
+  }
+]
+```
+

--- a/docs/yara/alerts.md
+++ b/docs/yara/alerts.md
@@ -108,7 +108,7 @@ Resources:
 ##  Event metadata {docsify-ignore}
 
 When the event triggers a specific YARA rule, its metadata is automatically decorated with the rule matches. 
-The`yara.matches` tag contains the JSON array payload where each object represents the YARA rule match. For example:
+The `yara.matches` tag contains the JSON array payload where each object represents the YARA rule match. For example:
 
 ```json
 [

--- a/pkg/filter/rules.go
+++ b/pkg/filter/rules.go
@@ -32,7 +32,6 @@ import (
 	"text/template"
 )
 
-
 const (
 	// ruleNameMeta identifies the rule that was triggered by the event
 	ruleNameMeta = "rule.name"

--- a/pkg/kstream/interceptors/image_windows.go
+++ b/pkg/kstream/interceptors/image_windows.go
@@ -20,6 +20,7 @@ package interceptors
 
 import (
 	"expvar"
+
 	"github.com/rabbitstack/fibratus/pkg/fs"
 	"github.com/rabbitstack/fibratus/pkg/kevent"
 	"github.com/rabbitstack/fibratus/pkg/kevent/kparams"
@@ -67,7 +68,7 @@ func (i *imageInterceptor) Intercept(kevt *kevent.Kevent) (*kevent.Kevent, bool,
 			// scan the the target filename
 			go func() {
 				imageYaraScans.Add(1)
-				err := i.yara.ScanFile(filename)
+				err := i.yara.ScanFile(filename, kevt)
 				if err != nil {
 					log.Warnf("unable to run yara scanner on %s image: %v", filename, err)
 				}

--- a/pkg/kstream/interceptors/ps_windows.go
+++ b/pkg/kstream/interceptors/ps_windows.go
@@ -20,6 +20,12 @@ package interceptors
 
 import (
 	"expvar"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
 	"github.com/rabbitstack/fibratus/pkg/kevent"
 	"github.com/rabbitstack/fibratus/pkg/kevent/kparams"
 	"github.com/rabbitstack/fibratus/pkg/kevent/ktypes"
@@ -27,11 +33,6 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/syscall/process"
 	"github.com/rabbitstack/fibratus/pkg/yara"
 	log "github.com/sirupsen/logrus"
-	"os"
-	"path/filepath"
-	"regexp"
-	"strings"
-	"time"
 )
 
 // systemRootRegexp is the regular expression for detecting path with unexpanded SystemRoot environment variable
@@ -122,7 +123,7 @@ func (ps psInterceptor) Intercept(kevt *kevent.Kevent) (*kevent.Kevent, bool, er
 				// run yara scanner on the target process
 				go func() {
 					procYaraScans.Add(1)
-					err := ps.yara.ScanProc(pid)
+					err := ps.yara.ScanProc(pid, kevt)
 					if err != nil {
 						log.Warnf("unable to run yara scanner on pid %d: %v", pid, err)
 					}

--- a/pkg/yara/types.go
+++ b/pkg/yara/types.go
@@ -18,14 +18,16 @@
 
 package yara
 
+import "github.com/rabbitstack/fibratus/pkg/kevent"
+
 // Scanner watches for certain kernel events such as process creation or image loading and
 // triggers the scanning either of the target process or image file. If matches occur, an
 // alert is emitted via specified alert sender.
 type Scanner interface {
 	// ScanProc scans process memory.
-	ScanProc(pid uint32) error
+	ScanProc(pid uint32, kevt *kevent.Kevent) error
 	// ScanFile scans the specified file in the file system.
-	ScanFile(filename string) error
+	ScanFile(filename string, kevt *kevent.Kevent) error
 	// Close disposes any resources allocated by scanner.
 	Close()
 }


### PR DESCRIPTION
To streamline the association of events with the respective YARA rule matches, a new tag, `yara.matches` is injected into event metadata. It contains the JSON representation of all the rule matches. Example:

```json
[
  {
    "Rule": "AnglerEKredirector ",
    "Namespace": "EK",
    "Tags": null,
    "Metas": [
      {
        "Identifier": "description",
        "Value": "Angler Exploit Kit Redirector"
      }
    ],
    "Strings": "..."
  },
  {
    "Rule": "angler_flash_uncompressed ",
    "Namespace": "EK",
    "Tags": [
      "exploitkit"
    ],
    "Metas": [
      {
        "Identifier": "description",
        "Value": "Angler Exploit Kit Detection"
      }
    ],
    "Strings": "..."
  }
]
```