### PR TITLE
feat(events): file attributes parameter in CreateFile events

### DIFF
--- a/pkg/filter/accessor_windows.go
+++ b/pkg/filter/accessor_windows.go
@@ -598,6 +598,21 @@ func (l *fileAccessor) get(f fields.Field, kevt *kevent.Kevent) (kparams.Value, 
 			return nil, err
 		}
 		return filepath.Ext(file), nil
+	case fields.FileAttributes:
+		val, err := kevt.Kparams.GetSlice(kparams.FileAttributes)
+		if err != nil {
+			return nil, err
+		}
+		slice, ok := val.([]fs.FileAttr)
+		if !ok {
+			return nil, nil
+		}
+		// convert from []fs.FileAttr to string slice
+		attrs := make([]string, 0, len(slice))
+		for _, attr := range slice {
+			attrs = append(attrs, attr.String())
+		}
+		return attrs, nil
 	}
 	return nil, nil
 }

--- a/pkg/filter/fields/fields_windows.go
+++ b/pkg/filter/fields/fields_windows.go
@@ -268,6 +268,8 @@ const (
 	FileOffset Field = "file.offset"
 	// FileType represents the file type
 	FileType Field = "file.type"
+	// FileAttributes represents a slice of file attributes
+	FileAttributes Field = "file.attributes"
 
 	// RegistryKeyName represents the registry key name
 	RegistryKeyName Field = "registry.key.name"
@@ -432,14 +434,15 @@ var fields = map[Field]FieldInfo{
 	ImageDefaultAddress: {ImageDefaultAddress, "default image address", kparams.HexInt64, []string{"image.default.address = '7efe0000'"}},
 	ImagePID:            {ImagePID, "target process identifier", kparams.Uint32, []string{"image.pid = 80"}},
 
-	FileObject:    {FileObject, "file object address", kparams.Uint64, []string{"file.object = 18446738026482168384"}},
-	FileName:      {FileName, "full file name", kparams.UnicodeString, []string{"file.name contains 'mimikatz'"}},
-	FileOperation: {FileOperation, "file operation", kparams.AnsiString, []string{"file.operation = 'open'"}},
-	FileShareMask: {FileShareMask, "file share mask", kparams.AnsiString, []string{"file.share.mask = 'rw-'"}},
-	FileIOSize:    {FileIOSize, "file I/O size", kparams.Uint32, []string{"file.io.size > 512"}},
-	FileOffset:    {FileOffset, "file offset", kparams.Uint64, []string{"file.offset = 1024"}},
-	FileType:      {FileType, "file type", kparams.AnsiString, []string{"file.type = 'directory'"}},
-	FileExtension: {FileExtension, "file extension", kparams.AnsiString, []string{"file.extension = '.dll'"}},
+	FileObject:     {FileObject, "file object address", kparams.Uint64, []string{"file.object = 18446738026482168384"}},
+	FileName:       {FileName, "full file name", kparams.UnicodeString, []string{"file.name contains 'mimikatz'"}},
+	FileOperation:  {FileOperation, "file operation", kparams.AnsiString, []string{"file.operation = 'open'"}},
+	FileShareMask:  {FileShareMask, "file share mask", kparams.AnsiString, []string{"file.share.mask = 'rw-'"}},
+	FileIOSize:     {FileIOSize, "file I/O size", kparams.Uint32, []string{"file.io.size > 512"}},
+	FileOffset:     {FileOffset, "file offset", kparams.Uint64, []string{"file.offset = 1024"}},
+	FileType:       {FileType, "file type", kparams.AnsiString, []string{"file.type = 'directory'"}},
+	FileExtension:  {FileExtension, "file extension", kparams.AnsiString, []string{"file.extension = '.dll'"}},
+	FileAttributes: {FileAttributes, "file attributes", kparams.Slice, []string{"file.attributes in ('archive', 'hidden')"}},
 
 	RegistryKeyName:   {RegistryKeyName, "fully qualified key name", kparams.UnicodeString, []string{"registry.key.name contains 'HKEY_LOCAL_MACHINE'"}},
 	RegistryKeyHandle: {RegistryKeyHandle, "registry key object address", kparams.HexInt64, []string{"registry.key.handle = 'FFFFB905D60C2268'"}},

--- a/pkg/fs/attrs.go
+++ b/pkg/fs/attrs.go
@@ -25,27 +25,71 @@ package fs
 type FileAttr uint32
 
 const (
-	// FileDirectory indicates that the file is a directory.
-	FileDirectory FileAttr = 0x10
-	// FileArchive denotes a file or directory that is an archive file or directory. Applications typically use this attribute to mark files for backup or removal.
-	FileArchive FileAttr = 0x20
-	// FileCompressed represents a file or a directory that is compressed.
-	FileCompressed FileAttr = 0x800
-	// FileEncrypted represents a file or a directory that is encrypted
-	FileEncrypted FileAttr = 0x4000
+	// FileReadOnly reprsents file that is read-only. Processes can read the file, but cannot write to it or delete it.
+	// This attribute is not honored on directories.
+	FileReadOnly FileAttr = 0x00000001
 	// FileHidden designates a file or directory that is hidden, i.e. it is not included in an ordinary directory listing.
-	FileHidden FileAttr = 0x2
-	// FileReparsePoint represents a file or directory that has an associated reparse point, or a file that is a symbolic link.
-	FileReparsePoint FileAttr = 0x400
-	// FileSparse denotes a sparse file. Spares files can optimize disk usage as the system does not allocate disk space for the file regions with sparse data.
-	FileSparse = 0x200
+	FileHidden FileAttr = 0x00000002
+	// FileSystem is a file or directory that the operating system uses a part of, or uses exclusively.
+	FileSystem FileAttr = 0x00000004
+	// FileOldDosVolID is unused
+	FileOldDosVolID FileAttr = 0x00000008
+	// FileDirectory indicates that the file is a directory.
+	FileDirectory FileAttr = 0x00000010
+	// FileArchive denotes a file or directory that is an archive file or directory. Applications typically use this attribute to mark files for backup or removal.
+	FileArchive FileAttr = 0x00000020
+	// FileDevice attribute is reserved for system use.
+	FileDevice FileAttr = 0x00000040
+	// FileNormal is a file that does not have other attributes set. This attribute is valid only when used alone.
+	FileNormal FileAttr = 0x00000080
 	// FileTemporary denotes files that are used for temporary storage.
-	FileTemporary = 0x100
+	FileTemporary = 0x00000100
+	// FileSparse denotes a sparse file. Spare files can optimize disk usage as the system does not allocate disk space for the file regions with sparse data.
+	FileSparse = 0x00000200
+	// FileReparsePoint represents a file or directory that has an associated reparse point, or a file that is a symbolic link.
+	FileReparsePoint FileAttr = 0x00000400
+	// FileCompressed represents a file or a directory that is compressed.
+	FileCompressed FileAttr = 0x00000800
+	// FileOffline represents data of a file is not available immediately. This attribute indicates that the file data is physically moved to offline storage.
+	FileOffline FileAttr = 0x00001000
+	// FileNotContentIndexed is a file or directory is not to be indexed by the content indexing service.
+	FileNotContentIndexed = 0x00002000
+	// FileEncrypted represents a file or a directory that is encrypted
+	FileEncrypted FileAttr = 0x00004000
+	// FileIntegrityStream is the directory or user data stream is configured with integrity (only supported on ReFS volumes).
+	// It is not included in an ordinary directory listing.
+	FileIntegrityStream FileAttr = 0x00008000
+	// FileVirtual is reserved for system use.
+	FileVirtual FileAttr = 0x00010000
+	// FileNoScrubData represents user data stream not to be read by the background data integrity scanner (AKA scrubber).
+	// When set on a directory it only provides inheritance. This flag is only supported on Storage Spaces and ReFS volumes
+	FileNoScrubData FileAttr = 0x00020000
+	// FileRecallOpen attribute only appears in directory enumeration classes (FILE_DIRECTORY_INFORMATION,
+	// FILE_BOTH_DIR_INFORMATION, etc.). When this attribute is set, it means that the file or directory has no physical
+	// representation on the local system; the item is virtual
+	FileRecallOpen FileAttr = 0x00040000
+	// FileRecallAccess means that the file or directory is not fully present locally.
+	// For a file that means that not all of its data is on local storage (e.g. it may be sparse with some data still in
+	// remote storage). For a directory it means that some of the directory contents are being virtualized from another
+	// location.
+	FileRecallAccess FileAttr = 0x400000
+	// FilePinned indicates user intent that the file or directory should be kept fully present locally
+	// even when not being actively accessed. This attribute is for use with hierarchical storage management software.
+	FilePinned FileAttr = 0x80000
+	// FileUnpinned indicates that the file or directory should not be kept fully present locally except
+	// when being actively accessed. This attribute is for use with hierarchical storage management software.
+	FileUnpinned FileAttr = 0x100000
 )
 
 // FileAttr returns human-readable file attribute name.
 func (fa FileAttr) String() string {
 	switch fa {
+	case FileReadOnly:
+		return "readonly"
+	case FileHidden:
+		return "hidden"
+	case FileSystem:
+		return "system"
 	case FileDirectory:
 		return "directory"
 	case FileArchive:
@@ -54,15 +98,108 @@ func (fa FileAttr) String() string {
 		return "compressed"
 	case FileEncrypted:
 		return "encrypted"
-	case FileHidden:
-		return "hidden"
 	case FileReparsePoint:
 		return "junction"
 	case FileSparse:
 		return "sparse"
 	case FileTemporary:
 		return "temporary"
+	case FileDevice:
+		return "device"
+	case FileNormal:
+		return "normal"
+	case FileOffline:
+		return "offline"
+	case FileNotContentIndexed:
+		return "unindexed"
+	case FileIntegrityStream:
+		return "stream"
+	case FileVirtual:
+		return "virtual"
+	case FileNoScrubData:
+		return "noscrub"
+	case FileRecallOpen:
+		return "recallopen"
+	case FileRecallAccess:
+		return "recallaccess"
+	case FilePinned:
+		return "pinned"
+	case FileUnpinned:
+		return "unpinned"
 	default:
 		return "unknown"
 	}
+}
+
+// FileAttributes returns all the attributes present in the bitmask.
+func FileAttributes(b uint32) []FileAttr {
+	fa := make([]FileAttr, 0)
+	a := FileAttr(b)
+	if a&FileReadOnly != 0 {
+		fa = append(fa, FileReadOnly)
+	}
+	if a&FileHidden != 0 {
+		fa = append(fa, FileHidden)
+	}
+	if a&FileSystem != 0 {
+		fa = append(fa, FileSystem)
+	}
+	if a&FileOldDosVolID != 0 {
+		fa = append(fa, FileOldDosVolID)
+	}
+	if a&FileDirectory != 0 {
+		fa = append(fa, FileDirectory)
+	}
+	if a&FileArchive != 0 {
+		fa = append(fa, FileArchive)
+	}
+	if a&FileCompressed != 0 {
+		fa = append(fa, FileCompressed)
+	}
+	if a&FileEncrypted != 0 {
+		fa = append(fa, FileEncrypted)
+	}
+	if a&FileReparsePoint != 0 {
+		fa = append(fa, FileReparsePoint)
+	}
+	if a&FileSparse != 0 {
+		fa = append(fa, FileSparse)
+	}
+	if a&FileTemporary != 0 {
+		fa = append(fa, FileTemporary)
+	}
+	if a&FileDevice != 0 {
+		fa = append(fa, FileDevice)
+	}
+	if a&FileNormal != 0 {
+		fa = append(fa, FileNormal)
+	}
+	if a&FileOffline != 0 {
+		fa = append(fa, FileOffline)
+	}
+	if a&FileNotContentIndexed != 0 {
+		fa = append(fa, FileNotContentIndexed)
+	}
+	if a&FileIntegrityStream != 0 {
+		fa = append(fa, FileIntegrityStream)
+	}
+	if a&FileVirtual != 0 {
+		fa = append(fa, FileVirtual)
+	}
+	if a&FileNoScrubData != 0 {
+		fa = append(fa, FileNoScrubData)
+	}
+	if a&FileRecallOpen != 0 {
+		fa = append(fa, FileRecallOpen)
+	}
+	if a&FileRecallAccess != 0 {
+		fa = append(fa, FileRecallAccess)
+	}
+	if a&FilePinned != 0 {
+		fa = append(fa, FilePinned)
+	}
+	if a&FileUnpinned != 0 {
+		fa = append(fa, FileUnpinned)
+	}
+	return fa
 }

--- a/pkg/kevent/kparam_windows.go
+++ b/pkg/kevent/kparam_windows.go
@@ -123,6 +123,12 @@ func (k Kparam) String() string {
 		switch slice := k.Value.(type) {
 		case []string:
 			return strings.Join(slice, ",")
+		case []fs.FileAttr:
+			attrs := make([]string, 0, len(slice))
+			for _, s := range slice {
+				attrs = append(attrs, s.String())
+			}
+			return strings.Join(attrs, ",")
 		default:
 			return fmt.Sprintf("%v", slice)
 		}

--- a/pkg/kevent/kparams/canonicalize.go
+++ b/pkg/kevent/kparams/canonicalize.go
@@ -63,6 +63,7 @@ const (
 	fileKey           = "FileKey"
 	fileExtraInfo     = "ExtraInfo"
 	fileIrpPtr        = "IrpPtr"
+	fileAttributes    = "FileAttributes"
 
 	keyName        = "KeyName"
 	keyHandle      = "KeyHandle"
@@ -197,6 +198,8 @@ func Canonicalize(name string) string {
 		return NTStatus
 	case desiredAccess:
 		return DesiredAccess
+	case fileAttributes:
+		return FileAttributes
 	default:
 		return ""
 	}

--- a/pkg/kevent/kparams/size.go
+++ b/pkg/kevent/kparams/size.go
@@ -33,7 +33,7 @@ func SizeOf(kpar string) uint32 {
 		return 8
 	case NTStatus, ProcessID, ThreadID, ProcessParentID,
 		SessionID, ExitStatus, FileCreateOptions, FileShareMask,
-		HandleID, FileIoSize, FileInfoClass:
+		HandleID, FileIoSize, FileInfoClass, FileAttributes:
 		return 4
 	case NetDport, NetSport, HandleObjectTypeID:
 		return 2

--- a/pkg/kevent/marshaller_windows.go
+++ b/pkg/kevent/marshaller_windows.go
@@ -166,6 +166,13 @@ func (kevt *Kevent) MarshalRaw() []byte {
 					b = append(b, bytes.WriteUint16(uint16(len(s)))...)
 					b = append(b, s...)
 				}
+			case []fs.FileAttr:
+				b = append(b, uint8('s'))
+				b = append(b, bytes.WriteUint16(uint16(len(slice)))...)
+				for _, s := range slice {
+					b = append(b, bytes.WriteUint16(uint16(len(s.String())))...)
+					b = append(b, s.String()...)
+				}
 			}
 		}
 	}

--- a/pkg/kstream/interceptors/fs_windows.go
+++ b/pkg/kstream/interceptors/fs_windows.go
@@ -345,6 +345,13 @@ func (f *fsInterceptor) processCreateFile(kevt *kevent.Kevent) error {
 	kevt.Kparams.Remove(kparams.FileExtraInfo)
 	// append human-readable file operation param
 	kevt.Kparams.Append(kparams.FileOperation, kparams.Enum, fs.FileDisposition(extraInfo))
+	// include file attributes as a slice parameter type
+	attrs, _ := kevt.Kparams.GetUint32(kparams.FileAttributes)
+	if attrs != 0 {
+		_ = kevt.Kparams.Set(kparams.FileAttributes, fs.FileAttributes(attrs), kparams.Slice)
+	} else {
+		kevt.Kparams.Remove(kparams.FileAttributes)
+	}
 
 	filename, err := kevt.Kparams.GetString(kparams.FileName)
 	if err != nil {


### PR DESCRIPTION
This PR adds support for a new `attributes` parameter in `CreateFile` events that represent all of the requested file attributes. An example of the `CreateFile` event with temporary and hidden attributes:

```
21156 2022-06-24 11:49:54.1806558 +0200 CEST - 2 firefox.exe (6404) - CreateFile (attributes➜ [hidden temporary], file_name➜ C:\Users\emoji\AppData\Roaming\Microsoft\Windows\Recent\CustomDestinations\6824f4a902c78fbd.customDestinations-ms~RF3c9f39.TMP, file_object➜ ffff9c8bd292a730, irp➜ ffff9c8bcd2eca88, operation➜ create, share_mask➜ ---, type➜ file)
```