### PR TITLE
feat (events): add the `status` parameter to CreateFile events

### DIFF
--- a/pkg/filter/accessor_windows.go
+++ b/pkg/filter/accessor_windows.go
@@ -613,6 +613,8 @@ func (l *fileAccessor) get(f fields.Field, kevt *kevent.Kevent) (kparams.Value, 
 			attrs = append(attrs, attr.String())
 		}
 		return attrs, nil
+	case fields.FileStatus:
+		return kevt.Kparams.GetString(kparams.NTStatus)
 	}
 	return nil, nil
 }

--- a/pkg/filter/fields/fields_windows.go
+++ b/pkg/filter/fields/fields_windows.go
@@ -270,6 +270,8 @@ const (
 	FileType Field = "file.type"
 	// FileAttributes represents a slice of file attributes
 	FileAttributes Field = "file.attributes"
+	// FileStatus represents the status message of the file operation
+	FileStatus Field = "file.status"
 
 	// RegistryKeyName represents the registry key name
 	RegistryKeyName Field = "registry.key.name"
@@ -443,6 +445,7 @@ var fields = map[Field]FieldInfo{
 	FileType:       {FileType, "file type", kparams.AnsiString, []string{"file.type = 'directory'"}},
 	FileExtension:  {FileExtension, "file extension", kparams.AnsiString, []string{"file.extension = '.dll'"}},
 	FileAttributes: {FileAttributes, "file attributes", kparams.Slice, []string{"file.attributes in ('archive', 'hidden')"}},
+	FileStatus:     {FileStatus, "file operation status message", kparams.UnicodeString, []string{"file.status != 'success'"}},
 
 	RegistryKeyName:   {RegistryKeyName, "fully qualified key name", kparams.UnicodeString, []string{"registry.key.name contains 'HKEY_LOCAL_MACHINE'"}},
 	RegistryKeyHandle: {RegistryKeyHandle, "registry key object address", kparams.HexInt64, []string{"registry.key.handle = 'FFFFB905D60C2268'"}},

--- a/pkg/kstream/interceptors/fs_windows.go
+++ b/pkg/kstream/interceptors/fs_windows.go
@@ -229,6 +229,11 @@ func (f *fsInterceptor) Intercept(kevt *kevent.Kevent) (*kevent.Kevent, bool, er
 				return kevt, true, err
 			}
 			fkevt.Kparams.Append(kparams.FileExtraInfo, kparams.Uint8, extraInfo)
+			// resolve the status of the file operation
+			status, err := kevt.Kparams.GetUint32(kparams.NTStatus)
+			if err == nil {
+				_ = fkevt.Kparams.Append(kparams.NTStatus, kparams.UnicodeString, formatStatus(status, fkevt))
+			}
 
 			delete(f.pendingKevents, irp)
 

--- a/pkg/kstream/interceptors/ps_windows.go
+++ b/pkg/kstream/interceptors/ps_windows.go
@@ -172,7 +172,7 @@ func (ps psInterceptor) Intercept(kevt *kevent.Kevent) (*kevent.Kevent, bool, er
 		// format the status code
 		status, err := kevt.Kparams.GetUint32(kparams.NTStatus)
 		if err == nil {
-			_ = kevt.Kparams.Set(kparams.NTStatus, formatStatus(status), kparams.UnicodeString)
+			_ = kevt.Kparams.Set(kparams.NTStatus, formatStatus(status, kevt), kparams.UnicodeString)
 		}
 		// convert desired access mask to hex value and transform
 		// the access mask to a list of symbolical names

--- a/pkg/kstream/interceptors/registry_windows.go
+++ b/pkg/kstream/interceptors/registry_windows.go
@@ -44,7 +44,6 @@ var (
 )
 
 const (
-	notFoundNTStatus = 3221225524
 	maxHandleQueries = 200
 )
 
@@ -141,7 +140,7 @@ func (r *registryInterceptor) Intercept(kevt *kevent.Kevent) (*kevent.Kevent, bo
 		// format registry operation status code
 		status, err := kevt.Kparams.GetUint32(kparams.NTStatus)
 		if err == nil {
-			_ = kevt.Kparams.Set(kparams.NTStatus, formatStatus(status), kparams.UnicodeString)
+			_ = kevt.Kparams.Set(kparams.NTStatus, formatStatus(status, kevt), kparams.UnicodeString)
 		}
 
 		// get the type/value of the registry key and append to parameters


### PR DESCRIPTION
With this PR we have the ability to observe and filter `CreateFile` events by the status message that includes the outcome of the operation. Closes #106 

An example of  the `CreateFile` event with the `status` parameter:

```
53861 2022-06-25 20:00:30.310177 +0200 CEST - 1 aswidsagent.exe (7880) - CreateFile (file_name➜ C:\PROGRAM FILES (X86)\COMMON FILES\ORACLE\JAVA\JAVAPATH\DEVICE\NULL, file_object➜ ffff8002915865d0, irp➜ ffff80028a4c6598, operation➜ supersede, share_mask➜ rw-, status➜ a reparse should be performed by the object manager since the name of the file resulted in a symbolic link., type➜ directory)
```