### PR TITLE
feat (rules): Stateful detection rules

### DIFF
--- a/configs/rules/default/default.yml
+++ b/configs/rules/default/default.yml
@@ -3,7 +3,7 @@
 # These filter rules try to mimic the subset of the sysmon config template
 # created by SwiftOnSecurity (https://github.com/SwiftOnSecurity/sysmon-config).
 #
-# All credits for digging the rule definitions go to the above author/contributors.
+# All credits for digging the rule conditioninitions go to the above author/contributors.
 #
 # Obviously, some events can't be directly translated to Fibratus equivalent
 # since Fibratus is not aware of them. In the same way,
@@ -22,9 +22,9 @@
   enabled: true
   policy: exclude
   relation: or
-  from-strings:
+  rules:
     - name: Windows error reporting/telemetry, WMI provider host
-      def: ps.comm istartswith
+      condition: ps.comm istartswith
           (
             ' \"C:\\Windows\\system32\\wermgr.exe\\" \"-queuereporting_svc\" ',
             'C:\\Windows\\system32\\DllHost.exe /Processid',
@@ -32,7 +32,7 @@
             'C:\\Windows\\system32\\wbem\\wmiprvse.exe -secured -Embedding'
           )
     - name: Windows error reporting/telemetry, Search Indexer, Session Manager, Auto check utility
-      def: ps.comm iin
+      condition: ps.comm iin
           (
             'C:\\Windows\\system32\\wermgr.exe -upload',
             'C:\\Windows\\system32\\SearchIndexer.exe /Embedding',
@@ -42,7 +42,7 @@
             'C:\\Windows\\System32\\RuntimeBroker.exe -Embedding'
           )
     - name: Various Windows processes
-      def: ps.exe iin
+      condition: ps.exe iin
           (
             'C:\\Program Files (x86)\\Common Files\\microsoft shared\\ink\\TabTip32.exe',
             'C:\\Windows\\System32\\TokenBrokerCookies.exe',
@@ -68,11 +68,11 @@
             'C:\\Windows\\System32\\usocoreworker.exe -Embedding'
           )
     - name: svchost
-      def: ps.comm iin {{ .Values.processes.comm.svchost | stringify }}
+      condition: ps.comm iin {{ .Values.processes.comm.svchost | stringify }}
     - name: Microsoft edge
-      def: ps.comm istartswith '\"C:\\Program Files (x86)\\Microsoft\\Edge Dev\\Application\\msedge.exe\" --type='
+      condition: ps.comm istartswith '\"C:\\Program Files (x86)\\Microsoft\\Edge Dev\\Application\\msedge.exe\" --type='
     - name: Microsoft dotNet
-      def: ps.comm istartswith
+      condition: ps.comm istartswith
           (
             'C:\\Windows\\Microsoft.NET\\Framework\\v4.0.30319\\ngen.exe',
             'C:\\WINDOWS\\Microsoft.NET\\Framework64\\v4.0.30319\\Ngen.exe'
@@ -85,7 +85,7 @@
             'C:\\Windows\\Microsoft.Net\\Framework64\\*\\WPF\\PresentationFontCache.exe'
           )
     - name: Microsoft Office
-      def: ps.exe iin
+      condition: ps.exe iin
           (
             'C:\\Program Files\\Microsoft Office\\Office16\\MSOSYNC.EXE',
             'C:\\Program Files (x86)\\Microsoft Office\\Office16\\MSOSYNC.EXE',
@@ -95,9 +95,9 @@
             'C:\\Program Files\\Common Files\\Microsoft Shared\\ClickToRun\\OfficeC2RClient.exe'
           )
     - name: Media Player
-      def: ps.exe = 'C:\\Program Files\\Windows Media Player\\wmpnscfg.exe'
+      condition: ps.exe = 'C:\\Program Files\\Windows Media Player\\wmpnscfg.exe'
     - name: Google
-      def: ps.comm istartswith
+      condition: ps.comm istartswith
           (
             '\"C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe\\\" --type=',
             '\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --type='
@@ -108,12 +108,10 @@
 - group: Suspicious process terminations
   selector:
     type: TerminateProcess
-  enabled: true
   policy: include
-  relation: or
-  from-strings:
+  rules:
     - name: User binaries
-      def: ps.name istartswith ('C:\\Users', '\\')
+      condition: ps.name istartswith ('C:\\Users', '\\')
 
 
 # ======================= Remote thread creation =====================================================
@@ -124,12 +122,10 @@
 - group: Suspicious remote thread creations
   selector:
     type: CreateThread
-  enabled: true
   policy: include
-  relation: or
-  from-strings:
+  rules:
     - name: Fishy remote threads
-      def: kevt.pid != thread.pid
+      condition: kevt.pid != thread.pid
              and
            ps.exe not iin
            (
@@ -156,12 +152,10 @@
 - group: Suspicious network-connecting binaries
   selector:
     type: Connect
-  enabled: true
   policy: include
-  relation: or
-  from-strings:
+  rules:
     - name: Suspicious sources for network-connecting binaries
-      def: ps.exe istartswith
+      condition: ps.exe istartswith
           (
             'C:\\Users',
             'C:\\Recycle',
@@ -174,7 +168,7 @@
             'C:\\Windows\\system32\\config'
           )
     - name: Suspicious Windows tools network-connecting binaries
-      def: ps.name in
+      condition: ps.name in
           (
             'at.exe',
             'certutil.exe',
@@ -184,7 +178,7 @@
             'driverquery.exe',
             'dsquery.exe',
             'hh.exe',
-            'infDefaultInstall.exe',
+            'infconditionaultInstall.exe',
             'java.exe',
             'javaw.exe',
             'javaws.exe',
@@ -213,7 +207,7 @@
             'wscript.exe'
           )
     - name: Relevant 3rd Party Tools
-      def: ps.name in
+      condition: ps.name in
           (
             'nc.exe',
             'ncat.exe',
@@ -228,7 +222,7 @@
             'psinfo.exe'
           )
     - name: Suspicious ports
-      def: net.dport in
+      condition: net.dport in
           (
             22,
             23,
@@ -249,12 +243,10 @@
 - group: Microsoft binaries and known addresses
   selector:
     type: Connect
-  enabled: true
   policy: exclude
-  relation: or
-  from-strings:
+  rules:
     - name: Microsoft binaries
-      def: ps.exe istartswith 'C:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\'
+      condition: ps.exe istartswith 'C:\\ProgramData\\Microsoft\\Windows conditionender\\Platform\\'
               or
            ps.exe endswith 'AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe'
               or
@@ -265,21 +257,19 @@
               'microsoft.com.nsatc.net'
            )
     - name: OCSP protocol known addresses
-      def: net.dip in (23.4.43.27, 72.21.91.29)
+      condition: net.dip in (23.4.43.27, 72.21.91.29)
     - name: Loopback addresses
-      def: net.dip = 127.0.0.1 or net.dip startswith 'fe80:0:0:0'
+      condition: net.dip = 127.0.0.1 or net.dip startswith 'fe80:0:0:0'
 
 # ======================= File created ===============================================================
 #
 - group: Suspicious file creation operations
   selector:
     type: CreateFile
-  enabled: true
   policy: include
-  relation: or
-  from-strings:
+  rules:
     - name: Startup links and shortcut modifications
-      def: file.operation = 'create'
+      condition: file.operation = 'create'
               and
            file.name icontains
            (
@@ -287,11 +277,11 @@
               '\\Startup\\'
            )
     - name: Microsoft Outlook attachments
-      def: file.operation = 'create' and file.name icontains '\\Content.Outlook\\'
+      condition: file.operation = 'create' and file.name icontains '\\Content.Outlook\\'
     - name: Downloaded files
-      def: file.operation = 'create' and file.name icontains '\\Downloads\\'
+      condition: file.operation = 'create' and file.name icontains '\\Downloads\\'
     - name: Microsoft ClickOnce application
-      def: file.operation = 'create'
+      condition: file.operation = 'create'
               and
            file.extension in
            (
@@ -299,7 +289,7 @@
               '.appref-ms'
            )
     - name: Batch scripting
-      def: file.operation = 'create'
+      condition: file.operation = 'create'
               and
            file.extension in
            (
@@ -309,7 +299,7 @@
               '.cmdline'
            )
     - name: Fishy extensions
-      def: file.operation = 'create'
+      condition: file.operation = 'create'
               and
            file.extension in
            (
@@ -333,7 +323,7 @@
               '.xls'
            )
     - name: Powershell persistence
-      def: file.operation = 'create'
+      condition: file.operation = 'create'
               and
            file.name imatches 'C:\\Windows\\*\\WindowsPowerShell'
 
@@ -342,12 +332,11 @@
 - group: Suspicious registry key modifications
   selector:
     category: registry
-  enabled: true
   policy: include
-  relation: or
-  from-strings:
+  rules:
     - name: Core Windows keys
-      def: kevt.name in ('RegCreateKey', 'RegDeleteKey', 'RegSetValue', 'RegDeleteValue')
+      condition: >
+        kevt.name in ('RegCreateKey', 'RegDeleteKey', 'RegSetValue', 'RegDeleteValue')
               and
            registry.key.name icontains
               (
@@ -378,7 +367,7 @@
               )
 
     - name: Services
-      def: kevt.name in ('RegCreateKey', 'RegDeleteKey', 'RegSetValue', 'RegDeleteValue')
+      condition: kevt.name in ('RegCreateKey', 'RegDeleteKey', 'RegSetValue', 'RegDeleteValue')
               and
            registry.key.name iendswith
            (

--- a/configs/rules/default/default.yml
+++ b/configs/rules/default/default.yml
@@ -3,7 +3,7 @@
 # These filter rules try to mimic the subset of the sysmon config template
 # created by SwiftOnSecurity (https://github.com/SwiftOnSecurity/sysmon-config).
 #
-# All credits for digging the rule conditioninitions go to the above author/contributors.
+# All credits for digging the rule definitions go to the above author/contributors.
 #
 # Obviously, some events can't be directly translated to Fibratus equivalent
 # since Fibratus is not aware of them. In the same way,
@@ -139,10 +139,11 @@
               'C:\\Windows\\system32\\kernel32.dll',
               'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe'
            )
-      action: |
-        {{ $title := cat "Identified remote thread creation in" .Kevt.Kparams.exe }}
-        {{ $text := cat "Injected by" .Kevt.PS.Exe }}
-        {{ emit $title $text }}
+      action: >
+        {{ emit
+            (printf "Detected remote thread creation in %s" .Kevt.Kparams.exe)
+            (printf "Possible code injection by %s" .Kevt.PS.Exe)
+        }}
 
 # ======================= Network connection initiated ===============================================
 #

--- a/configs/rules/default/stateful.yml
+++ b/configs/rules/default/stateful.yml
@@ -1,0 +1,20 @@
+- group: remote connection and command shell spawning
+  policy: sequence
+  rules:
+    - name: establish remote connection
+      condition: >
+        kevt.name = 'Connect'
+          and
+        cidr_contains(net.dip,
+          '10.0.0.0/8',
+          '172.16.0.0/12',
+          '172.17.0.0/16',
+          '192.168.0.0/16') = false
+    - name: spawn command shell
+      max-span: 1m
+      condition: >
+        kevt.name = 'CreateProcess'
+          and
+        ps.pid = $1.ps.pid
+          and
+        ps.sibling.name in ('cmd.exe', 'powershell.exe')

--- a/configs/rules/default/stateful.yml
+++ b/configs/rules/default/stateful.yml
@@ -1,15 +1,17 @@
-- group: remote connection and command shell spawning
+- group: remote connection and command shell execution
   policy: sequence
   rules:
     - name: establish remote connection
       condition: >
         kevt.name = 'Connect'
           and
-        cidr_contains(net.dip,
+          not
+        cidr_contains(
+          net.dip,
           '10.0.0.0/8',
           '172.16.0.0/12',
           '172.17.0.0/16',
-          '192.168.0.0/16') = false
+          '192.168.0.0/16')
     - name: spawn command shell
       max-span: 1m
       condition: >
@@ -18,3 +20,7 @@
         ps.pid = $1.ps.pid
           and
         ps.sibling.name in ('cmd.exe', 'powershell.exe')
+  action: >
+    {{ emit "Command shell spawned after remote connection"
+      (printf "%s process spawned a command shell after connecting to %s" .Kevts.k2.PS.Exe .Kevts.k1.Kparams.dip)
+    }}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/olivere/elastic/v7 v7.0.20
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pkg/errors v0.9.1
+	github.com/qmuntal/stateless v1.6.0 // indirect
 	github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5
 	github.com/sirupsen/logrus v1.4.1
 	github.com/spf13/cobra v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/qmuntal/stateless v1.6.0 h1:gL34XLU4ZIGGEtlhbG1IBOty5Aoa8i+XY1YiRFtdLWk=
+github.com/qmuntal/stateless v1.6.0/go.mod h1:cWTwXu9ey+FxI0fHvDi1nGCtpYa8N1X2aOmoRg2RUCI=
 github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5 h1:mZHayPoR0lNmnHyvtYjDeq0zlVHn9K/ZXoy17ylucdo=
 github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5/go.mod h1:GEXHk5HgEKCvEIIrSpFI3ozzG5xOKA2DVlEX/gGnewM=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/pkg/config/_fixtures/filters/default-new-attributes.yml
+++ b/pkg/config/_fixtures/filters/default-new-attributes.yml
@@ -1,0 +1,18 @@
+- group: internal network traffic
+  enabled: false
+  selector:
+    type: Connect
+  policy: exclude
+  relation: and
+  tags:
+    - TE
+  from-strings:
+    - name: only network category
+      def: kevt.category = 'net'
+
+- group: rouge processes
+  selector:
+    category: net
+  rules:
+    - name: suspicious network {{ upper "activity" }}
+      condition: kevt.category = 'net' and ps.name in ('at.exe', 'java.exe')

--- a/pkg/config/schema_windows.go
+++ b/pkg/config/schema_windows.go
@@ -489,7 +489,7 @@ var filterGroupSchema = `
 			]
 		},
 		"enabled":  	{"type": "boolean"},
-		"policy":   	{"type": "string", "enum": ["include", "exclude", "INCLUDE", "EXCLUDE"]},
+		"policy":   	{"type": "string", "enum": ["include", "exclude", "sequence", "INCLUDE", "EXCLUDE", "SEQUENCE"]},
 		"relation": 	{"type": "string", "enum": ["or", "and", "OR", "AND"]},
 		"tags":			{"type": "array", "items": [{"type": "string", "minLength": 1}]},
 		"from-strings": {
@@ -498,18 +498,32 @@ var filterGroupSchema = `
 				{
 					"type": "object",
 					"properties": {
-						"name": 	{"type": "string", "minLength": 3},
-						"def": 		{"type": "string", "minLength": 3},
-						"action": 	{"type": "string"}
+						"name": 		{"type": "string", "minLength": 3},
+						"def": 			{"type": "string", "minLength": 3},
+						"condition": 	{"type": "string", "minLength": 3},
+						"action": 		{"type": "string"},
+						"max-span": 	{"type": "string"}
 					},
-					"required": ["name", "def"],
+					"oneOf": [
+						{"required": ["def"]},
+						{"required": ["condition"]}
+					],
+					"required": ["name"],
 					"minItems": 1,
 					"additionalProperties": false
 				}
 
 		}
 	},
-	"required": ["group", "enabled", "selector", "from-strings"],
+	"if": {
+		"properties": {"policy": {"const": "sequence" }}
+	},
+	"then": {
+		"required": ["group", "from-strings"]
+	},
+	"else": {
+		"required": ["group", "selector", "from-strings"]
+	},
 	"additionalProperties": false
 }
 `

--- a/pkg/config/schema_windows.go
+++ b/pkg/config/schema_windows.go
@@ -492,6 +492,7 @@ var filterGroupSchema = `
 		"policy":   	{"type": "string", "enum": ["include", "exclude", "sequence", "INCLUDE", "EXCLUDE", "SEQUENCE"]},
 		"relation": 	{"type": "string", "enum": ["or", "and", "OR", "AND"]},
 		"tags":			{"type": "array", "items": [{"type": "string", "minLength": 1}]},
+		"action":       {"type": "string"},
 		"from-strings": {
 			"type": "array",
 			"items":
@@ -502,7 +503,7 @@ var filterGroupSchema = `
 						"def": 			{"type": "string", "minLength": 3},
 						"condition": 	{"type": "string", "minLength": 3},
 						"action": 		{"type": "string"},
-						"max-span": 	{"type": "string"}
+						"max-span": 	{"type": "string", "minLength": 2, "pattern": "[0-9]+ms|s|m|h|d"}
 					},
 					"oneOf": [
 						{"required": ["def"]},

--- a/pkg/config/schema_windows.go
+++ b/pkg/config/schema_windows.go
@@ -472,6 +472,26 @@ var schema = `
 var filterGroupSchema = `
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {"rules": {"$id": "#rules", "type": "object", "type": "array",
+			"items":
+				{
+					"type": "object",
+					"properties": {
+						"name": 		{"type": "string", "minLength": 3},
+						"def": 			{"type": "string", "minLength": 3},
+						"condition": 	{"type": "string", "minLength": 3},
+						"action": 		{"type": "string"},
+						"max-span": 	{"type": "string", "minLength": 2, "pattern": "[0-9]+ms|s|m|h|d"}
+					},
+					"oneOf": [
+						{"required": ["def"]},
+						{"required": ["condition"]}
+					],
+					"required": ["name"],
+					"minItems": 1,
+					"additionalProperties": false
+				}}},
+
 
 	"type": "object",
 	"properties": {
@@ -493,37 +513,25 @@ var filterGroupSchema = `
 		"relation": 	{"type": "string", "enum": ["or", "and", "OR", "AND"]},
 		"tags":			{"type": "array", "items": [{"type": "string", "minLength": 1}]},
 		"action":       {"type": "string"},
-		"from-strings": {
-			"type": "array",
-			"items":
-				{
-					"type": "object",
-					"properties": {
-						"name": 		{"type": "string", "minLength": 3},
-						"def": 			{"type": "string", "minLength": 3},
-						"condition": 	{"type": "string", "minLength": 3},
-						"action": 		{"type": "string"},
-						"max-span": 	{"type": "string", "minLength": 2, "pattern": "[0-9]+ms|s|m|h|d"}
-					},
-					"oneOf": [
-						{"required": ["def"]},
-						{"required": ["condition"]}
-					],
-					"required": ["name"],
-					"minItems": 1,
-					"additionalProperties": false
-				}
-
-		}
+		"from-strings": {"$ref": "#rules"},
+		"rules": 		{"$ref": "#rules"}
 	},
 	"if": {
 		"properties": {"policy": {"const": "sequence" }}
 	},
 	"then": {
-		"required": ["group", "from-strings"]
+		"required": ["group"],
+		"oneOf": [
+			{"required": ["from-strings"]},
+			{"required": ["rules"]}
+		]
 	},
 	"else": {
-		"required": ["group", "selector", "from-strings"]
+		"required": ["group", "selector"],
+		"oneOf": [
+			{"required": ["from-strings"]},
+			{"required": ["rules"]}
+		]
 	},
 	"additionalProperties": false
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -45,7 +45,7 @@ type ErrKparamNotFound struct {
 
 // Error returns the error message.
 func (e ErrKparamNotFound) Error() string {
-	return "couldn't find " + e.Name + " in event parameters"
+	return "couldn't find '" + e.Name + "' in event parameters"
 }
 
 // IsCancelUpstreamKevent determines if the error being passed if of `ErrCancelUpstreamKevent` type.

--- a/pkg/filter/_fixtures/sequence_policy_complex_pattern_bindings.yml
+++ b/pkg/filter/_fixtures/sequence_policy_complex_pattern_bindings.yml
@@ -21,3 +21,5 @@
     - name: outbound communication
       condition: >
         kevt.name in ('Send', 'Connect') and ps.pid = $3.ps.sibling.pid
+  action: >
+      {{ emit "Phishing dropper outbound communication" (printf "%s process initiated outbound communication to %s" .Kevts.k3.Kparams.name .Kevts.k4.Kparams.dip) }}

--- a/pkg/filter/_fixtures/sequence_policy_complex_pattern_bindings.yml
+++ b/pkg/filter/_fixtures/sequence_policy_complex_pattern_bindings.yml
@@ -13,7 +13,7 @@
           and
         file.extension = '.exe'
           and
-        ps.pid = $1.ps.pid
+        ps.pid = $1.ps.sibling.pid
       max-span: 1h
     - name: spawn dropper process
       condition: >

--- a/pkg/filter/_fixtures/sequence_policy_complex_pattern_bindings.yml
+++ b/pkg/filter/_fixtures/sequence_policy_complex_pattern_bindings.yml
@@ -1,4 +1,4 @@
-- group: phising dropper outbound communication
+- group: phishing dropper outbound communication
   policy: sequence
   enabled: true
   from-strings:

--- a/pkg/filter/_fixtures/sequence_policy_complex_pattern_bindings.yml
+++ b/pkg/filter/_fixtures/sequence_policy_complex_pattern_bindings.yml
@@ -22,4 +22,6 @@
       condition: >
         kevt.name in ('Send', 'Connect') and ps.pid = $3.ps.sibling.pid
   action: >
-      {{ emit "Phishing dropper outbound communication" (printf "%s process initiated outbound communication to %s" .Kevts.k3.Kparams.name .Kevts.k4.Kparams.dip) }}
+      {{ emit "Phishing dropper outbound communication"
+        (printf "%s process initiated outbound communication to %s" .Kevts.k3.Kparams.name .Kevts.k4.Kparams.dip)
+      }}

--- a/pkg/filter/_fixtures/sequence_policy_complex_pattern_bindings.yml
+++ b/pkg/filter/_fixtures/sequence_policy_complex_pattern_bindings.yml
@@ -1,0 +1,23 @@
+- group: phising dropper outbound communication
+  policy: sequence
+  enabled: true
+  from-strings:
+    - name: spawn browser client
+      condition: >
+        kevt.name = 'CreateProcess' and ps.sibling.name
+          in
+        ('firefox.exe', 'chrome.exe', 'edge.exe')
+    - name: downloaded executable file
+      condition: >
+        kevt.name = 'CreateFile' and file.operation = 'create'
+          and
+        file.extension = '.exe'
+          and
+        ps.pid = $1.ps.pid
+      max-span: 1h
+    - name: spawn dropper process
+      condition: >
+        kevt.name = 'CreateProcess' and ps.sibling.exe = $2.file.name
+    - name: outbound communication
+      condition: >
+        kevt.name in ('Send', 'Connect') and ps.pid = $3.ps.sibling.pid

--- a/pkg/filter/_fixtures/sequence_policy_simple.yml
+++ b/pkg/filter/_fixtures/sequence_policy_simple.yml
@@ -1,0 +1,9 @@
+- group: command shell execution and temp files
+  policy: sequence
+  enabled: true
+  from-strings:
+    - name: spawn command shell
+      condition: kevt.name = 'CreateProcess' and ps.name = 'cmd.exe'
+    - name: created temp file by command shell
+      condition: >
+        kevt.name = 'CreateFile' and ps.name = 'cmd.exe' and file.name icontains 'temp'

--- a/pkg/filter/_fixtures/sequence_policy_simple_max_span.yml
+++ b/pkg/filter/_fixtures/sequence_policy_simple_max_span.yml
@@ -1,0 +1,10 @@
+- group: command shell execution and temp files
+  policy: sequence
+  enabled: true
+  from-strings:
+    - name: spawn command shell
+      condition: kevt.name = 'CreateProcess' and ps.name = 'cmd.exe'
+    - name: created temp file by command shell
+      condition: >
+        kevt.name = 'CreateFile' and ps.name = 'cmd.exe' and file.name icontains 'temp'
+      max-span: 200ms

--- a/pkg/filter/_fixtures/sequence_policy_simple_pattern_bindings.yml
+++ b/pkg/filter/_fixtures/sequence_policy_simple_pattern_bindings.yml
@@ -1,0 +1,9 @@
+- group: command shell execution and temp files
+  policy: sequence
+  enabled: true
+  from-strings:
+    - name: spawn command shell
+      condition: kevt.name = 'CreateProcess' and ps.name = 'cmd.exe'
+    - name: created temp file by command shell
+      condition: >
+        kevt.name = 'CreateFile' and ps.pid = $1.ps.pid and file.name icontains 'temp'

--- a/pkg/filter/_fixtures/sequence_policy_simple_pattern_bindings.yml
+++ b/pkg/filter/_fixtures/sequence_policy_simple_pattern_bindings.yml
@@ -6,5 +6,9 @@
       condition: kevt.name = 'CreateProcess' and ps.name = 'cmd.exe'
     - name: created temp file by command shell
       condition: >
-        kevt.name = 'CreateFile' and ps.pid = $1.ps.pid and file.name icontains 'temp'
+        kevt.name = 'CreateFile'
+          and
+        ps.pid = $1.ps.pid
+          and
+        file.name icontains 'temp'
       max-span: 100ms

--- a/pkg/filter/_fixtures/sequence_policy_simple_pattern_bindings.yml
+++ b/pkg/filter/_fixtures/sequence_policy_simple_pattern_bindings.yml
@@ -1,7 +1,6 @@
 - group: command shell execution and temp files
   policy: sequence
-  enabled: true
-  from-strings:
+  rules:
     - name: spawn command shell
       condition: kevt.name = 'CreateProcess' and ps.name = 'cmd.exe'
     - name: created temp file by command shell

--- a/pkg/filter/_fixtures/sequence_policy_simple_pattern_bindings.yml
+++ b/pkg/filter/_fixtures/sequence_policy_simple_pattern_bindings.yml
@@ -7,3 +7,4 @@
     - name: created temp file by command shell
       condition: >
         kevt.name = 'CreateFile' and ps.pid = $1.ps.pid and file.name icontains 'temp'
+      max-span: 100ms

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -36,8 +36,12 @@ var (
 type Filter interface {
 	// Compile compiles the filter by parsing the filtering expression.
 	Compile() error
-	// Run runs a filter on the inbound kernel event and decides whether the event should be dropped or propagated to the downstream channel.
+	// Run runs a filter on the inbound kernel event and decides whether the event
+	// should be dropped or propagated to the downstream channel.
 	Run(kevt *kevent.Kevent) bool
+	// RunPartials runs a filter with stateful event tracking. Partials store all
+	// intermediate events that are the result of previous filter matches.
+	RunPartials(kevt *kevent.Kevent, partials map[uint16][]*kevent.Kevent) bool
 }
 
 type filter struct {
@@ -45,11 +49,9 @@ type filter struct {
 	parser    *ql.Parser
 	accessors []accessor
 	fields    []fields.Field
-	// multivaluer determines whether we should
-	// rely on the multivaluer to supply args
-	// for function calls or just use a simple
-	// map valuer
-	multivaluer bool
+	bindings  []*ql.PatternBindingLiteral
+	// useFuncValuer determines whether we should supply the function valuer
+	useFuncValuer bool
 }
 
 // Compile parsers the filter expression and builds a binary expression tree
@@ -67,7 +69,7 @@ func (f *filter) Compile() error {
 		return err
 	}
 
-	ql.WalkFunc(f.expr, func(n ql.Node) {
+	walk := func(n ql.Node) {
 		if expr, ok := n.(*ql.BinaryExpr); ok {
 			if lhs, ok := expr.LHS.(*ql.FieldLiteral); ok {
 				f.fields = append(f.fields, fields.Field(lhs.Value))
@@ -75,16 +77,20 @@ func (f *filter) Compile() error {
 			if rhs, ok := expr.RHS.(*ql.FieldLiteral); ok {
 				f.fields = append(f.fields, fields.Field(rhs.Value))
 			}
+			if rhs, ok := expr.RHS.(*ql.PatternBindingLiteral); ok {
+				f.bindings = append(f.bindings, rhs)
+			}
 		}
 		if expr, ok := n.(*ql.Function); ok {
-			f.multivaluer = true
+			f.useFuncValuer = true
 			for _, arg := range expr.Args {
 				if fld, ok := arg.(*ql.FieldLiteral); ok {
 					f.fields = append(f.fields, fields.Field(fld.Value))
 				}
 			}
 		}
-	})
+	}
+	ql.WalkFunc(f.expr, walk)
 
 	if len(f.fields) == 0 {
 		return errNoFields
@@ -97,11 +103,31 @@ func (f *filter) Run(kevt *kevent.Kevent) bool {
 	if f.expr == nil {
 		return false
 	}
+	return ql.Eval(f.expr, f.mapValuer(kevt), nil, f.useFuncValuer)
+}
+
+func (f *filter) RunPartials(kevt *kevent.Kevent, partials map[uint16][]*kevent.Kevent) bool {
+	if f.expr == nil {
+		return false
+	}
+	for i, kevts := range partials {
+		for _, e := range kevts {
+			valuer := f.bindingValuer(e, i)
+			ok := ql.Eval(f.expr, f.mapValuer(kevt), valuer, f.useFuncValuer)
+			if ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// mapValuer for each field present in the AST, we run the
+// accessors and extract the field vales that are
+// supplied to the valuer. The valuer feeds the
+// expression with correct values.
+func (f *filter) mapValuer(kevt *kevent.Kevent) map[string]interface{} {
 	valuer := make(map[string]interface{})
-	// for each field present in the AST, we run the
-	// accessors and extract the field vales that are
-	// supplied to the valuer. The valuer feeds the
-	// expression with correct values.
 	for _, field := range f.fields {
 		for _, accessor := range f.accessors {
 			v, err := accessor.get(field, kevt)
@@ -115,5 +141,28 @@ func (f *filter) Run(kevt *kevent.Kevent) bool {
 			valuer[field.String()] = v
 		}
 	}
-	return ql.Eval(f.expr, valuer, f.multivaluer)
+	return valuer
+}
+
+// bindingValuer for each pattern binding node, resolves its value from
+// the event that pertains to the same binding index.
+func (f *filter) bindingValuer(kevt *kevent.Kevent, idx uint16) map[string]interface{} {
+	valuer := make(map[string]interface{})
+	for _, binding := range f.bindings {
+		if binding.Index() != idx {
+			continue
+		}
+		for _, accessor := range f.accessors {
+			v, err := accessor.get(binding.Field(), kevt)
+			if err != nil && !kerrors.IsKparamNotFound(err) {
+				accessorErrors.Add(err.Error(), 1)
+				continue
+			}
+			if v == nil {
+				continue
+			}
+			valuer[binding.Value] = v
+		}
+	}
+	return valuer
 }

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -376,6 +376,9 @@ func TestFilterRunNetKevent(t *testing.T) {
 		Type: ktypes.SendTCPv4,
 		Tid:  2484,
 		PID:  859,
+		PS: &pstypes.PS{
+			Name: "cmd.exe",
+		},
 		Kparams: kevent.Kparams{
 			kparams.NetDport:    {Name: kparams.NetDport, Type: kparams.Uint16, Value: uint16(443)},
 			kparams.NetSport:    {Name: kparams.NetSport, Type: kparams.Uint16, Value: uint16(43123)},
@@ -403,6 +406,8 @@ func TestFilterRunNetKevent(t *testing.T) {
 		{`net.dip != 116.58.201.174`, true},
 		{`net.dip not in ('116.58.201.172', '16.58.201.176')`, true},
 		{`net.dip not in (116.58.201.172, 16.58.201.176)`, true},
+		{`ps.name = 'cmd.exe' and not cidr_contains(net.sip, '227.0.0.1/12', '8.2.3.0/4')`, true},
+		//{`ps.name = 'cmd.exe' and not ((net.sip not in (222.1.1.1)) or (net.sip not in (12.3.4.5)))`, true},
 		{`cidr_contains(net.dip, '216.58.201.1/24') = true`, true},
 		{`cidr_contains(net.dip, '226.58.201.1/24') = false`, true},
 		{`cidr_contains(net.dip, '216.58.201.1/24', '216.58.201.10/24') = true and kevt.pid = 859`, true},

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -52,7 +52,7 @@ func TestFilterCompile(t *testing.T) {
 	f = New(`ps.name`, cfg)
 	require.EqualError(t, f.Compile(), "expected at least one field or operator but zero found")
 	f = New(`ps.name =`, cfg)
-	require.EqualError(t, f.Compile(), "\nps.name =\n          ^ expected field, string, number, bool, ip, function")
+	require.EqualError(t, f.Compile(), "\nps.name =\n          ^ expected field, string, number, bool, ip, function, pattern binding")
 }
 
 func TestFilterRunProcessKevent(t *testing.T) {

--- a/pkg/filter/filter_windows.go
+++ b/pkg/filter/filter_windows.go
@@ -64,7 +64,7 @@ func New(expr string, config *config.Config) Filter {
 		parser:    ql.NewParser(expr),
 		accessors: accessors,
 		fields:    make([]fields.Field, 0),
-		bindings:  make([]*ql.PatternBindingLiteral, 0),
+		bindings:  make(map[uint16][]*ql.PatternBindingLiteral, 0),
 	}
 }
 
@@ -91,7 +91,7 @@ func NewFromCLIWithAllAccessors(args []string) (Filter, error) {
 		parser:    ql.NewParser(expr),
 		accessors: getAccessors(),
 		fields:    make([]fields.Field, 0),
-		bindings:  make([]*ql.PatternBindingLiteral, 0),
+		bindings:  make(map[uint16][]*ql.PatternBindingLiteral, 0),
 	}
 	if err := filter.Compile(); err != nil {
 		return nil, fmt.Errorf("bad filter: \n  %v", err)

--- a/pkg/filter/filter_windows.go
+++ b/pkg/filter/filter_windows.go
@@ -64,6 +64,7 @@ func New(expr string, config *config.Config) Filter {
 		parser:    ql.NewParser(expr),
 		accessors: accessors,
 		fields:    make([]fields.Field, 0),
+		bindings:  make([]*ql.PatternBindingLiteral, 0),
 	}
 }
 
@@ -90,6 +91,7 @@ func NewFromCLIWithAllAccessors(args []string) (Filter, error) {
 		parser:    ql.NewParser(expr),
 		accessors: getAccessors(),
 		fields:    make([]fields.Field, 0),
+		bindings:  make([]*ql.PatternBindingLiteral, 0),
 	}
 	if err := filter.Compile(); err != nil {
 		return nil, fmt.Errorf("bad filter: \n  %v", err)

--- a/pkg/filter/filter_windows.go
+++ b/pkg/filter/filter_windows.go
@@ -64,7 +64,7 @@ func New(expr string, config *config.Config) Filter {
 		parser:    ql.NewParser(expr),
 		accessors: accessors,
 		fields:    make([]fields.Field, 0),
-		bindings:  make(map[uint16][]*ql.PatternBindingLiteral, 0),
+		bindings:  make(map[uint16][]*ql.PatternBindingLiteral),
 	}
 }
 
@@ -91,7 +91,7 @@ func NewFromCLIWithAllAccessors(args []string) (Filter, error) {
 		parser:    ql.NewParser(expr),
 		accessors: getAccessors(),
 		fields:    make([]fields.Field, 0),
-		bindings:  make(map[uint16][]*ql.PatternBindingLiteral, 0),
+		bindings:  make(map[uint16][]*ql.PatternBindingLiteral),
 	}
 	if err := filter.Compile(); err != nil {
 		return nil, fmt.Errorf("bad filter: \n  %v", err)

--- a/pkg/filter/funcmap/funcmap_windows.go
+++ b/pkg/filter/funcmap/funcmap_windows.go
@@ -72,6 +72,8 @@ func InitFuncs(funcMap template.FuncMap) {
 
 // emit sends an alert via all configured alert senders.
 func emit(title string, text string, args ...string) string {
+	log.Debugf("sending alert: %s. Text: %s", title, text)
+
 	senders := alertsender.FindAll()
 	if len(senders) == 0 {
 		return "no alertsenders registered. Alert won't be sent"

--- a/pkg/filter/ql/ast.go
+++ b/pkg/filter/ql/ast.go
@@ -29,12 +29,20 @@ import (
 )
 
 // Eval evaluates expr against a map that contains the field values.
-func Eval(expr Expr, m map[string]interface{}, multivaluer bool) bool {
+func Eval(expr Expr, m map[string]interface{}, b map[string]interface{}, funcValuer bool) bool {
 	var eval ValuerEval
-	if multivaluer {
-		eval = ValuerEval{Valuer: MultiValuer(MapValuer(m), FunctionValuer{m})}
+	if funcValuer {
+		if len(b) > 0 {
+			eval = ValuerEval{Valuer: MultiValuer(MapValuer(m), PatternBindingValuer(b), FunctionValuer{m})}
+		} else {
+			eval = ValuerEval{Valuer: MultiValuer(MapValuer(m), FunctionValuer{m})}
+		}
 	} else {
-		eval = ValuerEval{Valuer: MapValuer(m)}
+		if len(b) > 0 {
+			eval = ValuerEval{Valuer: MultiValuer(MapValuer(m), PatternBindingValuer(b))}
+		} else {
+			eval = ValuerEval{Valuer: MapValuer(m)}
+		}
 	}
 	v, ok := eval.Eval(expr).(bool)
 	if !ok {
@@ -64,6 +72,15 @@ type CallValuer interface {
 
 	// Call is invoked to evaluate a function call (if possible).
 	Call(name string, args []interface{}) (interface{}, bool)
+}
+
+// PatternBindingValuer fetches values from pattern bindings
+type PatternBindingValuer map[string]interface{}
+
+// Value returns the value for a key in the PatternBindingValuer.
+func (b PatternBindingValuer) Value(key string) (interface{}, bool) {
+	v, ok := b[key]
+	return v, ok
 }
 
 // MultiValuer returns a Valuer that iterates over multiple Valuer instances
@@ -141,6 +158,12 @@ func (v *ValuerEval) Eval(expr Expr) interface{} {
 	case *BoolLiteral:
 		return expr.Value
 	case *FieldLiteral:
+		val, ok := v.Valuer.Value(expr.Value)
+		if !ok {
+			return nil
+		}
+		return val
+	case *PatternBindingLiteral:
 		val, ok := v.Valuer.Value(expr.Value)
 		if !ok {
 			return nil

--- a/pkg/filter/ql/ast.go
+++ b/pkg/filter/ql/ast.go
@@ -29,20 +29,17 @@ import (
 )
 
 // Eval evaluates expr against a map that contains the field values.
-func Eval(expr Expr, m map[string]interface{}, b map[string]interface{}, funcValuer bool) bool {
+func Eval(expr Expr, m map[string]interface{}, b map[string]interface{}, useFuncValuer bool) bool {
 	var eval ValuerEval
-	if funcValuer {
-		if len(b) > 0 {
-			eval = ValuerEval{Valuer: MultiValuer(MapValuer(m), PatternBindingValuer(b), FunctionValuer{m})}
-		} else {
-			eval = ValuerEval{Valuer: MultiValuer(MapValuer(m), FunctionValuer{m})}
-		}
-	} else {
-		if len(b) > 0 {
-			eval = ValuerEval{Valuer: MultiValuer(MapValuer(m), PatternBindingValuer(b))}
-		} else {
-			eval = ValuerEval{Valuer: MapValuer(m)}
-		}
+	switch {
+	case useFuncValuer && len(b) > 0:
+		eval = ValuerEval{Valuer: MultiValuer(MapValuer(m), PatternBindingValuer(b), FunctionValuer{m})}
+	case useFuncValuer:
+		eval = ValuerEval{Valuer: MultiValuer(MapValuer(m), FunctionValuer{m})}
+	case len(b) > 0:
+		eval = ValuerEval{Valuer: MultiValuer(MapValuer(m), PatternBindingValuer(b))}
+	default:
+		eval = ValuerEval{Valuer: MapValuer(m)}
 	}
 	v, ok := eval.Eval(expr).(bool)
 	if !ok {

--- a/pkg/filter/ql/lexer.go
+++ b/pkg/filter/ql/lexer.go
@@ -52,14 +52,14 @@ func (s *scanner) scan() (tok token, pos int, lit string) {
 	// as an ident or reserved word.
 	if isWhitespace(ch0) {
 		return s.scanWhitespace()
-	} else if isLetter(ch0) || ch0 == '_' {
+	} else if isLetter(ch0) || ch0 == '_' || ch0 == '$' {
 		s.r.unread()
 		return s.scanIdent()
 	} else if isDigit(ch0) {
 		return s.scanNumber()
 	}
 
-	// Otherwise parse individual characters.
+	// Otherwise, parse individual characters.
 	switch ch0 {
 	case reof:
 		return eof, pos, ""

--- a/pkg/filter/ql/lexer_test.go
+++ b/pkg/filter/ql/lexer_test.go
@@ -65,6 +65,7 @@ func TestScanner(t *testing.T) {
 		// pattern bindings
 		{s: `$1.ps.name`, tok: patternBinding, lit: "$1.ps.name"},
 		{s: `$4.kevt.name`, tok: patternBinding, lit: "$4.kevt.name"},
+		{s: `$4.ps.ancestor[1].name`, tok: patternBinding, lit: "$4.ps.ancestor[1].name"},
 
 		// identifiers
 		{s: `foo`, tok: ident, lit: `foo`},

--- a/pkg/filter/ql/lexer_test.go
+++ b/pkg/filter/ql/lexer_test.go
@@ -62,6 +62,10 @@ func TestScanner(t *testing.T) {
 		{s: `ps.pe.sections[.debug$S].entropy`, tok: field, lit: "ps.pe.sections[.debug$S].entropy"},
 		{s: `ps.envs[CommonProgramFiles86]`, tok: field, lit: "ps.envs[CommonProgramFiles86]"},
 
+		// pattern bindings
+		{s: `$1.ps.name`, tok: patternBinding, lit: "$1.ps.name"},
+		{s: `$4.kevt.name`, tok: patternBinding, lit: "$4.kevt.name"},
+
 		// identifiers
 		{s: `foo`, tok: ident, lit: `foo`},
 		{s: `_foo`, tok: ident, lit: `_foo`},

--- a/pkg/filter/ql/literal.go
+++ b/pkg/filter/ql/literal.go
@@ -21,6 +21,7 @@ package ql
 import (
 	"bytes"
 	"fmt"
+	"github.com/rabbitstack/fibratus/pkg/filter/fields"
 	"net"
 	"reflect"
 	"strconv"
@@ -64,6 +65,27 @@ type IPLiteral struct {
 	Value net.IP
 }
 
+// PatternBindingLiteral represents a pattern binding literal.
+type PatternBindingLiteral struct {
+	Value string
+}
+
+// Index returns the index pattern binding index number. E.g.
+// Say the pattern binding is $1.ps.name, this method returns
+// 1
+func (b PatternBindingLiteral) Index() uint16 {
+	i, err := strconv.Atoi(b.Value[1:2])
+	if err != nil {
+		return 0
+	}
+	return uint16(i)
+}
+
+// Field returns the string name from the pattern binding.
+func (b PatternBindingLiteral) Field() fields.Field {
+	return fields.Field(b.Value[3:])
+}
+
 func (i IPLiteral) String() string {
 	return i.Value.String()
 }
@@ -90,6 +112,10 @@ func (d DecimalLiteral) String() string {
 
 func (b BoolLiteral) String() string {
 	return strconv.FormatBool(b.Value)
+}
+
+func (b PatternBindingLiteral) String() string {
+	return b.Value
 }
 
 // ListLiteral represents a list of tag key literals.

--- a/pkg/filter/ql/parser.go
+++ b/pkg/filter/ql/parser.go
@@ -149,6 +149,8 @@ func (p *Parser) parseUnaryExpr() (Expr, error) {
 		return &StringLiteral{Value: lit}, nil
 	case field:
 		return &FieldLiteral{Value: lit}, nil
+	case patternBinding:
+		return &PatternBindingLiteral{Value: lit}, nil
 	case truet, falset:
 		return &BoolLiteral{Value: tok == truet}, nil
 	case integer:
@@ -170,7 +172,7 @@ func (p *Parser) parseUnaryExpr() (Expr, error) {
 		return &DecimalLiteral{Value: v}, nil
 	}
 
-	expectations := []string{"field", "string", "number", "bool", "ip", "function"}
+	expectations := []string{"field", "string", "number", "bool", "ip", "function", "pattern binding"}
 	if tok == badip {
 		expectations = []string{"a valid IP address"}
 	}

--- a/pkg/filter/ql/parser.go
+++ b/pkg/filter/ql/parser.go
@@ -75,10 +75,23 @@ func (p *Parser) ParseExpr() (Expr, error) {
 			}
 			rhs = &BinaryExpr{RHS: rhs1, Op: op1}
 		} else {
-			// otherwise parse the next expression
-			rhs, err = p.parseUnaryExpr()
-			if err != nil {
-				return nil, err
+			op1, _, _ := p.scanIgnoreWhitespace()
+			// if the negation appears after the operator
+			// try to parse an entire binary expr and wrap
+			// it inside the `not` expression
+			if op1 == not {
+				binaryExpr, err := p.ParseExpr()
+				if err != nil {
+					return nil, err
+				}
+				rhs = &NotExpr{binaryExpr}
+			} else {
+				p.unscan()
+				// otherwise, parse the next expression
+				rhs, err = p.parseUnaryExpr()
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 

--- a/pkg/filter/ql/parser_test.go
+++ b/pkg/filter/ql/parser_test.go
@@ -60,6 +60,8 @@ func TestParser(t *testing.T) {
 		{expr: "ps.name = 'cmd.exe' AND ps.name IN ('exe') ps.name", err: errors.New("ps.name = 'cmd.exe' AND ps.name IN ('exe') ps.name" +
 			"	^ expected operator")},
 		{expr: "ip_cidr(net.dip) = '24'", err: errors.New("ip_cidr function is undefined. Did you mean one of CIDR_CONTAINS|MD5?")},
+
+		{expr: "ps.name = 'cmd.exe' and not cidr_contains(net.sip, '172.14.0.0')"},
 	}
 
 	for i, tt := range tests {

--- a/pkg/filter/ql/token.go
+++ b/pkg/filter/ql/token.go
@@ -177,16 +177,26 @@ func tokstr(tok token, lit string) string {
 	return tok.String()
 }
 
-var patternBindingRegexp = regexp.MustCompile("\\$[1-9]\\.(.+)")
+// parsePatternBinding parses the pattern binding token and
+// returns true if the provided id is a pattern binding. Returns
+// false otherwise.
+func parsePatternBinding(id string) (string, bool) {
+	//nolint:gosimple
+	matches := regexp.MustCompile("\\$[1-9]\\.([a-z0-9A-Z\\[\\].]+)").FindStringSubmatch(id)
+	if len(matches) > 0 {
+		return matches[1], true
+	}
+	return "", false
+}
 
 // lookup returns the token associated with a given string.
 func lookup(id string) (token, string) {
 	if tok, ok := keywords[strings.ToLower(id)]; ok {
 		return tok, ""
 	}
-	matches := patternBindingRegexp.FindStringSubmatch(id)
-	if len(matches) > 0 {
-		if tok := fields.Lookup(matches[1]); tok != "" {
+	pb, ok := parsePatternBinding(id)
+	if ok {
+		if tok := fields.Lookup(pb); tok != "" {
 			return patternBinding, id
 		}
 	}

--- a/pkg/filter/rules.go
+++ b/pkg/filter/rules.go
@@ -343,6 +343,7 @@ func (s *sequenceState) expire(e *kevent.Kevent) bool {
 				s.partials[idx] = append(
 					s.partials[idx][:i],
 					s.partials[idx][i+1:]...)
+				partialsPerSequence.Add(s.name, -1)
 
 				if len(s.partials[idx]) == 0 {
 					log.Infof("%q sequence expired. All partials terminated", s.name)

--- a/pkg/filter/rules.go
+++ b/pkg/filter/rules.go
@@ -313,12 +313,12 @@ func (s *sequenceState) expire(e *kevent.Kevent) bool {
 		return false
 	}
 	canExpire := func(lhs, rhs *kevent.Kevent) bool {
-		if lhs.Type != ktypes.CreateProcess {
-			return false
+		if lhs.Type == ktypes.CreateProcess {
+			p1, _ := lhs.Kparams.GetPid()
+			p2, _ := rhs.Kparams.GetPid()
+			return p1 == p2
 		}
-		p1, _ := lhs.Kparams.GetPid()
-		p2, _ := rhs.Kparams.GetPid()
-		return p1 == p2
+		return lhs.PID == rhs.PID
 	}
 	for _, idx := range s.idxs {
 		currentPartials := s.partials[idx]
@@ -335,7 +335,7 @@ func (s *sequenceState) expire(e *kevent.Kevent) bool {
 			matched := s.matchedRules[idx+1]
 			bindingIndex := s.bindingIndexes[idx+1]
 			if !matched && bindingIndex == idx {
-				log.Infof("removing process %s (%d) "+
+				log.Debugf("removing process %s (%d) "+
 					"from partials pertaining to sequence [%s]",
 					e.Kparams.MustGetString(kparams.ProcessName),
 					e.Kparams.MustGetPid(),

--- a/pkg/filter/rules_test.go
+++ b/pkg/filter/rules_test.go
@@ -193,7 +193,7 @@ func TestSimpleSequencePolicy(t *testing.T) {
 	require.True(t, rules.Fire(kevt2))
 }
 
-func TestSimpleSequencePolicyWithMaxSpan(t *testing.T) {
+func TestSimpleSequencePolicyWithMaxSpanReached(t *testing.T) {
 	rules := NewRules(newConfig("_fixtures/sequence_policy_simple_max_span.yml"))
 	require.NoError(t, rules.Compile())
 
@@ -374,7 +374,7 @@ func TestSequenceComplexPatternBindings(t *testing.T) {
 
 	require.True(t, rules.Fire(kevt4))
 
-	// FSM should transition from terminal to inital state
+	// FSM should transition from terminal to initial state
 	require.False(t, rules.Fire(kevt1))
 	require.False(t, rules.Fire(kevt2))
 	time.Sleep(time.Millisecond * 15)

--- a/pkg/filter/rules_test.go
+++ b/pkg/filter/rules_test.go
@@ -227,6 +227,13 @@ func TestSimpleSequencePolicyWithMaxSpanReached(t *testing.T) {
 	require.False(t, rules.Fire(kevt1))
 	time.Sleep(time.Millisecond * 250)
 	require.False(t, rules.Fire(kevt2))
+
+	// now the state machine has transitioned
+	// to the initial state, which means we should
+	// be able to match the sequence if we reinsert
+	// the events
+	require.False(t, rules.Fire(kevt1))
+	require.True(t, rules.Fire(kevt2))
 }
 
 func TestSimpleSequencePolicyWithMaxSpanNotReached(t *testing.T) {
@@ -324,7 +331,7 @@ func TestSequenceComplexPatternBindings(t *testing.T) {
 		Type: ktypes.CreateFile,
 		Name: "CreateFile",
 		Tid:  2484,
-		PID:  859,
+		PID:  2243,
 		PS: &types.PS{
 			Name: "firefox.exe",
 			Exe:  "C:\\Program Files\\Mozilla Firefox\\firefox.exe",

--- a/pkg/kevent/kparam.go
+++ b/pkg/kevent/kparam.go
@@ -139,9 +139,29 @@ func (kpars Kparams) GetString(name string) (string, error) {
 	return kpar.Value.(string), nil
 }
 
+// MustGetString returns the string parameter or panics
+// if an error occurs while trying to get the parameter.
+func (kpars Kparams) MustGetString(name string) string {
+	s, err := kpars.GetString(name)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
 // GetPid returns the pid from the parameter.
 func (kpars Kparams) GetPid() (uint32, error) {
 	return kpars.getPid(kparams.ProcessID)
+}
+
+// MustGetPid returns the pid parameter. It panics if
+// an error occurs while trying to get the pid parameter.
+func (kpars Kparams) MustGetPid() uint32 {
+	pid, err := kpars.GetPid()
+	if err != nil {
+		panic(err)
+	}
+	return pid
 }
 
 // GetPpid returns the parent pid from the parameter.

--- a/pkg/util/atomic/atomic.go
+++ b/pkg/util/atomic/atomic.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021-2022 by Nedim Sabic Sabic
+ * https://www.fibratus.io
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package atomic
+
+import atom "sync/atomic"
+
+// Bool provides an atomic boolean type.
+type Bool struct{ u Uint32 }
+
+// Uint32 provides an atomic uint32 type.
+type Uint32 struct{ value uint32 }
+
+func MakeBool(v bool) Bool   { return Bool{MakeUint32(btoi(v))} }
+func NewBool(v bool) *Bool   { return &Bool{MakeUint32(btoi(v))} }
+func (b *Bool) Load() bool   { return b.u.Load() == 1 }
+func (b *Bool) Store(v bool) { b.u.Store(btoi(v)) }
+
+func MakeUint32(v uint32) Uint32 { return Uint32{v} }
+func NewUint32(v uint32) *Uint32 { return &Uint32{v} }
+func (u *Uint32) Load() uint32   { return atom.LoadUint32(&u.value) }
+func (u *Uint32) Store(v uint32) { atom.StoreUint32(&u.value, v) }
+
+func btoi(b bool) uint32 {
+	if b {
+		return 1
+	}
+	return 0
+}


### PR DESCRIPTION
This is a non-trivial PR that brings the concept of stateful detection rules. It is based on the idea of sequence rule groups. Traditionally in Fibratus, one could use either exclude or include event policies with their corresponding relations. The sequence rule group policy allows the implementation of rules that are triggered as the ordered sequence of events is being matched against the rules. Additionally, the rules can define pattern bindings to link the same set of events that matched in one rule to the subsequent rules. It is also possible to specify the max time span between the matching phase of multiple rules. To demonstrate the idea of sequence rules, let's see a naive example that detects the execution of the browser client followed by the creation of the PDF file by the same browser process within 5 minutes time frame.

```yaml
- group: browser client spawn and PDF download
  policy: sequence
  rules:
    - name: spawn browser client
      condition: >
         kevt.name = 'CreateProcess' 
             and 
        ps.sibling.name in ('chrome.exe', 'firefox.exe', 'edge.exe')
    - name: create pdf document
      condition: >
        kevt.name = 'CreateFile'
          and
        file.operation = 'create'
          and
        file.name icontains '.pdf'
          and
        ps.pid = $1.ps.sibling.pid
      max-span: 5m
```
