### PR TITLE
fix: Process command line normalization

### DIFF
--- a/pkg/kevent/kparam.go
+++ b/pkg/kevent/kparam.go
@@ -117,6 +117,17 @@ func (kpars Kparams) Set(name string, value kparams.Value, typ kparams.Type) err
 	return nil
 }
 
+// SetValue replaces the value for the given parameter name. It will return an error
+// if the supplied parameter is not present in the parameter map.
+func (kpars Kparams) SetValue(name string, value kparams.Value) error {
+	_, err := kpars.findParam(name)
+	if err != nil {
+		return fmt.Errorf("setting the value on a missing %q parameter is not allowed", name)
+	}
+	kpars[name].Value = value
+	return nil
+}
+
 // Get returns the raw value for given parameter name. It is the responsibility of the caller to probe type assertion
 // on the value before yielding its underlying type.
 func (kpars Kparams) Get(name string) (kparams.Value, error) {
@@ -263,6 +274,16 @@ func (kpars Kparams) GetUint32(name string) (uint32, error) {
 		return uint32(0), fmt.Errorf("unable to type cast %q parameter to uint32 value", name)
 	}
 	return v, nil
+}
+
+// MustGetUint32 returns  the underlying uint32 value parameter. It panics if
+// an error occurs while trying to get the parameter.
+func (kpars Kparams) MustGetUint32(name string) uint32 {
+	v, err := kpars.GetUint32(name)
+	if err != nil {
+		panic(err)
+	}
+	return v
 }
 
 // GetInt32 returns the underlying int32 value from the parameter.

--- a/pkg/kevent/kparam_test.go
+++ b/pkg/kevent/kparam_test.go
@@ -59,4 +59,9 @@ func TestKparams(t *testing.T) {
 	mode := filemode.(fs.FileShareMode)
 
 	assert.Equal(t, "r-d", mode.String())
+
+	require.NoError(t, kpars.SetValue(kparams.FileName, "\\Device\\HarddiskVolume2\\Windows\\system32\\KERNEL32.dll"))
+	filename1, err := kpars.GetString(kparams.FileName)
+	require.NoError(t, err)
+	assert.Equal(t, "\\Device\\HarddiskVolume2\\Windows\\system32\\KERNEL32.dll", filename1)
 }

--- a/pkg/kstream/interceptors/ps_windows_test.go
+++ b/pkg/kstream/interceptors/ps_windows_test.go
@@ -75,8 +75,9 @@ func TestPsInterceptorIntercept(t *testing.T) {
 	assert.Equal(t, "C:\\Windows\\System32\\smss.exe", exe)
 
 	tpid := fmt.Sprintf("%x", os.Getpid())
+
 	kpars2 := kevent.Kparams{
-		kparams.Comm:            {Name: kparams.Comm, Type: kparams.UnicodeString, Value: "C:\\Windows\\System32\\smss.exe"},
+		kparams.Comm:            {Name: kparams.Comm, Type: kparams.UnicodeString, Value: "\"C:\\Windows\\System32\\smss.exe\""},
 		kparams.ProcessID:       {Name: kparams.ProcessID, Type: kparams.HexInt32, Value: kparams.Hex(tpid)},
 		kparams.ProcessParentID: {Name: kparams.ProcessParentID, Type: kparams.HexInt32, Value: kparams.Hex("26c")},
 	}
@@ -89,4 +90,21 @@ func TestPsInterceptorIntercept(t *testing.T) {
 	require.NoError(t, err)
 
 	require.True(t, kevt2.Kparams.Contains(kparams.StartTime))
+
+	cmdline, _ := kevt2.Kparams.GetString(kparams.Comm)
+	require.Equal(t, "C:\\Windows\\System32\\smss.exe", cmdline)
+
+	kpars3 := kevent.Kparams{
+		kparams.Comm:        {Name: kparams.Comm, Type: kparams.UnicodeString, Value: "csrss.exe"},
+		kparams.ProcessName: {Name: kparams.ProcessName, Type: kparams.UnicodeString, Value: "csrss.exe"},
+	}
+
+	kevt3 := &kevent.Kevent{
+		Type:    ktypes.CreateProcess,
+		Kparams: kpars3,
+	}
+
+	_, _, err = psi.Intercept(kevt3)
+	cmdline1, _ := kevt3.Kparams.GetString(kparams.Comm)
+	require.Equal(t, "C:\\Windows\\System32\\csrss.exe", cmdline1)
 }

--- a/pkg/kstream/interceptors/ps_windows_test.go
+++ b/pkg/kstream/interceptors/ps_windows_test.go
@@ -105,6 +105,7 @@ func TestPsInterceptorIntercept(t *testing.T) {
 	}
 
 	_, _, err = psi.Intercept(kevt3)
+	require.NoError(t, err)
 	cmdline1, _ := kevt3.Kparams.GetString(kparams.Comm)
 	require.Equal(t, "C:\\Windows\\System32\\csrss.exe", cmdline1)
 }

--- a/pkg/ps/types/types_windows.go
+++ b/pkg/ps/types/types_windows.go
@@ -218,17 +218,7 @@ func NewFromKcap(buf []byte) (*PS, error) {
 	return &ps, nil
 }
 
-func splitArgs(comm string) []string {
-	ext := strings.Index(comm, ".exe")
-	if ext == -1 {
-		return []string{}
-	}
-	ext += 5
-	if ext > len(comm) {
-		return []string{}
-	}
-	return strings.Fields(comm[ext:])
-}
+func splitArgs(cmdline string) []string { return strings.Fields(cmdline) }
 
 // AddThread adds a thread to process's state descriptor.
 func (ps *PS) AddThread(thread Thread) {

--- a/pkg/ps/types/types_windows_test.go
+++ b/pkg/ps/types/types_windows_test.go
@@ -20,6 +20,7 @@ package types
 
 import (
 	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -58,4 +59,16 @@ func TestVisit(t *testing.T) {
 	Walk(func(ps *PS) { parents1 = append(parents1, ps.Name) }, ps5)
 
 	assert.Equal(t, expected1, parents1)
+}
+
+func TestPSArgs(t *testing.T) {
+	ps := NewPS(
+		233,
+		4532,
+		"spotify.exe",
+		"",
+		"C:\\Users\\admin\\AppData\\Roaming\\Spotify\\Spotify.exe --type=crashpad-handler /prefetch:7 --max-uploads=5 --max-db-size=20 --max-db-age=5 --monitor-self-annotation=ptype=crashpad-handler \"--metrics-dir=C:\\Users\\admin\\AppData\\Local\\Spotify\\User Data\" --url=https://crashdump.spotify.com:443/ --annotation=platform=win32 --annotation=product=spotify",
+		Thread{}, nil)
+	require.Len(t, ps.Args, 12)
+	require.Equal(t, "/prefetch:7", ps.Args[2])
 }


### PR DESCRIPTION
This PR fixes the normalization of the process cmdline. Previously, the command line wasn't mutated after applying the normalization. The command line `SystemRoot` env var is expanded prior to determining the executable full path.