### PR TITLE
perf: Speed up UTF-16 decoding

### DIFF
--- a/pkg/kevent/kparams/readers.go
+++ b/pkg/kevent/kparams/readers.go
@@ -22,8 +22,7 @@
 package kparams
 
 import (
-	"syscall"
-	"unicode/utf16"
+	"github.com/rabbitstack/fibratus/pkg/syscall/utf16"
 	"unsafe"
 )
 
@@ -79,7 +78,7 @@ func ReadUTF16String(buf uintptr, offset, length uint16) (string, uint16) {
 		return "", 0
 	}
 	s := (*[1<<30 - 1]uint16)(unsafe.Pointer(buf + uintptr(offset)))[: length-offset : length-offset]
-	return syscall.UTF16ToString(s), uint16(len(s) + 2)
+	return utf16.Decode(s[:len(s)/2-1]), uint16(len(s) + 2)
 }
 
 // ConsumeUTF16String reads the byte slice with UTF16-encoded string
@@ -89,13 +88,13 @@ func ConsumeUTF16String(buf uintptr, offset, length uint16) string {
 		return ""
 	}
 	s := (*[1<<30 - 1]uint16)(unsafe.Pointer(buf + uintptr(offset)))[: length-offset : length-offset]
-	return string(utf16.Decode(s[:len(s)/2-1]))
+	return utf16.Decode(s[:len(s)/2-1])
 }
 
 // ReadSID reads the security identifier from the provided buffer.
 func ReadSID(buf uintptr, offset uint16) ([]byte, uint16) {
 	// this is a Security Token which can be null and takes 4 bytes.
-	// Otherwise it is an 8 byte structure (TOKEN_USER) followed by SID,
+	// Otherwise, it is an 8 byte structure (TOKEN_USER) followed by SID,
 	// which is variable size depending on the 2nd byte in the SID
 	sid := ReadUint32(buf, offset)
 	if sid == 0 {

--- a/pkg/kevent/kparams/readers.go
+++ b/pkg/kevent/kparams/readers.go
@@ -78,7 +78,7 @@ func ReadUTF16String(buf uintptr, offset, length uint16) (string, uint16) {
 		return "", 0
 	}
 	s := (*[1<<30 - 1]uint16)(unsafe.Pointer(buf + uintptr(offset)))[: length-offset : length-offset]
-	return utf16.Decode(s[:len(s)/2-1]), uint16(len(s) + 2)
+	return utf16.Decode(s[:len(s)/2-1-2]), uint16(len(s) + 2)
 }
 
 // ConsumeUTF16String reads the byte slice with UTF16-encoded string

--- a/pkg/syscall/utf16/string_test.go
+++ b/pkg/syscall/utf16/string_test.go
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021-2022 by Nedim Sabic Sabic
+ * https://www.fibratus.io
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utf16
+
+import (
+	"github.com/stretchr/testify/require"
+	"math/rand"
+	"testing"
+	"unicode/utf16"
+)
+
+func TestDecode(t *testing.T) {
+	for i := 0; i < 24; i++ {
+		buf := genbuf(1 << i)
+		w := string(utf16.Decode(buf))
+		g := Decode(buf)
+		if w != g {
+			t.Errorf("mismatch on 1<<%d", i)
+		}
+	}
+	s := []rune("Do you want café?")
+	encoded := utf16.Encode(s)
+	require.Equal(t, "Do you want café?", Decode(encoded))
+}
+
+func BenchmarkStdlibDecode(b *testing.B) {
+	b.ReportAllocs()
+	b.StopTimer()
+	buf := genbuf(b.N)
+	b.StartTimer()
+	_ = string(utf16.Decode(buf))
+}
+
+func BenchmarkDecode(b *testing.B) {
+	b.ReportAllocs()
+	b.StopTimer()
+	buf := genbuf(b.N)
+	b.StartTimer()
+	_ = Decode(buf)
+}
+
+func genbuf(n int) []uint16 {
+	r := rand.New(rand.NewSource(int64(n)))
+	buf := make([]rune, n)
+	for i := 0; i < n; i++ {
+		// simulate mostly-ASCII
+		if r.Intn(100) == 0 {
+			buf[i] = rune(r.Intn(0x10ffff + 1))
+		} else {
+			buf[i] = rune(r.Intn(1 << 7))
+		}
+	}
+	return utf16.Encode(buf)
+}


### PR DESCRIPTION
This PR delivers a custom UTF-16 decoding function that significantly outperforms the stdlib equivalent. Benchmarks results:

```
BenchmarkStdlibDecode
BenchmarkStdlibDecode-8   	69832465	        15.93 ns/op	       5 B/op	       0 allocs/op

BenchmarkDecode
BenchmarkDecode-8   	311599040	         3.873 ns/op	       3 B/op	       0 allocs/op
```