### PR TITLE
feat(rules): Bound fields

### DIFF
--- a/pkg/filter/_fixtures/default/default.yml
+++ b/pkg/filter/_fixtures/default/default.yml
@@ -6,7 +6,7 @@
 #
 # Obviously, some events can't be directly translated from the corresponding
 # sysmon expressions, since Fibratus doesn't support them yet. In the same way,
-# some filter fields are still missing in Fibratus, so that sysmon rules were
+# some filter fields are still missing in Fibratus, so those sysmon rules were
 # omitted.
 #
 # ======================= Process creation ================================

--- a/pkg/filter/_fixtures/sequence_and_simple_rule_mix.yml
+++ b/pkg/filter/_fixtures/sequence_and_simple_rule_mix.yml
@@ -1,4 +1,4 @@
-- group: command shell execution and temp files
+- group: Command shell execution and temp files
   enabled: true
   rules:
     - name: Process spawned by powershell

--- a/pkg/filter/_fixtures/sequence_rule_bound_fields.yml
+++ b/pkg/filter/_fixtures/sequence_rule_bound_fields.yml
@@ -12,4 +12,4 @@
             and
          $e1.ps.sid = ps.sid
         | as e2
-        |kevt.name = 'Connect' and ps.sid != $e2.ps.sid and ps.sid = $e1.ps.sid |
+        |kevt.name = 'Connect' and ps.sid != $e2.ps.sid and ps.sid = $e1.ps.sid|

--- a/pkg/filter/_fixtures/sequence_rule_bound_fields.yml
+++ b/pkg/filter/_fixtures/sequence_rule_bound_fields.yml
@@ -1,0 +1,15 @@
+- group: Command shell execution and temp files with network outbound
+  enabled: true
+  rules:
+    - name: Command shell created a temp file with network outbound
+      condition: >
+        sequence
+        maxspan 200ms
+        |kevt.name = 'CreateProcess' and ps.name = 'cmd.exe'| as e1
+        |kevt.name = 'CreateFile'
+            and
+         file.name icontains 'temp'
+            and
+         $e1.ps.sid = ps.sid
+        | as e2
+        |kevt.name = 'Connect' and ps.sid != $e2.ps.sid and ps.sid = $e1.ps.sid |

--- a/pkg/filter/_fixtures/sequence_rule_simple.yml
+++ b/pkg/filter/_fixtures/sequence_rule_simple.yml
@@ -1,4 +1,4 @@
-- group: command shell execution and temp files
+- group: Command shell execution and temp files
   enabled: true
   rules:
     - name: Command shell created a temp file

--- a/pkg/filter/_fixtures/sequence_rule_simple_max_span.yml
+++ b/pkg/filter/_fixtures/sequence_rule_simple_max_span.yml
@@ -1,4 +1,4 @@
-- group: command shell execution and temp files
+- group: Command shell execution and temp files
   enabled: true
   rules:
     - name: Command shell created a temp file

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -55,7 +55,7 @@ func TestFilterCompile(t *testing.T) {
 	f = New(`ps.name`, cfg)
 	require.EqualError(t, f.Compile(), "expected at least one field or operator but zero found")
 	f = New(`ps.name =`, cfg)
-	require.EqualError(t, f.Compile(), "ps.name =\n╭─────────^\n|\n|\n╰─────────────────── expected field, string, number, bool, ip, function")
+	require.EqualError(t, f.Compile(), "ps.name =\n╭─────────^\n|\n|\n╰─────────────────── expected field, bound field, string, number, bool, ip, function")
 }
 
 func TestSeqFilterCompile(t *testing.T) {

--- a/pkg/filter/ql/ast.go
+++ b/pkg/filter/ql/ast.go
@@ -171,6 +171,12 @@ func (v *ValuerEval) Eval(expr Expr) interface{} {
 			return nil
 		}
 		return val
+	case *BoundFieldLiteral:
+		val, ok := v.Valuer.Value(expr.Value)
+		if !ok {
+			return nil
+		}
+		return val
 	case *IPLiteral:
 		return expr.Value
 	case *Function:

--- a/pkg/filter/ql/error_test.go
+++ b/pkg/filter/ql/error_test.go
@@ -86,9 +86,9 @@ func TestParseError(t *testing.T) {
 |	          'user shell folders\\startup'
 |	        )
 |
-╰─────────────────── expected field, string, number, bool, ip, function, pattern binding`
+╰─────────────────── expected field, bound field, string, number, bool, ip, function`
 
-	e := newParseError("[", []string{"field, string, number, bool, ip, function, pattern binding"}, 145, expr)
+	e := newParseError("[", []string{"field, bound field, string, number, bool, ip, function"}, 145, expr)
 	require.Equal(t, expected, e.Error())
 
 	expr = `ps.name = 'cmd.exe' aand ps.cmdline contains 'ss'`

--- a/pkg/filter/ql/function_test.go
+++ b/pkg/filter/ql/function_test.go
@@ -34,6 +34,7 @@ func TestParseFunction(t *testing.T) {
 		{expr: "cidr_contains(net.dip)", err: errors.New("CIDR_CONTAINS function requires 2 argument(s) but 1 argument(s) given")},
 		{expr: "cidr_contains(net.dip, 12)", err: errors.New("argument #2 (cidr) in function CIDR_CONTAINS should be one of: string")},
 		{expr: "cidr_contains(net.dip, '172.17.12.4/24')"},
+		{expr: "cidr_contains($e1.net.dip, '172.17.12.4/24')"},
 		{expr: "md('172.17.12.4')", err: errors.New("md function is undefined")},
 		{expr: "concat('hello ', 'world')"},
 		{expr: "concat('hello')", err: errors.New("CONCAT function requires 2 argument(s) but 1 argument(s) given")},
@@ -49,7 +50,7 @@ func TestParseFunction(t *testing.T) {
 		_, err := p.ParseExpr()
 		if err == nil && tt.err != nil {
 			t.Errorf("%d. exp=%s expected error=%v", i, tt.expr, tt.err)
-		} else if err != nil {
+		} else if err != nil && tt.err != nil {
 			assert.True(t, strings.Contains(err.Error(), tt.err.Error()))
 		} else if err != nil && tt.err == nil {
 			t.Errorf("%d. exp=%s got error=%v", i, tt.expr, err)

--- a/pkg/filter/ql/parser.go
+++ b/pkg/filter/ql/parser.go
@@ -86,6 +86,10 @@ func (p *Parser) ParseSequence() (*Sequence, error) {
 			if len(exprs) < 1 {
 				return nil, fmt.Errorf("%s: sequences require at least two expressions", p.expr)
 			}
+			const maxExpressions = 5
+			if len(exprs) > maxExpressions {
+				return nil, fmt.Errorf("%s: maximum number of expressions reached", p.expr)
+			}
 			seq.Expressions = exprs
 			if seq.impairBy() {
 				return nil, fmt.Errorf("%s: all expressions require the 'by' statement", p.expr)
@@ -107,17 +111,27 @@ func (p *Parser) ParseSequence() (*Sequence, error) {
 			return nil, newParseError(tokstr(tok, lit), []string{"|"}, posEnd, p.expr)
 		}
 
+		var seqexpr SequenceExpr
 		tok, _, _ = p.scanIgnoreWhitespace()
-		if tok == By {
+		switch tok {
+		case By:
 			tok, pos, lit := p.scanIgnoreWhitespace()
 			if tok != Field {
 				return nil, newParseError(tokstr(tok, lit), []string{"field"}, pos, p.expr)
 			}
-			exprs = append(exprs, SequenceExpr{Expr: expr, By: fields.Field(lit)})
-		} else {
-			exprs = append(exprs, SequenceExpr{Expr: expr})
+			seqexpr = SequenceExpr{Expr: expr, By: fields.Field(lit)}
+		case As:
+			tok, pos, lit := p.scanIgnoreWhitespace()
+			if tok != Ident {
+				return nil, newParseError(tokstr(tok, lit), []string{"identifier"}, pos, p.expr)
+			}
+			seqexpr = SequenceExpr{Expr: expr, Alias: lit}
+		default:
+			seqexpr = SequenceExpr{Expr: expr}
 			p.unscan()
 		}
+		seqexpr.walk()
+		exprs = append(exprs, seqexpr)
 	}
 }
 
@@ -286,6 +300,12 @@ func (p *Parser) parseUnaryExpr() (Expr, error) {
 		return &StringLiteral{Value: lit}, nil
 	case Field:
 		return &FieldLiteral{Value: lit}, nil
+	case BoundField:
+		n := strings.Index(lit, ".")
+		if n > 0 && fields.Lookup(lit[n+1:]) == "" {
+			return nil, newParseError(tokstr(tok, lit), []string{"field after bound ref"}, pos+n, p.expr)
+		}
+		return &BoundFieldLiteral{Value: lit}, nil
 	case True, False:
 		return &BoolLiteral{Value: tok == True}, nil
 	case Integer:
@@ -307,7 +327,7 @@ func (p *Parser) parseUnaryExpr() (Expr, error) {
 		return &DecimalLiteral{Value: v}, nil
 	}
 
-	expectations := []string{"field", "string", "number", "bool", "ip", "function"}
+	expectations := []string{"field", "bound field", "string", "number", "bool", "ip", "function"}
 	if tok == BadIP {
 		expectations = []string{"a valid IP address"}
 	}

--- a/pkg/filter/ql/parser.go
+++ b/pkg/filter/ql/parser.go
@@ -130,6 +130,7 @@ func (p *Parser) ParseSequence() (*Sequence, error) {
 			seqexpr = SequenceExpr{Expr: expr}
 			p.unscan()
 		}
+		seqexpr.init()
 		seqexpr.walk()
 		exprs = append(exprs, seqexpr)
 	}

--- a/pkg/filter/ql/parser_test.go
+++ b/pkg/filter/ql/parser_test.go
@@ -260,6 +260,26 @@ func TestParseSequence(t *testing.T) {
 			time.Second * 30,
 			false,
 		},
+		{
+
+			`maxspan 30s
+			 |kevt.name = 'CreateProcess'| as e1
+			 |kevt.name = 'CreateFile' and $e1.ps.name = file.name |
+			`,
+			nil,
+			time.Second * 30,
+			false,
+		},
+		{
+
+			`maxspan 30s
+			 |kevt.name = 'CreateProcess'| as e1
+			 |kevt.name = 'CreateFile' and $e1.ps.ame = file.name |
+			`,
+			errors.New("expected field after bound ref"),
+			time.Second * 30,
+			false,
+		},
 	}
 
 	for i, tt := range tests {

--- a/pkg/filter/ql/token.go
+++ b/pkg/filter/ql/token.go
@@ -31,8 +31,9 @@ const (
 	WS
 	EOF
 
-	Field // ps.name
-	Str   // 'cmd.exe'
+	Field      // ps.name
+	BoundField // $evt1.file.name
+	Str        // 'cmd.exe'
 	Badstr
 	Badesc
 	Ident
@@ -80,6 +81,7 @@ const (
 	Seq     // SEQUENCE
 	MaxSpan // MAXSPAN
 	By      // BY
+	As      // AS
 )
 
 var keywords map[string]token
@@ -89,7 +91,7 @@ func init() {
 	for _, tok := range []token{And, Or, Contains, IContains, In,
 		IIn, Not, Startswith, IStartswith, Endswith, IEndswith,
 		Matches, IMatches, Fuzzy, IFuzzy, Fuzzynorm, IFuzzynorm,
-		Seq, MaxSpan, By} {
+		Seq, MaxSpan, By, As} {
 		keywords[strings.ToLower(tokens[tok])] = tok
 	}
 	keywords["true"] = True
@@ -101,18 +103,19 @@ var tokens = [...]string{
 	EOF:     "EOF",
 	WS:      "WS",
 
-	Ident:    "IDENT",
-	Field:    "FIELD",
-	Integer:  "INTEGER",
-	Decimal:  "DECIMAL",
-	Duration: "DURATION",
-	Str:      "STRING",
-	Badstr:   "BADSTRING",
-	Badesc:   "BADESCAPE",
-	IP:       "IPADDRESS",
-	BadIP:    "BADIPADDRESS",
-	True:     "TRUE",
-	False:    "FALSE",
+	Ident:      "IDENT",
+	Field:      "FIELD",
+	BoundField: "BOUNDFIELD",
+	Integer:    "INTEGER",
+	Decimal:    "DECIMAL",
+	Duration:   "DURATION",
+	Str:        "STRING",
+	Badstr:     "BADSTRING",
+	Badesc:     "BADESCAPE",
+	IP:         "IPADDRESS",
+	BadIP:      "BADIPADDRESS",
+	True:       "TRUE",
+	False:      "FALSE",
 
 	And:         "AND",
 	Or:          "OR",
@@ -149,6 +152,7 @@ var tokens = [...]string{
 	Seq:     "SEQUENCE",
 	MaxSpan: "MAXSPAN",
 	By:      "BY",
+	As:      "AS",
 }
 
 // isOperator determines whether the current token is an operator.

--- a/pkg/filter/rules.go
+++ b/pkg/filter/rules.go
@@ -102,10 +102,9 @@ type filterGroup struct {
 }
 
 type compiledFilter struct {
-	filter  Filter
-	ss      *sequenceState
-	buckets map[uint32]bool
-	config  *config.FilterConfig
+	filter Filter
+	ss     *sequenceState
+	config *config.FilterConfig
 }
 
 // sequenceState represents the state of the
@@ -268,27 +267,6 @@ func (s *sequenceState) clear() {
 	partialsPerSequence.Delete(s.name)
 }
 
-func (s *sequenceState) clearMatchedRules() {
-	s.matchedRules = make(map[uint16]bool)
-}
-
-func (s *sequenceState) join(isConstrained bool) bool {
-	if !isConstrained {
-		return true
-	}
-	nseqs := uint16(len(s.partials))
-	for i := uint16(1); i < nseqs+1; i++ {
-		for _, outer := range s.partials[i] {
-			for _, inner := range s.partials[i+1] {
-				if compareSeqJoin(outer.SequenceBy(), inner.SequenceBy()) {
-					s.matches[i], s.matches[i+1] = outer, inner
-				}
-			}
-		}
-	}
-	return uint16(len(s.matches)) == nseqs
-}
-
 func compareSeqJoin(s1, s2 any) bool {
 	if s1 == nil || s2 == nil {
 		return false
@@ -434,22 +412,8 @@ func newFilterGroup(g config.FilterGroup, filters []*compiledFilter) *filterGrou
 	return &filterGroup{group: g, filters: filters}
 }
 
-func newCompiledFilter(f Filter, filterConfig *config.FilterConfig, groupConfig config.FilterGroup, ss *sequenceState) *compiledFilter {
-	buckets := make(map[uint32]bool)
-	for name, values := range f.GetStringFields() {
-		if name == fields.KevtName || name == fields.KevtCategory {
-			for _, v := range values {
-				buckets[hashers.FnvUint32([]byte(v))] = true
-			}
-		}
-	}
-	if len(buckets) == 0 {
-		log.Warnf("%q rule in %q group doesn't have event type or event category condition! "+
-			"This could cause runtime performance degradation. Please consider "+
-			"narrowing the scope of this rule by including the kevt.name or kevt.category condition",
-			filterConfig.Name, groupConfig.Name)
-	}
-	return &compiledFilter{config: filterConfig, filter: f, buckets: buckets, ss: ss}
+func newCompiledFilter(f Filter, filterConfig *config.FilterConfig, ss *sequenceState) *compiledFilter {
+	return &compiledFilter{config: filterConfig, filter: f, ss: ss}
 }
 
 // isScoped determines if this filter is scoped, i.e. it has the event name or category
@@ -469,17 +433,6 @@ func (f compiledFilter) run(kevt *kevent.Kevent, i uint16) bool {
 		return f.filter.RunSequence(kevt, i, f.ss.partials)
 	}
 	return f.filter.Run(kevt)
-}
-
-// isEligible determines if the filter should be evaluated by inspecting
-// the event type filter fields defined in the expression. We allow an event
-// being eligible for evaluation even when the filter doesn't contain the kevt.name
-// binary expression. However, this is considered a warning which could potentially
-// cause runtime performance degradation if the filter is evaluated against every
-// event. TerminateProcess event is always eligible as it is used to expire the sequence
-// state.
-func (f compiledFilter) isEligible(kevt *kevent.Kevent) bool {
-	return kevt.IsTerminateProcess() || f.buckets[kevt.Type.Hash()] || f.buckets[kevt.Category.Hash()]
 }
 
 type filterGroups []*filterGroup
@@ -503,8 +456,6 @@ func (r *Rules) isGroupMapped(scopeHash, groupHash uint32) bool {
 	}
 	return false
 }
-
-func (r *Rules) zeroGroups() bool { return len(r.filterGroups) == 0 }
 
 // NewRules produces a fresh rules instance.
 func NewRules(c *config.Config) Rules {
@@ -590,7 +541,7 @@ func (r *Rules) Compile() error {
 				seqState.fsm.Configure(sequenceDeadlineState).Permit(resetTransition, initialState)
 				seqState.fsm.Configure(sequenceExpiredState).Permit(resetTransition, initialState)
 			}
-			filters = append(filters, newCompiledFilter(f, filterConfig, group, seqState))
+			filters = append(filters, newCompiledFilter(f, filterConfig, seqState))
 			filtersCount.Add(1)
 		}
 
@@ -637,17 +588,15 @@ func (r *Rules) findGroups(kevt *kevent.Kevent) filterGroups {
 }
 
 func (r *Rules) Fire(kevt *kevent.Kevent) bool {
-	// if there are no rule groups we assume
-	// no group files were defined or specified
-	// in the config, so, the default behaviour
-	// in such cases is to pass the event and
-	// hand over it to the CLI filter
-	if r.zeroGroups() {
+	// no rules were loaded into the engine in
+	// which the event is forwarded to the aggregator
+	// unless the CLI filter decides otherwise
+	if len(r.filterGroups) == 0 {
 		return true
 	}
-	// find rule groups for a particular
-	// event type or category. Events are
-	// dropped if no groups are found
+	// find rule groups for a particular event type
+	// or category. If no rule groups are found we
+	// drop the event
 	groups := r.findGroups(kevt)
 	if len(groups) == 0 {
 		return false
@@ -656,7 +605,7 @@ func (r *Rules) Fire(kevt *kevent.Kevent) bool {
 	// groups with include policies, so we first
 	// evaluate those. If no filter matches occur,
 	// we let pass the event but only if there are
-	// no groups with include/sequence policies
+	// no groups with include policy
 	if r.excludePolicies {
 		if r.runRules(groups, config.ExcludePolicy, kevt) {
 			return false
@@ -672,17 +621,20 @@ func (r *Rules) Fire(kevt *kevent.Kevent) bool {
 
 func (r *Rules) runSequence(kevt *kevent.Kevent, f *compiledFilter) bool {
 	seq := f.filter.GetSequence()
-	exprs := seq.Expressions
-	for i, expr := range exprs {
+	for i, expr := range seq.Expressions {
+		// only try to evaluate the expression
+		// if upstream expressions have matched
 		if !f.ss.next(i) {
 			continue
 		}
-		if !expr.IsEligible(kevt) {
+		// prevent running the filter if the expression
+		// can't be matched against the current event
+		if !expr.IsEvaluable(kevt) {
 			continue
 		}
 		rule := expr.Expr.String()
 		matches := f.run(kevt, uint16(i))
-
+		// append the partial and transition state machine
 		if matches && f.ss.isAfter(rule, kevt) {
 			f.ss.addPartial(rule, kevt)
 			err := f.ss.matchTransition(rule, kevt)
@@ -692,12 +644,24 @@ func (r *Rules) runSequence(kevt *kevent.Kevent, f *compiledFilter) bool {
 			}
 		}
 	}
-	isTerminalState := f.ss.isTerminalState()
-	ok := isTerminalState && f.ss.join(seq.IsConstrained())
-	if isTerminalState {
-		f.ss.clearMatchedRules()
+	// if both the terminal state is reached and the partials
+	// in the sequence state could be joined by the specified
+	// field(s), the rule has matched successfully, and we can
+	// collect all events involved in the rule match
+	isTerminal := f.ss.isTerminalState()
+	if isTerminal {
+		nseqs := uint16(len(f.ss.partials))
+		for i := uint16(1); i < nseqs+1; i++ {
+			for _, outer := range f.ss.partials[i] {
+				for _, inner := range f.ss.partials[i+1] {
+					if compareSeqJoin(outer.SequenceBy(), inner.SequenceBy()) {
+						f.ss.matches[i], f.ss.matches[i+1] = outer, inner
+					}
+				}
+			}
+		}
 	}
-	return ok
+	return isTerminal
 }
 
 func (r *Rules) runRules(groups filterGroups, policy config.FilterGroupPolicy, kevt *kevent.Kevent) bool {
@@ -712,15 +676,15 @@ nextGroup:
 		// group upon first match or either all rules in the group
 		// need to match
 		for i, f := range g.filters {
-			var ok bool
+			var match bool
 			if f.ss != nil {
 				if f.ss.expire(kevt) {
 					continue
 				}
-				ok = r.runSequence(kevt, f)
+				match = r.runSequence(kevt, f)
 			} else {
-				ok = f.run(kevt, uint16(i))
-				if ok {
+				match = f.run(kevt, uint16(i))
+				if match {
 					// transition sequence states since a match
 					// in a simple rule could trigger multiple
 					// matches in sequence rules
@@ -747,12 +711,12 @@ nextGroup:
 			case config.ExcludePolicy:
 				switch g.group.Relation {
 				case config.OrRelation:
-					if ok {
+					if match {
 						excludeOrFilterMatches.Add(f.config.Name, 1)
 						return true
 					}
 				case config.AndRelation:
-					if !ok {
+					if !match {
 						// jump to the next exclude group
 						continue nextGroup
 					}
@@ -761,7 +725,7 @@ nextGroup:
 			case config.IncludePolicy:
 				switch g.group.Relation {
 				case config.OrRelation:
-					if ok {
+					if match {
 						includeOrFilterMatches.Add(f.config.Name, 1)
 						log.Debugf("rule [%s] in group [%s] matched", f.config.Name, g.group.Name)
 						// attach rule and group meta
@@ -783,7 +747,7 @@ nextGroup:
 						return true
 					}
 				case config.AndRelation:
-					if !ok {
+					if !match {
 						// jump to the next include group
 						continue nextGroup
 					}


### PR DESCRIPTION
Bound fields is the new functionality of the rule engine that permits linking sequence events by sharing the properties of the aliased event. The following example illustrates the use of bound fields:

```
sequence
maxspan 200ms
    |kevt.name = 'CreateProcess' and ps.name = 'cmd.exe'| as e
    |kevt.name = 'CreateFile'
          and
     file.name icontains 'temp'
          and
     $e.ps.sid = ps.sid
    | 
````
We first declare the event alias using the `AS` keyword and reference the bound fields by prefixing the `$` symbol before the alias name.
