### PR TITLE
feat(filter): Function for getting registry values

### DIFF
--- a/pkg/filter/ql/function.go
+++ b/pkg/filter/ql/function.go
@@ -60,8 +60,8 @@ var funcs = map[string]FunctionDef{
 	functions.SubstrFn.String():       &functions.Substr{},
 	functions.EntropyFn.String():      &functions.Entropy{},
 	functions.RegexFn.String():        functions.NewRegex(),
-	functions.IsMinidumpFn.String():   functions.IsMinidump{},
-	functions.GetRegValueFn.String():  functions.GetRegValue{},
+	functions.IsMinidumpFn.String():   &functions.IsMinidump{},
+	functions.GetRegValueFn.String():  &functions.GetRegValue{},
 }
 
 // FunctionDef is the interface that all function definitions have to satisfy.

--- a/pkg/filter/ql/function.go
+++ b/pkg/filter/ql/function.go
@@ -61,6 +61,7 @@ var funcs = map[string]FunctionDef{
 	functions.EntropyFn.String():      &functions.Entropy{},
 	functions.RegexFn.String():        functions.NewRegex(),
 	functions.IsMinidumpFn.String():   functions.IsMinidump{},
+	functions.GetRegValueFn.String():  functions.GetRegValue{},
 }
 
 // FunctionDef is the interface that all function definitions have to satisfy.

--- a/pkg/filter/ql/functions/get_reg_value.go
+++ b/pkg/filter/ql/functions/get_reg_value.go
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2021-2022 by Nedim Sabic Sabic
+ * https://www.fibratus.io
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package functions
+
+import (
+	"golang.org/x/sys/windows/registry"
+	"path/filepath"
+	"strings"
+)
+
+// GetRegValue retrieves the content of the registry value.
+type GetRegValue struct{}
+
+func (f GetRegValue) Call(args []interface{}) (interface{}, bool) {
+	if len(args) < 1 {
+		return false, false
+	}
+	path := parseString(0, args)
+	n := strings.Index(path, "\\")
+	if n > 0 {
+		rootKey := path[:n]
+		subkey, value := filepath.Split(path[:n])
+		key, err := registry.OpenKey(keyFromString(rootKey), subkey, registry.QUERY_VALUE)
+		if err != nil {
+			return nil, true
+		}
+		defer key.Close()
+		b := make([]byte, 0)
+		_, typ, err := key.GetValue(value, b)
+		if err != nil {
+			return nil, true
+		}
+		var val interface{}
+		switch typ {
+		case registry.SZ, registry.EXPAND_SZ:
+			val, _, err = key.GetStringValue(value)
+		case registry.MULTI_SZ:
+			val, _, err = key.GetStringsValue(value)
+		case registry.DWORD, registry.QWORD:
+			val, _, err = key.GetIntegerValue(value)
+		case registry.BINARY:
+			val, _, err = key.GetBinaryValue(value)
+		}
+		if err != nil {
+			return nil, true
+		}
+		return val, true
+	}
+	return nil, true
+}
+
+func (f GetRegValue) Desc() FunctionDesc {
+	desc := FunctionDesc{
+		Name: GetRegValueFn,
+		Args: []FunctionArgDesc{
+			{Keyword: "path", Types: []ArgType{Field, String, Func}, Required: true},
+		},
+	}
+	return desc
+}
+
+func (f GetRegValue) Name() Fn { return GetRegValueFn }
+
+func keyFromString(k string) registry.Key {
+	switch strings.ToUpper(k) {
+	case "HKEY_LOCAL_MACHINE", "HKLM":
+		return registry.LOCAL_MACHINE
+	case "HKEY_CURRENT_USER", "HKCU":
+		return registry.CURRENT_USER
+	case "HKEY_USERS", "HKU":
+		return registry.USERS
+	case "HKEY_CLASSES_ROOT", "HKCR":
+		return registry.CLASSES_ROOT
+	case "HKEY_CURRENT_CONFIG", "HKCC":
+		return registry.CURRENT_CONFIG
+	case "HKEY_PERFORMANCE_DATA", "HKPD":
+		return registry.PERFORMANCE_DATA
+	}
+	return registry.Key(-1)
+}

--- a/pkg/filter/ql/functions/get_reg_value.go
+++ b/pkg/filter/ql/functions/get_reg_value.go
@@ -35,7 +35,7 @@ func (f GetRegValue) Call(args []interface{}) (interface{}, bool) {
 	n := strings.Index(path, "\\")
 	if n > 0 {
 		rootKey := path[:n]
-		subkey, value := filepath.Split(path[:n])
+		subkey, value := filepath.Split(path[n+1:])
 		key, err := registry.OpenKey(keyFromString(rootKey), subkey, registry.QUERY_VALUE)
 		if err != nil {
 			return nil, true
@@ -52,7 +52,12 @@ func (f GetRegValue) Call(args []interface{}) (interface{}, bool) {
 			val, _, err = key.GetStringValue(value)
 		case registry.MULTI_SZ:
 			val, _, err = key.GetStringsValue(value)
-		case registry.DWORD, registry.QWORD:
+		case registry.DWORD:
+			val, _, err = key.GetIntegerValue(value)
+			if err == nil {
+				val = uint32(val.(uint64))
+			}
+		case registry.QWORD:
 			val, _, err = key.GetIntegerValue(value)
 		case registry.BINARY:
 			val, _, err = key.GetBinaryValue(value)
@@ -91,6 +96,7 @@ func keyFromString(k string) registry.Key {
 		return registry.CURRENT_CONFIG
 	case "HKEY_PERFORMANCE_DATA", "HKPD":
 		return registry.PERFORMANCE_DATA
+	default:
+		return registry.Key(0)
 	}
-	return registry.Key(-1)
 }

--- a/pkg/filter/ql/functions/get_reg_value_test.go
+++ b/pkg/filter/ql/functions/get_reg_value_test.go
@@ -58,11 +58,11 @@ func TestGetRegValue(t *testing.T) {
 	defer key.Close()
 
 	defer func() {
-		key.DeleteValue("FibratusTestDword")
-		key.DeleteValue("FibratusTestQword")
-		key.DeleteValue("FibratusTestSz")
-		key.DeleteValue("FibratusTestMultiSz")
-		key.DeleteValue("FibratusTestExpandSz")
+		_ = key.DeleteValue("FibratusTestDword")
+		_ = key.DeleteValue("FibratusTestQword")
+		_ = key.DeleteValue("FibratusTestSz")
+		_ = key.DeleteValue("FibratusTestMultiSz")
+		_ = key.DeleteValue("FibratusTestExpandSz")
 	}()
 
 	require.NoError(t, key.SetDWordValue("FibratusTestDword", 1))

--- a/pkg/filter/ql/functions/get_reg_value_test.go
+++ b/pkg/filter/ql/functions/get_reg_value_test.go
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021-2022 by Nedim Sabic Sabic
+ * https://www.fibratus.io
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package functions
+
+import "testing"
+
+func TestGetRegValue(t *testing.T) {
+
+}

--- a/pkg/filter/ql/functions/get_reg_value_test.go
+++ b/pkg/filter/ql/functions/get_reg_value_test.go
@@ -18,8 +18,62 @@
 
 package functions
 
-import "testing"
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows/registry"
+	"testing"
+)
 
 func TestGetRegValue(t *testing.T) {
+	var tests = []struct {
+		args     []interface{}
+		expected interface{}
+	}{
+		{
+			[]interface{}{"HKCU\\Volatile Environment\\FibratusTestDword"},
+			uint32(1),
+		},
+		{
+			[]interface{}{"HKEY_CURRENT_USER\\Volatile Environment\\FibratusTestQword"},
+			uint64(1000),
+		},
+		{
+			[]interface{}{"HKCU\\Volatile Environment\\FibratusTestSz"},
+			"fibratus",
+		},
+		{
+			[]interface{}{"HKCU\\Volatile Environment\\FibratusTestMultiSz"},
+			[]string{"fibratus", "tracing"},
+		},
+		{
+			[]interface{}{"HKCU\\Volatile Environment\\FibratusTestExpandSz"},
+			"%SYSTEMROOT%\\fibratus",
+		},
+	}
 
+	key, err := registry.OpenKey(registry.CURRENT_USER, "Volatile Environment", registry.SET_VALUE)
+	require.NoError(t, err)
+	defer key.Close()
+
+	defer func() {
+		key.DeleteValue("FibratusTestDword")
+		key.DeleteValue("FibratusTestQword")
+		key.DeleteValue("FibratusTestSz")
+		key.DeleteValue("FibratusTestMultiSz")
+		key.DeleteValue("FibratusTestExpandSz")
+	}()
+
+	require.NoError(t, key.SetDWordValue("FibratusTestDword", 1))
+	require.NoError(t, key.SetQWordValue("FibratusTestQword", 1000))
+	require.NoError(t, key.SetStringValue("FibratusTestSz", "fibratus"))
+	require.NoError(t, key.SetStringsValue("FibratusTestMultiSz", []string{"fibratus", "tracing"}))
+	require.NoError(t, key.SetExpandStringValue("FibratusTestExpandSz", "%SYSTEMROOT%\\fibratus"))
+
+	for i, tt := range tests {
+		f := GetRegValue{}
+		res, _ := f.Call(tt.args)
+		assert.Equal(t, tt.expected, res, fmt.Sprintf("%d. result mismatch: exp=%v got=%v", i, tt.expected, res))
+	}
 }

--- a/pkg/filter/ql/functions/types.go
+++ b/pkg/filter/ql/functions/types.go
@@ -54,6 +54,8 @@ const (
 	RegexFn
 	// IsMinidumpFn represents the ISMINIDUMP function
 	IsMinidumpFn
+	// GetRegValueFn represents the GET_REG_VALUE function
+	GetRegValueFn
 )
 
 // ArgType is the type alias for the argument value type.
@@ -170,6 +172,8 @@ func (f Fn) String() string {
 		return "REGEX"
 	case IsMinidumpFn:
 		return "IS_MINIDUMP"
+	case GetRegValueFn:
+		return "GET_REG_VALUE"
 	default:
 		return "UNDEFINED"
 	}


### PR DESCRIPTION
The `GET_REG_VALUE` filter function permits retrieving the content of the given registry value. The value is supplied in FQKN form. For example, to get the content of the `HKEY_CURRENT_USER\Control Panel\Personalization\Desktop Slideshow\Shuffle` value, we could have the following expression:

```
get_reg_value('HCU\Control Panel\Personalization\Desktop Slideshow\Shuffle') = 0
```