### PR TITLE
chore(filter): Ensure correctness of bound field references

### DIFF
--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -70,6 +70,19 @@ func TestSeqFilterCompile(t *testing.T) {
 	assert.True(t, len(f.GetStringFields()) > 0)
 }
 
+func TestSeqFilterInvalidBoundRefs(t *testing.T) {
+	f := New(`sequence
+|kevt.name = 'CreateProcess'| as e1
+|kevt.name = 'CreateFile' and file.name = $e.ps.exe |
+`, cfg)
+	require.Error(t, f.Compile())
+	f1 := New(`sequence
+|kevt.name = 'CreateProcess'| as e1
+|kevt.name = 'CreateFile' and file.name = $e1.ps.exe |
+`, cfg)
+	require.NoError(t, f1.Compile())
+}
+
 func TestStringFields(t *testing.T) {
 	f := New(`ps.name = 'cmd.exe' and kevt.name = 'CreateProcess' or kevt.name in ('TerminateProcess', 'CreateFile')`, cfg)
 	require.NoError(t, f.Compile())

--- a/pkg/filter/filter_windows.go
+++ b/pkg/filter/filter_windows.go
@@ -73,6 +73,7 @@ func New(expr string, config *config.Config) Filter {
 		accessors:    accessors,
 		fields:       make([]fields.Field, 0),
 		stringFields: make(map[fields.Field][]string),
+		boundFields:  make([]*ql.BoundFieldLiteral, 0),
 	}
 }
 
@@ -100,6 +101,7 @@ func NewFromCLIWithAllAccessors(args []string) (Filter, error) {
 		accessors:    getAccessors(),
 		fields:       make([]fields.Field, 0),
 		stringFields: make(map[fields.Field][]string),
+		boundFields:  make([]*ql.BoundFieldLiteral, 0),
 	}
 	if err := filter.Compile(); err != nil {
 		return nil, fmt.Errorf("bad filter:\n %v", err)


### PR DESCRIPTION
If downstream sequence expressions are referencing unknown or invalid bound fields, the filter engine should throw an error highlighting the invalid bound field reference.