### PR TITLE
feat(filter): Process UUID field

### DIFF
--- a/pkg/filter/_fixtures/sequence_rule_ps_uuid.yml
+++ b/pkg/filter/_fixtures/sequence_rule_ps_uuid.yml
@@ -1,0 +1,16 @@
+- group: Unique process id
+  enabled: true
+  rules:
+    - name: Unique process id
+      condition: >
+        sequence
+        maxspan 1h
+        by ps.uuid
+        |kevt.name = 'CreateProcess' and ps.sibling.name
+            in
+        ('firefox.exe', 'chrome.exe', 'edge.exe')
+        |
+        |kevt.name = 'CreateFile' and file.operation = 'create'
+            and
+        file.extension = '.exe'
+        |

--- a/pkg/filter/accessor_windows.go
+++ b/pkg/filter/accessor_windows.go
@@ -256,6 +256,12 @@ func (ps *psAccessor) get(f fields.Field, kevt *kevent.Kevent) (kparams.Value, e
 			return nil, ErrPsNil
 		}
 		return ps.UUID(), nil
+	case fields.PsParentUUID:
+		ps := getParentPs(kevt)
+		if ps == nil {
+			return nil, ErrPsNil
+		}
+		return ps.UUID(), nil
 	case fields.PsHandles:
 		ps := kevt.PS
 		if ps == nil {

--- a/pkg/filter/accessor_windows.go
+++ b/pkg/filter/accessor_windows.go
@@ -250,6 +250,12 @@ func (ps *psAccessor) get(f fields.Field, kevt *kevent.Kevent) (kparams.Value, e
 			mods = append(mods, filepath.Base(m.Name))
 		}
 		return mods, nil
+	case fields.PsUUID:
+		ps := kevt.PS
+		if ps == nil {
+			return nil, ErrPsNil
+		}
+		return ps.UUID(), nil
 	case fields.PsHandles:
 		ps := kevt.PS
 		if ps == nil {

--- a/pkg/filter/fields/fields_windows.go
+++ b/pkg/filter/fields/fields_windows.go
@@ -125,6 +125,8 @@ const (
 	PsSiblingUsername Field = "ps.sibling.username"
 	// PsUUID represents the unique process identifier
 	PsUUID Field = "ps.uuid"
+	// PsParentUUID represents the unique parent process identifier
+	PsParentUUID Field = "ps.parent.uuid"
 
 	// ThreadBasePrio is the base thread priority
 	ThreadBasePrio Field = "thread.prio"
@@ -427,6 +429,7 @@ var fields = map[Field]FieldInfo{
 	PsSiblingDomain:     {PsSiblingDomain, "created or terminated process domain", kparams.UnicodeString, []string{"ps.sibling.domain contains 'SERVICE'"}},
 	PsSiblingUsername:   {PsSiblingUsername, "created or terminated process username", kparams.UnicodeString, []string{"ps.sibling.username contains 'system'"}},
 	PsUUID:              {PsUUID, "unique process identifier", kparams.Uint64, []string{"ps.uuid > 6000054355"}},
+	PsParentUUID:        {PsParentUUID, "unique parent process identifier", kparams.Uint64, []string{"ps.parent.uuid > 6000054355"}},
 
 	ThreadBasePrio:        {ThreadBasePrio, "scheduler priority of the thread", kparams.Int8, []string{"thread.prio = 5"}},
 	ThreadIOPrio:          {ThreadIOPrio, "I/O priority hint for scheduling I/O operations", kparams.Int8, []string{"thread.io.prio = 4"}},

--- a/pkg/filter/fields/fields_windows.go
+++ b/pkg/filter/fields/fields_windows.go
@@ -123,6 +123,8 @@ const (
 	PsSiblingDomain Field = "ps.sibling.domain"
 	// PsSiblingUsername represents the sibling process username field
 	PsSiblingUsername Field = "ps.sibling.username"
+	// PsUUID represents the unique process identifier
+	PsUUID Field = "ps.uuid"
 
 	// ThreadBasePrio is the base thread priority
 	ThreadBasePrio Field = "thread.prio"
@@ -424,6 +426,7 @@ var fields = map[Field]FieldInfo{
 	PsSiblingSessionID:  {PsSiblingSessionID, "created or terminated process session identifier", kparams.Int16, []string{"ps.sibling.sessionid == 1"}},
 	PsSiblingDomain:     {PsSiblingDomain, "created or terminated process domain", kparams.UnicodeString, []string{"ps.sibling.domain contains 'SERVICE'"}},
 	PsSiblingUsername:   {PsSiblingUsername, "created or terminated process username", kparams.UnicodeString, []string{"ps.sibling.username contains 'system'"}},
+	PsUUID:              {PsUUID, "unique process identifier", kparams.Uint64, []string{"ps.uuid > 6000054355"}},
 
 	ThreadBasePrio:        {ThreadBasePrio, "scheduler priority of the thread", kparams.Int8, []string{"thread.prio = 5"}},
 	ThreadIOPrio:          {ThreadIOPrio, "I/O priority hint for scheduling I/O operations", kparams.Int8, []string{"thread.io.prio = 4"}},

--- a/pkg/kcap/header.go
+++ b/pkg/kcap/header.go
@@ -37,7 +37,7 @@ const magic = 0x6669627261747573
 const major = uint8(1)
 
 // minor represents the minor digit of the kcap file format
-const minor = uint8(0)
+const minor = uint8(1)
 
 // flags denotes extra flags for the purpose of the header description
 const flags = uint64(0)

--- a/pkg/kevent/kparam.go
+++ b/pkg/kevent/kparam.go
@@ -507,6 +507,20 @@ func (kpars Kparams) GetTime(name string) (time.Time, error) {
 	return v, nil
 }
 
+// MustGetTime returns the underlying time structure from the parameter or panics
+// if any errors occur.
+func (kpars Kparams) MustGetTime(name string) time.Time {
+	kpar, err := kpars.findParam(name)
+	if err != nil {
+		panic(err)
+	}
+	v, ok := kpar.Value.(time.Time)
+	if !ok {
+		panic(fmt.Errorf("unable to type cast %q parameter to Time value", name))
+	}
+	return v
+}
+
 // GetStringSlice returns the string slice from the event parameter.
 func (kpars Kparams) GetStringSlice(name string) ([]string, error) {
 	kpar, err := kpars.findParam(name)

--- a/pkg/kevent/marshaller_windows.go
+++ b/pkg/kevent/marshaller_windows.go
@@ -254,11 +254,11 @@ func (kevt *Kevent) UnmarshalRaw(b []byte, ver kcapver.Version) error {
 	}
 
 	// read parameters
-	nbKparams := bytes.ReadUint16(b[44+offset:])
+	nparams := bytes.ReadUint16(b[44+offset:])
 	// accumulates the offset of all parameter name and value lengths
 	var poffset uint16
 
-	for i := 0; i < int(nbKparams); i++ {
+	for i := 0; i < int(nparams); i++ {
 		// read kparam type
 		typ := bytes.ReadUint16(b[46+offset+poffset:])
 		// read kparam name

--- a/pkg/kevent/marshaller_windows.go
+++ b/pkg/kevent/marshaller_windows.go
@@ -189,11 +189,11 @@ func (kevt *Kevent) MarshalRaw() []byte {
 	// write process state
 	if kevt.PS != nil && (kevt.Type == ktypes.CreateProcess || kevt.Type == ktypes.EnumProcess) {
 		buf := kevt.PS.Marshal()
-		sec := section.New(section.Process, kcapver.ProcessSecV1, 0, uint32(len(buf)))
+		sec := section.New(section.Process, kcapver.ProcessSecV2, 0, uint32(len(buf)))
 		b = append(b, sec[:]...)
 		b = append(b, buf...)
 	} else {
-		sec := section.New(section.Process, kcapver.ProcessSecV1, 0, 0)
+		sec := section.New(section.Process, kcapver.ProcessSecV2, 0, 0)
 		b = append(b, sec[:]...)
 	}
 
@@ -417,7 +417,7 @@ func (kevt *Kevent) UnmarshalRaw(b []byte, ver kcapver.Version) error {
 	// read process state
 	sec := section.Read(b[48+offset:])
 	if sec.Size() != 0 {
-		ps, err := ptypes.NewFromKcap(b[58+offset:])
+		ps, err := ptypes.NewFromKcap(b[58+offset:], sec)
 		if err != nil {
 			return err
 		}

--- a/pkg/ps/snapshotter_windows.go
+++ b/pkg/ps/snapshotter_windows.go
@@ -189,6 +189,7 @@ func (s *snapshotter) Write(kevt *kevent.Kevent) error {
 			log.Warnf("couldn't enumerate handles for pid (%d): %v", pid, err)
 		}
 		ps.Parent = s.procs[ps.Ppid]
+		ps.StartTime = kevt.Kparams.MustGetTime(kparams.StartTime)
 
 		// inspect PE metadata and attach corresponding headers
 		s.readPE(ps)
@@ -488,6 +489,7 @@ func (s *snapshotter) Find(pid uint32) *pstypes.PS {
 	if err != nil {
 		log.Warnf("couldn't enumerate handles for pid (%d): %v", pid, err)
 	}
+	ps.StartTime = time.Now()
 
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/ps/types/marshaller_windows_test.go
+++ b/pkg/ps/types/marshaller_windows_test.go
@@ -22,13 +22,16 @@ import (
 	htypes "github.com/rabbitstack/fibratus/pkg/handle/types"
 	"github.com/rabbitstack/fibratus/pkg/kcap/section"
 	kcapver "github.com/rabbitstack/fibratus/pkg/kcap/version"
+	"github.com/rabbitstack/fibratus/pkg/pe"
 	"github.com/rabbitstack/fibratus/pkg/syscall/handle"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
+	"time"
 )
 
 func TestPSMarshaler(t *testing.T) {
+	n := time.Now()
 	ps := &PS{
 		PID:       2436,
 		Ppid:      6304,
@@ -40,6 +43,8 @@ func TestPSMarshaler(t *testing.T) {
 		Args:      []string{"-contentproc", `--channel="6304.3.1055809391\1014207667`, "-childID", "1", "-isForBrowser", "-prefsHandle", "2584", "-prefMapHandle", "2580", "-prefsLen", "70", "-prefMapSize", "216993", "-parentBuildID"},
 		SessionID: 4,
 		Envs:      map[string]string{"ProgramData": "C:\\ProgramData", "COMPUTRENAME": "archrabbit"},
+		uuid:      123456789,
+		StartTime: n,
 		Handles: []htypes.Handle{
 			{Num: handle.Handle(0xffffd105e9baaf70),
 				Name:   `\REGISTRY\MACHINE\SYSTEM\ControlSet001\Services\Tcpip\Parameters\Interfaces\{b677c565-6ca5-45d3-b618-736b4e09b036}`,
@@ -73,13 +78,106 @@ func TestPSMarshaler(t *testing.T) {
 	}
 
 	b := ps.Marshal()
-	sec := section.New(section.Process, kcapver.ProcessSecV1, 0, 0)
+	sec := section.New(section.Process, kcapver.ProcessSecV2, 0, 0)
 	clone, err := NewFromKcap(b, sec)
 	require.NoError(t, err)
 
 	assert.Equal(t, uint32(2436), clone.PID)
 	assert.Equal(t, uint32(6304), clone.Ppid)
 	assert.Equal(t, "firefox.exe", clone.Name)
+	assert.Equal(t, uint64(123456789), clone.uuid)
+	assert.True(t, n.Equal(clone.StartTime))
+	assert.Equal(t, `C:\Program Files\Mozilla Firefox\firefox.exe`, clone.Exe)
+	assert.Equal(t, `C:\Program Files\Mozilla Firefox\firefox.exe -contentproc --channel="6304.3.1055809391\1014207667" -childID 1 -isForBrowser -prefsHandle 2584 -prefMapHandle 2580 -prefsLen 70 -prefMapSize 216993 -parentBuildID 20200107212822 -greomni "C:\Program Files\Mozilla Firefox\omni.ja" -appomni "C:\Program Files\Mozilla Firefox\browser\omni.ja" -appdir "C:\Program Files\Mozilla Firefox\browser" - 6304 "\\.\pipe\gecko-crash-server-pipe.6304" 2596 tab`, clone.Comm)
+	assert.Equal(t, `C:\Program Files\Mozilla Firefox\`, clone.Cwd)
+	assert.Equal(t, "archrabbit\\SYSTEM", clone.SID)
+	assert.Equal(t, []string{"-contentproc", `--channel="6304.3.1055809391\1014207667`, "-childID", "1", "-isForBrowser", "-prefsHandle", "2584", "-prefMapHandle", "2580", "-prefsLen", "70", "-prefMapSize", "216993", "-parentBuildID"}, clone.Args)
+	assert.Equal(t, uint8(4), clone.SessionID)
+	assert.Equal(t, map[string]string{"ProgramData": "C:\\ProgramData", "COMPUTRENAME": "archrabbit"}, clone.Envs)
+
+	require.Len(t, clone.Handles, 3)
+
+	alpc := clone.Handles[1]
+	assert.Equal(t, "ALPC Port", alpc.Type)
+	assert.Equal(t, `\RPC Control\OLEA61B27E13E028C4EA6C286932E80`, alpc.Name)
+	assert.IsType(t, &htypes.AlpcPortInfo{}, alpc.MD)
+
+	md := alpc.MD.(*htypes.AlpcPortInfo)
+	assert.Equal(t, uint32(1), md.Seqno)
+}
+
+func TestPSMarshalerWithPE(t *testing.T) {
+	n := time.Now()
+	p := &pe.PE{
+		NumberOfSections: 7,
+		NumberOfSymbols:  10,
+		EntryPoint:       "20110",
+		ImageBase:        "140000000",
+		LinkTime:         n,
+		Sections: []pe.Sec{
+			{Name: ".text", Size: 132608, Entropy: 6.368381, Md5: "db23dce3911a42e987041d98abd4f7cd"},
+			{Name: ".rdata", Size: 35840, Entropy: 5.996976, Md5: "ffa5c960b421ca9887e54966588e97e8"},
+		},
+		Symbols:          []string{"SelectObject", "GetTextFaceW", "EnumFontsW", "TextOutW", "GetProcessHeap"},
+		Imports:          []string{"GDI32.dll", "USER32.dll", "msvcrt.dll", "api-ms-win-core-libraryloader-l1-2-0.dl"},
+		VersionResources: map[string]string{"CompanyName": "Microsoft Corporation", "FileDescription": "Notepad", "FileVersion": "10.0.18362.693"},
+	}
+	ps := &PS{
+		PID:       2436,
+		Ppid:      6304,
+		Name:      "firefox.exe",
+		Exe:       `C:\Program Files\Mozilla Firefox\firefox.exe`,
+		Comm:      `C:\Program Files\Mozilla Firefox\firefox.exe -contentproc --channel="6304.3.1055809391\1014207667" -childID 1 -isForBrowser -prefsHandle 2584 -prefMapHandle 2580 -prefsLen 70 -prefMapSize 216993 -parentBuildID 20200107212822 -greomni "C:\Program Files\Mozilla Firefox\omni.ja" -appomni "C:\Program Files\Mozilla Firefox\browser\omni.ja" -appdir "C:\Program Files\Mozilla Firefox\browser" - 6304 "\\.\pipe\gecko-crash-server-pipe.6304" 2596 tab`,
+		Cwd:       `C:\Program Files\Mozilla Firefox\`,
+		SID:       "archrabbit\\SYSTEM",
+		Args:      []string{"-contentproc", `--channel="6304.3.1055809391\1014207667`, "-childID", "1", "-isForBrowser", "-prefsHandle", "2584", "-prefMapHandle", "2580", "-prefsLen", "70", "-prefMapSize", "216993", "-parentBuildID"},
+		SessionID: 4,
+		Envs:      map[string]string{"ProgramData": "C:\\ProgramData", "COMPUTRENAME": "archrabbit"},
+		uuid:      123456789,
+		StartTime: n,
+		PE:        p,
+		Handles: []htypes.Handle{
+			{Num: handle.Handle(0xffffd105e9baaf70),
+				Name:   `\REGISTRY\MACHINE\SYSTEM\ControlSet001\Services\Tcpip\Parameters\Interfaces\{b677c565-6ca5-45d3-b618-736b4e09b036}`,
+				Type:   "Key",
+				Object: 777488883434455544,
+				Pid:    uint32(1023),
+			},
+			{
+				Num:  handle.Handle(0xffffd105e9adaf70),
+				Name: `\RPC Control\OLEA61B27E13E028C4EA6C286932E80`,
+				Type: "ALPC Port",
+				Pid:  uint32(1023),
+				MD: &htypes.AlpcPortInfo{
+					Seqno:   1,
+					Context: 0x0,
+					Flags:   0x0,
+				},
+				Object: 457488883434455544,
+			},
+			{
+				Num:  handle.Handle(0xeaffd105e9adaf30),
+				Name: `C:\Users\bunny`,
+				Type: "File",
+				Pid:  uint32(1023),
+				MD: &htypes.FileInfo{
+					IsDirectory: true,
+				},
+				Object: 357488883434455544,
+			},
+		},
+	}
+
+	b := ps.Marshal()
+	sec := section.New(section.Process, kcapver.ProcessSecV2, 0, 0)
+	clone, err := NewFromKcap(b, sec)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint32(2436), clone.PID)
+	assert.Equal(t, uint32(6304), clone.Ppid)
+	assert.Equal(t, "firefox.exe", clone.Name)
+	assert.Equal(t, uint64(123456789), clone.uuid)
+	assert.True(t, n.Equal(clone.StartTime))
 	assert.Equal(t, `C:\Program Files\Mozilla Firefox\firefox.exe`, clone.Exe)
 	assert.Equal(t, `C:\Program Files\Mozilla Firefox\firefox.exe -contentproc --channel="6304.3.1055809391\1014207667" -childID 1 -isForBrowser -prefsHandle 2584 -prefMapHandle 2580 -prefsLen 70 -prefMapSize 216993 -parentBuildID 20200107212822 -greomni "C:\Program Files\Mozilla Firefox\omni.ja" -appomni "C:\Program Files\Mozilla Firefox\browser\omni.ja" -appdir "C:\Program Files\Mozilla Firefox\browser" - 6304 "\\.\pipe\gecko-crash-server-pipe.6304" 2596 tab`, clone.Comm)
 	assert.Equal(t, `C:\Program Files\Mozilla Firefox\`, clone.Cwd)

--- a/pkg/ps/types/marshaller_windows_test.go
+++ b/pkg/ps/types/marshaller_windows_test.go
@@ -20,6 +20,8 @@ package types
 
 import (
 	htypes "github.com/rabbitstack/fibratus/pkg/handle/types"
+	"github.com/rabbitstack/fibratus/pkg/kcap/section"
+	kcapver "github.com/rabbitstack/fibratus/pkg/kcap/version"
 	"github.com/rabbitstack/fibratus/pkg/syscall/handle"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -71,7 +73,8 @@ func TestPSMarshaler(t *testing.T) {
 	}
 
 	b := ps.Marshal()
-	clone, err := NewFromKcap(b)
+	sec := section.New(section.Process, kcapver.ProcessSecV1, 0, 0)
+	clone, err := NewFromKcap(b, sec)
 	require.NoError(t, err)
 
 	assert.Equal(t, uint32(2436), clone.PID)

--- a/pkg/syscall/process/process.go
+++ b/pkg/syscall/process/process.go
@@ -147,6 +147,8 @@ const (
 	BasicInformationClass InfoClassFlags = 0
 	// HandleInformationClass returns allocated process handles
 	HandleInformationClass InfoClassFlags = 51
+	// SequenceNumberInformationClass returns the process sequence number
+	SequenceNumberInformationClass InfoClassFlags = 92
 )
 
 // Open acquires a handle from the running process.

--- a/pkg/util/bootid/bootid.go
+++ b/pkg/util/bootid/bootid.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021-2022 by Nedim Sabic Sabic
+ * https://www.fibratus.io
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bootid
+
+import "unsafe"
+
+// The KUSER_SHARED_DATA structure defines a data region that the kernel places
+// at a static address for access within user-mode. It is important to note that
+// this region of memory, when accessed via user-mode, is read only. The read-only
+// user-mode address for the shared data is 0x7FFE0000.
+const kuserSharedData uintptr = 0x7FFE0000
+
+const offset uintptr = 0x02C4 // BootId field offset
+
+// Read obtains the value of the BootId field in the KUSER_SHARED_DATA structure.
+func Read() uint64 {
+	return uint64(*(*uint32)(unsafe.Pointer(uintptr(unsafe.Pointer(kuserSharedData)) + offset)))
+}

--- a/pkg/util/bootid/bootid_test.go
+++ b/pkg/util/bootid/bootid_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 by Nedim Sabic Sabic
+ * Copyright 2021-2022 by Nedim Sabic Sabic
  * https://www.fibratus.io
  * All Rights Reserved.
  *
@@ -16,29 +16,13 @@
  * limitations under the License.
  */
 
-package version
+package bootid
 
-// Version designates the type for specifying the current section version.
-type Version uint16
-
-const (
-	// KevtSecV1 is the v1 of the kernel event section
-	KevtSecV1 Version = iota + 1
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
 )
 
-const (
-	// ProcessSecV1 is the v1 of the process section
-	ProcessSecV1 Version = iota + 1
-	// ProcessSecV2 is the v2 of the process section
-	ProcessSecV2
-)
-
-const (
-	// HandleSecV1 is the v1 of the handle section
-	HandleSecV1 Version = iota + 1
-)
-
-const (
-	// PESecV1 is the v1 of the PE section
-	PESecV1 Version = iota + 1
-)
+func TestReadBootId(t *testing.T) {
+	require.True(t, Read() > 0)
+}

--- a/rules/credential_access_os_credential_dumping.yml
+++ b/rules/credential_access_os_credential_dumping.yml
@@ -87,7 +87,7 @@
       condition: >
         sequence
         maxspan 2m
-        by ps.exe
+        by ps.uuid
           |open_process
               and
            ps.access.mask.names in ('ALL_ACCESS', 'CREATE_PROCESS')

--- a/rules/initial_access_phishing.yml
+++ b/rules/initial_access_phishing.yml
@@ -51,5 +51,3 @@
         {{
             emit . "Potentially malicious module loaded by Microsoft Office process" ""
         }}
-
-


### PR DESCRIPTION
Process UUID is meant to offer a more robust version of process ID that is resistant to being repeated. This filter field is especially important in sequence rules where we want to express a connection from two or more events generated by the same process.