### PR TITLE
feat(filter): Generic event argument filter field

### DIFF
--- a/pkg/filter/fields/fields_windows.go
+++ b/pkg/filter/fields/fields_windows.go
@@ -27,7 +27,7 @@ import (
 
 // pathRegexp splits the provided path into different components. The first capture
 // contains the indexed field name. Next is the indexed key and, finally the segment.
-var pathRegexp = regexp.MustCompile(`(pe.sections|pe.resources|ps.envs|ps.modules|ps.ancestor)\[(.+\s*)].?(.*)`)
+var pathRegexp = regexp.MustCompile(`(pe.sections|pe.resources|ps.envs|ps.modules|ps.ancestor|kevt.arg)\[(.+\s*)].?(.*)`)
 
 // Field represents the type alias for the field
 type Field string
@@ -226,6 +226,8 @@ const (
 	KevtMeta Field = "kevt.meta"
 	// KevtNparams is the number of event parameters
 	KevtNparams Field = "kevt.nparams"
+	// KevtArg represents the field sequence for generic argument access
+	KevtArg Field = "kevt.arg"
 
 	// HandleID represents the handle identifier within the process address space
 	HandleID Field = "handle.id"
@@ -353,11 +355,12 @@ const (
 	ProcessSessionID Segment = "sessionid"
 )
 
-func (f Field) IsEnvsSequence() bool        { return strings.HasPrefix(f.String(), "ps.envs[") }
-func (f Field) IsModsSequence() bool        { return strings.HasPrefix(f.String(), "ps.modules[") }
-func (f Field) IsAncestorSequence() bool    { return strings.HasPrefix(f.String(), "ps.ancestor[") }
-func (f Field) IsPeSectionsSequence() bool  { return strings.HasPrefix(f.String(), "pe.sections[") }
-func (f Field) IsPeResourcesSequence() bool { return strings.HasPrefix(f.String(), "pe.resources[") }
+func (f Field) IsEnvsMap() bool        { return strings.HasPrefix(f.String(), "ps.envs[") }
+func (f Field) IsModsMap() bool        { return strings.HasPrefix(f.String(), "ps.modules[") }
+func (f Field) IsAncestorMap() bool    { return strings.HasPrefix(f.String(), "ps.ancestor[") }
+func (f Field) IsPeSectionsMap() bool  { return strings.HasPrefix(f.String(), "pe.sections[") }
+func (f Field) IsPeResourcesMap() bool { return strings.HasPrefix(f.String(), "pe.resources[") }
+func (f Field) IsKevtArgMap() bool     { return strings.HasPrefix(f.String(), "kevt.arg[") }
 
 var fields = map[Field]FieldInfo{
 	KevtSeq:         {KevtSeq, "event sequence number", kparams.Uint64, []string{"kevt.seq > 666"}},
@@ -580,6 +583,10 @@ func Lookup(name string) Field {
 		}
 	case PsEnvs:
 		if segment == "" {
+			return Field(name)
+		}
+	case KevtArg:
+		if key != "" {
 			return Field(name)
 		}
 	}

--- a/pkg/filter/fields/fields_windows_test.go
+++ b/pkg/filter/fields/fields_windows_test.go
@@ -41,4 +41,6 @@ func TestLookup(t *testing.T) {
 	assert.Equal(t, Field("ps.ancestor[any].pid"), Lookup("ps.ancestor[any].pid"))
 	assert.Equal(t, Field("ps.ancestor[2].sid"), Lookup("ps.ancestor[2].sid"))
 	assert.Empty(t, Lookup("ps.ancestor[ro].name"))
+	assert.Equal(t, Field("kevt.arg[exe]"), Lookup("kevt.arg[exe]"))
+	assert.Empty(t, Lookup("kevt.arg"))
 }

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -362,6 +362,7 @@ func TestFilterRunKevent(t *testing.T) {
 		Host:        "archrabbit",
 		Description: "Creates or opens a new file, directory, I/O device, pipe, console",
 		Kparams: kevent.Kparams{
+			kparams.ProcessID:     {Name: kparams.ProcessID, Type: kparams.PID, Value: uint32(3434)},
 			kparams.FileObject:    {Name: kparams.FileObject, Type: kparams.Uint64, Value: uint64(12456738026482168384)},
 			kparams.FileName:      {Name: kparams.FileName, Type: kparams.UnicodeString, Value: "\\Device\\HarddiskVolume2\\Windows\\system32\\user32.dll"},
 			kparams.FileType:      {Name: kparams.FileType, Type: kparams.AnsiString, Value: "file"},
@@ -384,13 +385,16 @@ func TestFilterRunKevent(t *testing.T) {
 		{`kevt.name = 'CreateFile'`, true},
 		{`kevt.category = 'file'`, true},
 		{`kevt.host = 'archrabbit'`, true},
-		{`kevt.nparams = 4`, true},
+		{`kevt.nparams = 5`, true},
+		{`kevt.arg[file_name] = '\\Device\\HarddiskVolume2\\Windows\\system32\\user32.dll'`, true},
+		{`kevt.arg[type] = 'file'`, true},
+		{`kevt.arg[pid] = 3434`, true},
 
 		{`kevt.desc contains 'Creates or opens a new file'`, true},
 
 		{`kevt.date.d = 3 AND kevt.date.m = 5 AND kevt.time.s = 5 AND kevt.time.m = 4 and kevt.time.h = 15`, true},
 		{`kevt.time = '15:04:05'`, true},
-		{`concat(kevt.name, kevt.host, kevt.nparams) = 'CreateFilearchrabbit4'`, true},
+		{`concat(kevt.name, kevt.host, kevt.nparams) = 'CreateFilearchrabbit5'`, true},
 		{`ltrim(kevt.host, 'arch') = 'rabbit'`, true},
 		{`concat(ltrim(kevt.name, 'Create'), kevt.host) = 'Filearchrabbit'`, true},
 		{`lower(rtrim(kevt.name, 'File')) = 'create'`, true},


### PR DESCRIPTION
`kevt.arg` represents a generic filter field capable of extracting any parameter from the incoming event. The parameter name matches the internal key used to index the parameter. For example, `kevt.arg[exe]` would extract the `exe` parameter from the event parameters.