### PR TITLE
feat(kevent): Introduce image signature event parameters and rule macros

### DIFF
--- a/pkg/filter/accessor_windows.go
+++ b/pkg/filter/accessor_windows.go
@@ -640,6 +640,10 @@ func (i *imageAccessor) get(f fields.Field, kevt *kevent.Kevent) (kparams.Value,
 		return kevt.Kparams.GetUint32(kparams.ImageCheckSum)
 	case fields.ImagePID:
 		return kevt.Kparams.GetPid()
+	case fields.ImageSignatureType:
+		return kevt.GetParamAsString(kparams.ImageSignatureType), nil
+	case fields.ImageSignatureLevel:
+		return kevt.GetParamAsString(kparams.ImageSignatureLevel), nil
 	}
 	return nil, nil
 }

--- a/pkg/filter/fields/fields_windows.go
+++ b/pkg/filter/fields/fields_windows.go
@@ -332,6 +332,10 @@ const (
 	ImageName Field = "image.name"
 	// ImagePID is the pid of the process where the image was loaded
 	ImagePID Field = "image.pid"
+	// ImageSignatureType represents the image signature type
+	ImageSignatureType Field = "image.signature.type"
+	// ImageSignatureLevel represents the image signature level
+	ImageSignatureLevel Field = "image.signature.level"
 
 	// None represents the unknown field
 	None Field = ""
@@ -497,6 +501,8 @@ var fields = map[Field]FieldInfo{
 	ImageSize:           {ImageSize, "image size", kparams.Uint32, []string{"image.size > 1024"}, nil},
 	ImageDefaultAddress: {ImageDefaultAddress, "default image address", kparams.HexInt64, []string{"image.default.address = '7efe0000'"}, nil},
 	ImagePID:            {ImagePID, "target process identifier", kparams.Uint32, []string{"image.pid = 80"}, nil},
+	ImageSignatureType:  {ImageSignatureType, "image signature type", kparams.AnsiString, []string{"image.signature.type != 'NONE'"}, nil},
+	ImageSignatureLevel: {ImageSignatureLevel, "image signature level", kparams.AnsiString, []string{"image.signature.level = 'AUTHENTICODE'"}, nil},
 
 	FileObject:     {FileObject, "file object address", kparams.Uint64, []string{"file.object = 18446738026482168384"}, nil},
 	FileName:       {FileName, "full file name", kparams.UnicodeString, []string{"file.name contains 'mimikatz'"}, nil},

--- a/pkg/kevent/kparams/fields_windows.go
+++ b/pkg/kevent/kparams/fields_windows.go
@@ -127,6 +127,10 @@ const (
 	ImageDefaultBase = "default_address"
 	// ImageFilename is the parameter name that denotes file name and extension of the DLL/executable image.
 	ImageFilename = "file_name"
+	// ImageSignatureLevel is the parameter denoting the loaded module signature level
+	ImageSignatureLevel = "signature_level"
+	// ImageSignatureType is the parameter denoting the loaded module signature type
+	ImageSignatureType = "signature_type"
 
 	// NetSize identifies the parameter name that represents the packet size.
 	NetSize = "size"

--- a/pkg/kstream/kstreamc_windows_test.go
+++ b/pkg/kstream/kstreamc_windows_test.go
@@ -175,7 +175,10 @@ func TestConsumerEvents(t *testing.T) {
 			nil,
 			func(e *kevent.Kevent) bool {
 				img := filepath.Join(os.Getenv("windir"), "System32", "notepad.exe")
-				return e.IsLoadImage() && strings.EqualFold(img, e.GetParamAsString(kparams.ImageFilename))
+				// should get a catalog-signed binary
+				signatureType := e.GetParamAsString(kparams.ImageSignatureType)
+				return e.IsLoadImage() && strings.EqualFold(img, e.GetParamAsString(kparams.ImageFilename)) &&
+					signatureType == "CATALOG_CACHED"
 			},
 			false,
 		},

--- a/pkg/pe/types.go
+++ b/pkg/pe/types.go
@@ -76,6 +76,8 @@ type PE struct {
 	Imports []string `json:"imports"`
 	// VersionResources holds the version resources
 	VersionResources map[string]string `json:"resources"`
+	// IsSigned determines if the PE contains the digital signature.
+	IsSigned bool `json:"is_signed"`
 }
 
 // String returns the string representation of the PE metadata.

--- a/pkg/sys/syscall.go
+++ b/pkg/sys/syscall.go
@@ -41,3 +41,12 @@ package sys
 
 // Windows Terminal Server Functions
 //sys WTSQuerySessionInformationA(handle windows.Handle, sessionID uint32, klass uint8, buf **uint16, size *uint32) (err error) = wtsapi32.WTSQuerySessionInformationW
+
+// Windows Trust Functions
+//sys WinVerifyTrust(handle windows.Handle, action *windows.GUID, data *WintrustData) (ret uint32, err error) [failretval!=0] = wintrust.WinVerifyTrust
+//sys CryptCatalogAdminAcquireContext(handle *windows.Handle, subsystem *windows.GUID, hashAlgorithm *uint16, hashPolicy uintptr, flags uint32) (err error) = wintrust.CryptCATAdminAcquireContext2
+//sys CryptCatalogAdminReleaseContext(handle windows.Handle, flags int32) (ok bool) = wintrust.CryptCATAdminReleaseContext
+//sys CryptCatalogAdminCalcHashFromFileHandle(handle windows.Handle, fd uintptr, size *uint32, hash uintptr, flags uint32) (err error) = wintrust.CryptCATAdminCalcHashFromFileHandle2
+//sys CryptCatalogAdminEnumCatalogFromHash(handle windows.Handle, hash uintptr, size uint32, flags uint32, prevCatalog *windows.Handle) (catalog windows.Handle) = wintrust.CryptCATAdminEnumCatalogFromHash
+//sys CryptCatalogInfoFromContext(handle windows.Handle, catalog *CatalogInfo, flags uint32) (err error) = wintrust.CryptCATCatalogInfoFromContext
+//sys CryptCatalogAdminReleaseCatalogContext(handle windows.Handle, info windows.Handle, flags uint32) (err error) = wintrust.CryptCATAdminReleaseCatalogContext

--- a/pkg/sys/trust.go
+++ b/pkg/sys/trust.go
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2021-2022 by Nedim Sabic Sabic
+ * https://www.fibratus.io
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sys
+
+import (
+	"golang.org/x/sys/windows"
+	"unsafe"
+)
+
+const (
+	// WtdUIAll display all UI interface.
+	WtdUIAll = 1
+	// WtdUINone display no UI.
+	WtdUINone = 2
+	// WtdUINoBad do not display any negative UI
+	WtdUINoBad = 3
+	// WtdUINoGood do not display any positive UI
+	WtdUINoGood = 4
+	// WtdRevokeNone dictates that no additional revocation checking
+	// will be done when the WtdRevokeNone flag is used in conjunction
+	// with the HTTPSPROV_ACTION value set in the action parameter of the
+	// WinVerifyTrust function. To ensure the WinVerifyTrust function does
+	// not attempt any network retrieval when verifying code signatures,
+	// WTD_CACHE_ONLY_URL_RETRIEVAL must be set in the ProviderFlags parameter.
+	WtdRevokeNone = 0
+	// WtdChoiceFile specifies the file object is verified by the trust provider.
+	WtdChoiceFile = 1
+	// WtdChoiceCatalog specifies the file object is verified through catalog by the trust provider.
+	WtdChoiceCatalog = 2
+	// WtdStateActionVerify verifies the trust of the object (typically a file)
+	// that is specified by the UnionChoice member. The StateData member will
+	// receive a handle to the state data. This handle must be freed by specifying
+	// the WtdStateActionClose action in a subsequent call.
+	WtdStateActionVerify = 0x00000001
+	// WtdStateActionClose frees the StateData member previously allocated with
+	// the WtdStateActionVerify action. This action must be specified for every use
+	// of the WtdStateActionVerify action.
+	WtdStateActionClose = 0x00000002
+	// WtdSaferFlag is the trust provider flag
+	WtdSaferFlag = 0x100
+)
+
+// WintrustData structure is used when calling WinVerifyTrust
+// to pass necessary information into the trust providers.
+type WintrustData struct {
+	Size                          uint32
+	PolicyCallbackBuffer          uintptr
+	SubjectInterfacePackageBuffer uintptr
+	UIChoice                      uint32
+	RevocationChecks              uint32
+	UnionChoice                   uint32
+	Union                         uintptr // C union
+	StateAction                   uint32
+	StateData                     windows.Handle
+	URLReference                  uintptr
+	ProviderFlags                 uint32
+	UIContext                     uint32
+	SignatureSettings             *WintrustSignatureSettings
+}
+
+// WintrustSignatureSettings structure can be used to specify the signatures on a file.
+type WintrustSignatureSettings struct {
+	Size                uint32
+	Index               uint32
+	Flags               uint32
+	SecondarySignatures uint32
+	SignatureIndex      uint32
+	CryptoPolicy        uintptr // pointer to CERT_STRONG_SIGN_PARA structure
+}
+
+// WintrustFileInfo structure is used when calling WinVerifyTrust to verify an individual file.
+type WintrustFileInfo struct {
+	Size         uint32
+	FilePath     *uint16 // file path to be verified
+	FileHandle   uintptr // file handle to open file
+	KnownSubject *windows.GUID
+}
+
+// WintrustCatalogInfo structure is used when calling WinVerifyTrust to verify a member of a Microsoft catalog.
+type WintrustCatalogInfo struct {
+	Size            uint32
+	CatalogVersion  uint32
+	CatalogFilePath uintptr
+	MemberTag       uintptr
+	MemberFilePath  uintptr
+	MemberFile      windows.Handle
+	FileHash        uintptr
+	FileHashSize    uint32
+	CatalogContext  uintptr
+	CatalogAdmin    windows.Handle
+}
+
+// CatalogInfo structure contains the name of a catalog file. This structure is used by
+// the CryptCatalogInfoFromContext function.
+type CatalogInfo struct {
+	Size uint32
+	Name [1024]byte
+}
+
+// CatalogFile returns the full path to the catalog file.
+func (c CatalogInfo) CatalogFile() string {
+	p := (*[unsafe.Sizeof(c.Name) / 2]uint16)(unsafe.Pointer(&c.Name[0]))
+	return windows.UTF16ToString(p[:])
+}
+
+// IsWintrustFound indicates if the wintrust DLL is present in the system.
+func IsWintrustFound() bool { return modwintrust.Load() == nil }

--- a/pkg/util/format/format.go
+++ b/pkg/util/format/format.go
@@ -18,7 +18,13 @@
 
 package format
 
-import "strconv"
+import (
+	"fmt"
+	"strconv"
+)
 
 // UintToHex converts an unsigned wide integer to hex string.
 func UintToHex(v uint64) string { return strconv.FormatUint(v, 16) }
+
+// BytesToHex converts a byte slice to hex representation
+func BytesToHex(b []byte) string { return fmt.Sprintf("%X", b) }

--- a/pkg/util/signature/cat.go
+++ b/pkg/util/signature/cat.go
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2021-2022 by Nedim Sabic Sabic
+ * https://www.fibratus.io
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package signature
+
+import (
+	"github.com/rabbitstack/fibratus/pkg/sys"
+	"github.com/rabbitstack/fibratus/pkg/util/format"
+	"golang.org/x/sys/windows"
+	"os"
+	"runtime"
+	"unsafe"
+)
+
+// isCatalogSigned determines if the provided file is catalog signed.
+func isCatalogSigned(filename string) bool {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	// acquire handle to a catalog administrator context
+	var catalogAdmin windows.Handle
+	err := sys.CryptCatalogAdminAcquireContext(&catalogAdmin, nil, nil, 0, 0)
+	if err != nil {
+		return false
+	}
+	defer sys.CryptCatalogAdminReleaseContext(catalogAdmin, 0)
+
+	// calculate file hash
+	file, err := os.Open(filename)
+	if err != nil {
+		return false
+	}
+	//nolint:errcheck
+	defer file.Close()
+	size := uint32(100)
+	hash := make([]byte, size)
+	err = sys.CryptCatalogAdminCalcHashFromFileHandle(
+		catalogAdmin,
+		file.Fd(),
+		&size,
+		uintptr(unsafe.Pointer(&hash[0])), 0,
+	)
+	if err != nil {
+		return false
+	}
+
+	// enumerate catalogs that contain the calculated hash.
+	// If no catalogs are found, we can deduce the file is
+	// not catalog signed
+	catalog := sys.CryptCatalogAdminEnumCatalogFromHash(
+		catalogAdmin,
+		uintptr(unsafe.Pointer(&hash[0])),
+		size, 0, nil,
+	)
+	if catalog == 0 {
+		return false
+	}
+	return true
+}
+
+// verifyCatalogSignature calculates the provided file hash and tries
+// to locate the hash within the catalog. If the hash is found in the
+// catalog, the signature verification process is performed.
+func verifyCatalogSignature(filename string) bool {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	// acquire handle to a catalog administrator context
+	var catalogAdmin windows.Handle
+	err := sys.CryptCatalogAdminAcquireContext(&catalogAdmin, nil, nil, 0, 0)
+	if err != nil {
+		return false
+	}
+	defer sys.CryptCatalogAdminReleaseContext(catalogAdmin, 0)
+
+	// calculate file hash
+	file, err := os.Open(filename)
+	if err != nil {
+		return false
+	}
+	//nolint:errcheck
+	defer file.Close()
+	size := uint32(100)
+	hash := make([]byte, size)
+	err = sys.CryptCatalogAdminCalcHashFromFileHandle(
+		catalogAdmin,
+		file.Fd(),
+		&size,
+		uintptr(unsafe.Pointer(&hash[0])), 0,
+	)
+	if err != nil {
+		return false
+	}
+
+	// enumerate catalogs that contain the calculated hash
+	catalog := sys.CryptCatalogAdminEnumCatalogFromHash(
+		catalogAdmin,
+		uintptr(unsafe.Pointer(&hash[0])),
+		size, 0, nil,
+	)
+	if catalog == 0 {
+		return false
+	}
+	//nolint:errcheck
+	defer sys.CryptCatalogAdminReleaseCatalogContext(catalogAdmin, catalog, 0)
+	var catalogInfo sys.CatalogInfo
+	catalogInfo.Size = uint32(unsafe.Sizeof(sys.CatalogInfo{}))
+	err = sys.CryptCatalogInfoFromContext(catalog, &catalogInfo, 0)
+	if err != nil {
+		return false
+	}
+
+	// tag is a hexadecimal representation of the hash of the file
+	tag := windows.StringToUTF16Ptr(format.BytesToHex(hash[:size]))
+
+	cat := &sys.WintrustCatalogInfo{
+		Size:            uint32(unsafe.Sizeof(sys.WintrustCatalogInfo{})),
+		CatalogFilePath: uintptr(unsafe.Pointer(&catalogInfo.Name[0])),
+		MemberFilePath:  uintptr(unsafe.Pointer(windows.StringToUTF16Ptr(filename))),
+		MemberFile:      windows.Handle(file.Fd()),
+		MemberTag:       uintptr(unsafe.Pointer(tag)),
+		FileHash:        uintptr(unsafe.Pointer(&hash[0])),
+		FileHashSize:    size,
+		CatalogAdmin:    catalogAdmin,
+	}
+	data := &sys.WintrustData{
+		Size:             uint32(unsafe.Sizeof(sys.WintrustData{})),
+		UIChoice:         sys.WtdUINone,
+		RevocationChecks: sys.WtdRevokeNone,
+		UnionChoice:      sys.WtdChoiceCatalog,
+		Union:            uintptr(unsafe.Pointer(cat)),
+		StateAction:      sys.WtdStateActionVerify,
+		ProviderFlags:    sys.WtdSaferFlag,
+	}
+
+	status, err := sys.WinVerifyTrust(windows.InvalidHandle, &WintrustActionGenericVerifyV2, data)
+	// release stata data by specifying the corresponding action
+	data.StateAction = sys.WtdStateActionClose
+	_, _ = sys.WinVerifyTrust(windows.InvalidHandle, &WintrustActionGenericVerifyV2, data)
+	if err != nil {
+		return false
+	}
+	if status != 0 {
+		return false
+	}
+	return true
+}

--- a/pkg/util/signature/cat.go
+++ b/pkg/util/signature/cat.go
@@ -65,6 +65,7 @@ func IsCatalogSigned(filename string) bool {
 		uintptr(unsafe.Pointer(&hash[0])),
 		size, 0, nil,
 	)
+	//nolint:errcheck
 	defer sys.CryptCatalogAdminReleaseCatalogContext(catalogAdmin, catalog, 0)
 	return catalog != 0
 }
@@ -111,6 +112,7 @@ func verifyCatalogSignature(filename string) bool {
 	if catalog == 0 {
 		return false
 	}
+	//nolint:errcheck
 	defer sys.CryptCatalogAdminReleaseCatalogContext(catalogAdmin, catalog, 0)
 	var catalogInfo sys.CatalogInfo
 	catalogInfo.Size = uint32(unsafe.Sizeof(sys.CatalogInfo{}))

--- a/pkg/util/signature/cat_test.go
+++ b/pkg/util/signature/cat_test.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021-2022 by Nedim Sabic Sabic
+ * https://www.fibratus.io
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package signature
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsCatalogSigned(t *testing.T) {
+	executable, err := os.Executable()
+	require.NoError(t, err)
+
+	var tests = []struct {
+		filename string
+		want     bool
+	}{
+		{
+			executable,
+			false,
+		},
+		{
+			filepath.Join(os.Getenv("windir"), "notepad.exe"),
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.filename, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsCatalogSigned(tt.filename))
+		})
+	}
+}

--- a/pkg/util/signature/signature.go
+++ b/pkg/util/signature/signature.go
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2021-2022 by Nedim Sabic Sabic
+ * https://www.fibratus.io
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package signature
+
+import (
+	"github.com/rabbitstack/fibratus/pkg/pe"
+	"github.com/rabbitstack/fibratus/pkg/sys"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
+	"runtime"
+	"sync"
+	"unsafe"
+)
+
+var isWintrustDLLFound bool
+var once sync.Once
+
+// Check determines if the provided executable image or DLL is signed.
+// It first parses the PE security directory to look for the signature
+// information. If the certificate is not embedded inside the PE object
+// then this method will try to locate the hash in the catalog file.
+func Check(filename string) *Signature {
+	once.Do(func() {
+		isWintrustDLLFound = sys.IsWintrustFound()
+		if !isWintrustDLLFound {
+			log.Warn("unable to find wintrust.dll library. This will lead to " +
+				"PE objects signature verification to be skipped possibly " +
+				"causing false positive samples in detection rules relying on " +
+				"image signature filter fields")
+		}
+	})
+	// check if the signature is embedded in PE
+	f, err := pe.ParseFile(filename, pe.WithSecurity())
+	if err != nil {
+		return nil
+	}
+	s := &Signature{filename: filename}
+	if f.IsSigned {
+		s.Type = Embedded
+		return s
+	}
+	if !isWintrustDLLFound {
+		return nil
+	}
+	// maybe the signature is in the catalog?
+	if isCatalogSigned(filename) {
+		s.Type = Catalog
+	}
+	return s
+}
+
+// Verify verifies the DLL or executable image signature.
+// The signature is verified via Authenticode policy provider.
+// Windows must verify the trust chain by following the certificates
+// to a trusted root certificate.
+// If the verification fails on the PE object, then the attempt to
+// verify the signature in the catalog file is made. This method
+// returns a bool value indicating if the signature is trusted.
+func (s *Signature) Verify() bool {
+	if !isWintrustDLLFound {
+		return false
+	}
+	if verifyFileSignature(s.filename) || verifyCatalogSignature(s.filename) {
+		s.Level = AuthenticodeLevel
+		return true
+	}
+	s.Level = UnsignedLevel
+	return false
+}
+
+// verifyFileSignature performs a trust verification action on the PE file
+// by passing the inquiry to a trust provider that supports the action identifier.
+func verifyFileSignature(filename string) bool {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	fileinfo := &sys.WintrustFileInfo{
+		Size:     uint32(unsafe.Sizeof(sys.WintrustFileInfo{})),
+		FilePath: windows.StringToUTF16Ptr(filename),
+	}
+	data := &sys.WintrustData{
+		Size:             uint32(unsafe.Sizeof(sys.WintrustData{})),
+		UIChoice:         sys.WtdUINone,
+		RevocationChecks: sys.WtdRevokeNone,
+		UnionChoice:      sys.WtdChoiceFile,
+		Union:            uintptr(unsafe.Pointer(fileinfo)),
+		StateAction:      sys.WtdStateActionVerify,
+		ProviderFlags:    sys.WtdSaferFlag,
+	}
+
+	// the trust provider should perform the verification
+	// action without the user's assistance. This is achieved
+	// by providing INVALID_HANDLE_VALUE as a first parameter
+	status, err := sys.WinVerifyTrust(windows.InvalidHandle, &WintrustActionGenericVerifyV2, data)
+	// release stata data by specifying the corresponding action
+	data.StateAction = sys.WtdStateActionClose
+	_, _ = sys.WinVerifyTrust(windows.InvalidHandle, &WintrustActionGenericVerifyV2, data)
+	if err != nil {
+		return false
+	}
+	if status != 0 {
+		return false
+	}
+	// trust provider verifies that the subject is trusted
+	// for the specified action, the return value is zero
+	return true
+}

--- a/pkg/util/signature/signature_test.go
+++ b/pkg/util/signature/signature_test.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021-2022 by Nedim Sabic Sabic
+ * https://www.fibratus.io
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package signature
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSignature(t *testing.T) {
+	executable, err := os.Executable()
+	require.NoError(t, err)
+
+	var tests = []struct {
+		name     string
+		filename string
+		sigType  uint32
+		sigLevel uint32
+	}{
+		{
+			"PE embedded signature",
+			filepath.Join(os.Getenv("windir"), "System32", "kernel32.dll"),
+			Embedded,
+			AuthenticodeLevel,
+		},
+		{
+			"catalog signature",
+			filepath.Join(os.Getenv("windir"), "notepad.exe"),
+			Catalog,
+			AuthenticodeLevel,
+		},
+		{
+			"unsigned binary",
+			executable,
+			None,
+			UnsignedLevel,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sig := Check(tt.filename)
+			require.NotNil(t, sig)
+			assert.Equal(t, tt.sigType, sig.Type)
+			sig.Verify()
+			assert.Equal(t, tt.sigLevel, sig.Level)
+		})
+	}
+}

--- a/pkg/util/signature/types.go
+++ b/pkg/util/signature/types.go
@@ -18,11 +18,6 @@
 
 package signature
 
-import "golang.org/x/sys/windows"
-
-// WintrustActionGenericVerifyV2 is the action that indicates the file or object should be verified by using the Authenticode policy provider.
-var WintrustActionGenericVerifyV2 = windows.GUID{Data1: 0xaac56b, Data2: 0xcd44, Data3: 0x11d0, Data4: [8]byte{0x8c, 0xc2, 0x0, 0xc0, 0x4f, 0xc2, 0x95, 0xee}}
-
 const (
 	// UncheckedLevel specifies signature unchecked level
 	UncheckedLevel uint32 = 0

--- a/pkg/util/signature/types.go
+++ b/pkg/util/signature/types.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021-2022 by Nedim Sabic Sabic
+ * https://www.fibratus.io
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package signature
+
+import "golang.org/x/sys/windows"
+
+// WintrustActionGenericVerifyV2 is the action that indicates the file or object should be verified by using the Authenticode policy provider.
+var WintrustActionGenericVerifyV2 = windows.GUID{Data1: 0xaac56b, Data2: 0xcd44, Data3: 0x11d0, Data4: [8]byte{0x8c, 0xc2, 0x0, 0xc0, 0x4f, 0xc2, 0x95, 0xee}}
+
+const (
+	// UncheckedLevel specifies signature unchecked level
+	UncheckedLevel uint32 = 0
+	// UnsignedLevel specifies signature unsigned level
+	UnsignedLevel uint32 = 1
+	// AuthenticodeLevel determines the object is Authenticode signed
+	AuthenticodeLevel uint32 = 4
+
+	// None indicates non-existent signature
+	None uint32 = 0
+	// Embedded indicates the signature is baked into the PE object
+	Embedded uint32 = 1
+	// Catalog indicates the executable or DLL signature is stored in the catalog
+	Catalog uint32 = 3
+)
+
+// Types enum defines signature types which verified the image.
+var Types = map[uint32]string{
+	0: "NONE",             // unsigned or verification hasn't been attempted
+	1: "EMBEDDED",         // embedded signature
+	2: "CACHED",           // cached signature; presence of a CI EA means the file was previously verified
+	3: "CATALOG_CACHED",   // cached catalog verified via Catalog Database or searching catalog directly
+	4: "CATALOG_UNCACHED", // uncached catalog verified via Catalog Database or searching catalog directly
+	5: "CATALOG_HINT",     // successfully verified using an EA that informs CI that catalog to try first
+	6: "PACKAGE_CATALOG",  // AppX / MSIX package catalog verified
+}
+
+// Levels enum defines all possible image signature levels at which the code was verified.
+var Levels = map[uint32]string{
+	0:  "UNCHECKED",    // signing level hasn't yet been checked
+	1:  "UNSIGNED",     // file is unsigned or has no signature that passes the active policies
+	2:  "ENTERPRISE",   // trusted by Windows Defender Application Control policy
+	3:  "DEVELOPER",    // developer signed code
+	4:  "AUTHENTICODE", // Authenticode signed
+	5:  "STORE_PPL",    // Microsoft Store signed app PPL (Protected Process Light)
+	6:  "STORE",        // Microsoft Store-signed
+	7:  "ANTIMALWARE",  // signed by an Antimalware vendor whose product is using AMPPL
+	8:  "MICROSOFT",    // Microsoft signed
+	9:  "CUSTOM_4",
+	10: "CUSTOM_5",
+	11: "DYNAMIC_CODEGEN", // only used for signing of the .NET NGEN compiler
+	12: "WINDOWS",         // Windows signed
+	13: "CUSTOM_7",
+	14: "WINDOWS_TCB", // Windows Trusted Computing Base signed
+	15: "CUSTOM_6",
+}
+
+// Signature represents the signature status.
+type Signature struct {
+	// Type specifies the signature type. If the image is not signed, the
+	// type is equal to None.
+	Type uint32
+	// Level specifies the signature level at which the code was signed.
+	Level    uint32
+	filename string
+}
+
+func (s *Signature) IsSigned() bool  { return s.Type != None }
+func (s *Signature) IsTrusted() bool { return s.Level != UncheckedLevel && s.Level != UnsignedLevel }

--- a/rules/macros/macros.yml
+++ b/rules/macros/macros.yml
@@ -59,6 +59,30 @@
     loading of kernel driver by observing the object manager events and watching
     for driver objects being created.
 
+- macro: load_unsigned_module
+  expr: >
+    load_module and image.signature.type = 'NONE'
+  description: |
+    Detects when unsigned executable or DLL is loaded into process address space.
+    The module is considered as unsigned if it lacks the cert in the PE security
+    directory or the Authenticode hash is not present in any of the catalogs.
+
+- macro: load_untrusted_module
+  expr: >
+    load_module
+      and
+    image.signature.level = 'UNCHECKED' or image.signature.level = 'UNSIGNED'
+  description: |
+    Detects when untrusted executable or DLL is loaded into process address space.
+    Windows must verify the trust chain by following the certificates to a trusted
+    root certificate. If the trust chain is not satisfied, the module is considered
+    untrusted.
+
+- macro: load_unsigned_or_untrusted_module
+  expr: (load_unsigned_module) or (load_untrusted_module)
+  description: >
+    Detects when either unsigned or untrusted module is loaded into process address space.
+
 - macro: write_minidump_file
   expr: >
     write_file

--- a/rules/macros/macros.yml
+++ b/rules/macros/macros.yml
@@ -71,7 +71,7 @@
   expr: >
     load_module
       and
-    image.signature.level = 'UNCHECKED' or image.signature.level = 'UNSIGNED'
+    (image.signature.level = 'UNCHECKED' or image.signature.level = 'UNSIGNED')
   description: |
     Detects when untrusted executable or DLL is loaded into process address space.
     Windows must verify the trust chain by following the certificates to a trusted


### PR DESCRIPTION
This PR delivers new `ImageLoad` event parameters to designate the type and level of the image/module signature. Since the event parameters published by ETW are frequently reported with unchecked signature type even for core Windows binaries and DLLs, it is necessary to manually check whether the module is signed and also if it is a trusted image - i.e. the trust chain is verified following certificates to a trusted root certificate.

Various rule macros are delivered as part of this PR and ready to use in detection rules (should be self-explanatory):

- `load_unsigned_module`
- `load_untrusted_module`
- `load_unsigned_or_untrusted_module`