### PR TITLE
feat(kevent): New DuplicateHandle event

### DIFF
--- a/pkg/handle/object.go
+++ b/pkg/handle/object.go
@@ -29,7 +29,6 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/sys"
 	"github.com/rabbitstack/fibratus/pkg/util/key"
 	"golang.org/x/sys/windows"
-	"os"
 )
 
 var devMapper = fs.NewDevMapper()
@@ -43,18 +42,11 @@ func Duplicate(handle windows.Handle, pid uint32, access uint32) (windows.Handle
 	}
 	//nolint:errcheck
 	defer windows.CloseHandle(source)
-	// this process receives the duplicated handle
-	target, err := windows.OpenProcess(windows.PROCESS_DUP_HANDLE, false, uint32(os.Getpid()))
-	if err != nil {
-		return windows.InvalidHandle, err
-	}
-	//nolint:errcheck
-	defer windows.CloseHandle(target)
 	// duplicate the remote handle in the current process's address space.
 	// Note that for certain handle types this operation might fail
 	// as they don't permit duplicate operations
 	var dup windows.Handle
-	err = windows.DuplicateHandle(source, handle, target, &dup, access, false, 0)
+	err = windows.DuplicateHandle(source, handle, windows.CurrentProcess(), &dup, access, false, 0)
 	if err != nil {
 		return windows.InvalidHandle, fmt.Errorf("unable to duplicate handle: %v", err)
 	}

--- a/pkg/kevent/backlog.go
+++ b/pkg/kevent/backlog.go
@@ -45,7 +45,7 @@ func (b *Backlog) Put(evt *Kevent) {
 		b.cache.RemoveOldest()
 	}
 	key := evt.DelayKey()
-	if key != 0 {
+	if key != 0 && evt.Delayed {
 		b.cache.Add(key, evt)
 	}
 }

--- a/pkg/kevent/kparam_windows.go
+++ b/pkg/kevent/kparam_windows.go
@@ -325,6 +325,19 @@ func (e *Kevent) produceParams(evt *etw.EventRecord) {
 		e.AppendParam(kparams.HandleID, kparams.Uint32, handleID)
 		e.AppendParam(kparams.HandleObjectTypeID, kparams.HandleType, typeID)
 		e.AppendParam(kparams.HandleObjectName, kparams.UnicodeString, handleName)
+	case ktypes.DuplicateHandle:
+		object := evt.ReadUint64(0)
+		srcHandleID := evt.ReadUint32(8)
+		dstHandleID := evt.ReadUint32(12)
+		targetPID := evt.ReadUint32(16)
+		typeID := evt.ReadUint16(20)
+		sourcePID := evt.ReadUint32(22)
+		e.AppendParam(kparams.HandleObject, kparams.Address, object)
+		e.AppendParam(kparams.HandleID, kparams.Uint32, dstHandleID)
+		e.AppendParam(kparams.HandleSourceID, kparams.Uint32, srcHandleID)
+		e.AppendParam(kparams.HandleObjectTypeID, kparams.HandleType, typeID)
+		e.AppendParam(kparams.ProcessID, kparams.PID, sourcePID)
+		e.AppendParam(kparams.TargetProcessID, kparams.PID, targetPID)
 	case ktypes.LoadImage,
 		ktypes.UnloadImage,
 		ktypes.ImageRundown:

--- a/pkg/kevent/kparams/fields_windows.go
+++ b/pkg/kevent/kparams/fields_windows.go
@@ -24,6 +24,8 @@ const (
 
 	// ProcessID represents the process identifier.
 	ProcessID = "pid"
+	// TargetProcessID represents the target process identifier.
+	TargetProcessID = "target_pid"
 	// ProcessObject field represents the address of the process object in the kernel.
 	ProcessObject = "kproc"
 	// ThreadID field represents the thread identifier.
@@ -177,6 +179,8 @@ const (
 
 	// HandleID identifies the parameter that specifies the handle identifier.
 	HandleID = "handle_id"
+	// HandleSourceID identifies the parameter that specifies the source handle identifier.
+	HandleSourceID = "handle_source_id"
 	// HandleObject identifies the parameter that represents the kernel object to which handle is associated.
 	HandleObject = "handle_object"
 	// HandleObjectName identifies the parameter that represents the kernel object name.

--- a/pkg/kevent/ktypes/ktypes_windows.go
+++ b/pkg/kevent/ktypes/ktypes_windows.go
@@ -136,10 +136,12 @@ var (
 	// RetransmitTCPv6 is the TCP IPv6 network retransmit event.
 	RetransmitTCPv6 = pack(windows.GUID{Data1: 0x9a280ac0, Data2: 0xc8e0, Data3: 0x11d1, Data4: [8]byte{0x84, 0xe2, 0x0, 0xc0, 0x4f, 0xb9, 0x98, 0xa2}}, 30)
 
-	// CreateHandle represents handle creation kernel event
+	// CreateHandle represents handle creation event
 	CreateHandle = pack(windows.GUID{Data1: 0x89497f50, Data2: 0xeffe, Data3: 0x4440, Data4: [8]byte{0x8c, 0xf2, 0xce, 0x6b, 0x1c, 0xdc, 0xac, 0xa7}}, 32)
-	// CloseHandle represents handle closure kernel event
+	// CloseHandle represents handle closure event
 	CloseHandle = pack(windows.GUID{Data1: 0x89497f50, Data2: 0xeffe, Data3: 0x4440, Data4: [8]byte{0x8c, 0xf2, 0xce, 0x6b, 0x1c, 0xdc, 0xac, 0xa7}}, 33)
+	// DuplicateHandle represents handle duplication event
+	DuplicateHandle = pack(windows.GUID{Data1: 0x89497f50, Data2: 0xeffe, Data3: 0x4440, Data4: [8]byte{0x8c, 0xf2, 0xce, 0x6b, 0x1c, 0xdc, 0xac, 0xa7}}, 34)
 
 	// VirtualAlloc represents virtual memory allocation event
 	VirtualAlloc = pack(windows.GUID{Data1: 0x3d6fa8d3, Data2: 0xfe05, Data3: 0x11d0, Data4: [8]byte{0x9d, 0xda, 0x00, 0xc0, 0x4f, 0xd7, 0xba, 0x7c}}, 98)
@@ -209,6 +211,8 @@ func (k Ktype) String() string {
 		return "CreateHandle"
 	case CloseHandle:
 		return "CloseHandle"
+	case DuplicateHandle:
+		return "DuplicateHandle"
 	case RegKCBRundown:
 		return "RegKCBRundown"
 	case RegOpenKey:
@@ -283,7 +287,7 @@ func (k Ktype) Category() Category {
 		SendTCPv4, SendTCPv6, SendUDPv4, SendUDPv6,
 		RecvTCPv4, RecvTCPv6, RecvUDPv4, RecvUDPv6:
 		return Net
-	case CreateHandle, CloseHandle:
+	case CreateHandle, CloseHandle, DuplicateHandle:
 		return Handle
 	case VirtualAlloc, VirtualFree:
 		return Mem
@@ -363,6 +367,8 @@ func (k Ktype) Description() string {
 		return "Creates a new handle"
 	case CloseHandle:
 		return "Closes the handle"
+	case DuplicateHandle:
+		return "Duplicates the handle"
 	case LoadDriver:
 		return "Loads the kernel driver"
 	case VirtualAlloc:

--- a/pkg/kevent/ktypes/metainfo_windows.go
+++ b/pkg/kevent/ktypes/metainfo_windows.go
@@ -78,6 +78,7 @@ var kevents = map[Ktype]KeventInfo{
 	UnloadImage:        {"UnloadImage", Image, "Unloads the module from the address space of the calling process"},
 	CreateHandle:       {"CreateHandle", Handle, "Creates a new handle"},
 	CloseHandle:        {"CloseHandle", Handle, "Closes the handle"},
+	DuplicateHandle:    {"DuplicateHandle", Handle, "Duplicates the handle"},
 	LoadDriver:         {"LoadDriver", Driver, "Loads the kernel driver"},
 	VirtualAlloc:       {"VirtualAlloc", Mem, "Reserves, commits, or changes the state of a region of memory within the process virtual address space"},
 	VirtualFree:        {"VirtualFree", Mem, "Releases or decommits a region of memory within the process virtual address space"},
@@ -130,6 +131,7 @@ var ktypes = map[string]Ktype{
 	"LoadDriver":         LoadDriver,
 	"VirtualAlloc":       VirtualAlloc,
 	"VirtualFree":        VirtualFree,
+	"DuplicateHandle":    DuplicateHandle,
 }
 
 // KtypeToKeventInfo maps the event type to the structure storing detailed information about the event.

--- a/pkg/kstream/processors/chain_windows.go
+++ b/pkg/kstream/processors/chain_windows.go
@@ -63,7 +63,7 @@ func NewChain(
 		chain.addProcessor(newNetProcessor())
 	}
 	if config.Kstream.EnableHandleKevents {
-		chain.addProcessor(newHandleProcessor(hsnap, devMapper, devPathResolver))
+		chain.addProcessor(newHandleProcessor(hsnap, psnap, devMapper, devPathResolver))
 	}
 	if config.Kstream.EnableMemKevents {
 		chain.addProcessor(newMemProcessor(psnap, vaRegionProber))

--- a/pkg/kstream/processors/handle_windows_test.go
+++ b/pkg/kstream/processors/handle_windows_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/kevent"
 	"github.com/rabbitstack/fibratus/pkg/kevent/kparams"
 	"github.com/rabbitstack/fibratus/pkg/kevent/ktypes"
+	"github.com/rabbitstack/fibratus/pkg/ps"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -92,7 +93,8 @@ func TestHandleProcessor(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			hsnap := tt.hsnap()
-			p := newHandleProcessor(hsnap, fs.NewDevMapper(), fs.NewDevPathResolver())
+			psnap := new(ps.SnapshotterMock)
+			p := newHandleProcessor(hsnap, psnap, fs.NewDevMapper(), fs.NewDevPathResolver())
 			var err error
 			tt.e, _, err = p.ProcessEvent(tt.e)
 			require.NoError(t, err)

--- a/pkg/outputs/eventlog/eventlog.go
+++ b/pkg/outputs/eventlog/eventlog.go
@@ -241,6 +241,8 @@ func ktypeToEventID(kevt *kevent.Kevent) uint32 {
 		return 49
 	case ktypes.VirtualFree:
 		return 50
+	case ktypes.DuplicateHandle:
+		return 51
 	}
 	return unknownEventID
 }

--- a/pkg/outputs/eventlog/mc/fibratus.mc
+++ b/pkg/outputs/eventlog/mc/fibratus.mc
@@ -226,3 +226,8 @@ SymbolicName=VirtualFree
 Language=English
 Releases or decommits a region of memory within the process virtual address space.
 .
+MessageId=50
+SymbolicName=DuplicateHandle
+Language=English
+Duplicates handle.
+.

--- a/rules/macros/macros.yml
+++ b/rules/macros/macros.yml
@@ -49,6 +49,9 @@
 - macro: virtual_free
   expr: kevt.name = 'VirtualFree'
 
+- macro: duplicate_handle
+  expr: kevt.name = 'DuplicateHandle'
+
 - macro: load_driver
   expr: >
     kevt.name = 'LoadDriver'


### PR DESCRIPTION
Introduce support for the `DuplicateHandle` event. As its name suggests, this event is captured as a response to the handle duplication operations. 