### PR TITLE
feat: Certifcate params/filter fields in PE images

### DIFF
--- a/pkg/filter/accessor_windows.go
+++ b/pkg/filter/accessor_windows.go
@@ -624,17 +624,9 @@ func (i *imageAccessor) get(f fields.Field, kevt *kevent.Kevent) (kparams.Value,
 	case fields.ImageName:
 		return kevt.GetParamAsString(kparams.ImageFilename), nil
 	case fields.ImageDefaultAddress:
-		address, err := kevt.Kparams.GetHex(kparams.ImageDefaultBase)
-		if err != nil {
-			return nil, err
-		}
-		return address.String(), nil
+		return kevt.GetParamAsString(kparams.ImageDefaultBase), nil
 	case fields.ImageBase:
-		address, err := kevt.Kparams.GetHex(kparams.ImageBase)
-		if err != nil {
-			return nil, err
-		}
-		return address.String(), nil
+		return kevt.GetParamAsString(kparams.ImageBase), nil
 	case fields.ImageSize:
 		return kevt.Kparams.GetUint64(kparams.ImageSize)
 	case fields.ImageChecksum:
@@ -645,6 +637,16 @@ func (i *imageAccessor) get(f fields.Field, kevt *kevent.Kevent) (kparams.Value,
 		return kevt.GetParamAsString(kparams.ImageSignatureType), nil
 	case fields.ImageSignatureLevel:
 		return kevt.GetParamAsString(kparams.ImageSignatureLevel), nil
+	case fields.ImageCertSubject:
+		return kevt.GetParamAsString(kparams.ImageCertSubject), nil
+	case fields.ImageCertIssuer:
+		return kevt.GetParamAsString(kparams.ImageCertIssuer), nil
+	case fields.ImageCertSerial:
+		return kevt.GetParamAsString(kparams.ImageCertSerial), nil
+	case fields.ImageCertBefore:
+		return kevt.Kparams.GetTime(kparams.ImageCertNotBefore)
+	case fields.ImageCertAfter:
+		return kevt.Kparams.GetTime(kparams.ImageCertNotAfter)
 	}
 	return nil, nil
 }
@@ -661,11 +663,7 @@ func (r *registryAccessor) get(f fields.Field, kevt *kevent.Kevent) (kparams.Val
 	case fields.RegistryKeyName:
 		return kevt.GetParamAsString(kparams.RegKeyName), nil
 	case fields.RegistryKeyHandle:
-		keyHandle, err := kevt.Kparams.GetHex(kparams.RegKeyHandle)
-		if err != nil {
-			return nil, err
-		}
-		return keyHandle.String(), nil
+		return kevt.GetParamAsString(kparams.RegKeyHandle), nil
 	case fields.RegistryValue:
 		return kevt.Kparams.GetRaw(kparams.RegValue)
 	case fields.RegistryValueType:
@@ -776,8 +774,8 @@ func (*peAccessor) get(f fields.Field, kevt *kevent.Kevent) (kparams.Value, erro
 		switch {
 		case f.IsPeSectionsMap():
 			// get the section name
-			sname, segment := captureInBrackets(f.String())
-			sec := p.Section(sname)
+			section, segment := captureInBrackets(f.String())
+			sec := p.Section(section)
 			if sec == nil {
 				return nil, nil
 			}

--- a/pkg/filter/fields/fields_windows.go
+++ b/pkg/filter/fields/fields_windows.go
@@ -336,6 +336,17 @@ const (
 	ImageSignatureType Field = "image.signature.type"
 	// ImageSignatureLevel represents the image signature level
 	ImageSignatureLevel Field = "image.signature.level"
+	// ImageCertSubject is the field that indicates the subject of the certificate is the entity its public key is associated with.
+	ImageCertSubject = "image.cert.subject"
+	// ImageCertIssuer is the field that represents the certificate authority (CA).
+	ImageCertIssuer = "image.cert.issuer"
+	// ImageCertSerial is the field that represents the serial number MUST be a positive integer assigned
+	// by the CA to each certificate.
+	ImageCertSerial = "image.cert.serial"
+	// ImageCertBefore is the field that specifies the certificate won't be valid before this timestamp.
+	ImageCertBefore = "image.cert.before"
+	// ImageCertAfter is the field that specifies the certificate won't be valid after this timestamp.
+	ImageCertAfter = "image.cert.after"
 
 	// MemBaseAddress identifies the field that denotes the allocation base address
 	MemBaseAddress Field = "mem.address"
@@ -517,6 +528,11 @@ var fields = map[Field]FieldInfo{
 	ImagePID:            {ImagePID, "target process identifier", kparams.Uint32, []string{"image.pid = 80"}, nil},
 	ImageSignatureType:  {ImageSignatureType, "image signature type", kparams.AnsiString, []string{"image.signature.type != 'NONE'"}, nil},
 	ImageSignatureLevel: {ImageSignatureLevel, "image signature level", kparams.AnsiString, []string{"image.signature.level = 'AUTHENTICODE'"}, nil},
+	ImageCertSerial:     {ImageCertSerial, "image certificate serial number", kparams.UnicodeString, []string{"image.cert.serial = '330000023241fb59996dcc4dff000000000232'"}, nil},
+	ImageCertSubject:    {ImageCertSubject, "image certificate subject", kparams.UnicodeString, []string{"image.cert.subject contains 'Washington, Redmond, Microsoft Corporation'"}, nil},
+	ImageCertIssuer:     {ImageCertIssuer, "image certificate CA", kparams.UnicodeString, []string{"image.cert.issuer contains 'Washington, Redmond, Microsoft Corporation'"}, nil},
+	ImageCertAfter:      {ImageCertAfter, "image certificate expiration date", kparams.Time, []string{"image.cert.after contains '2024-02-01 00:05:42 +0000 UTC'"}, nil},
+	ImageCertBefore:     {ImageCertBefore, "image certificate enrollment date", kparams.Time, []string{"image.cert.before contains '2024-02-01 00:05:42 +0000 UTC'"}, nil},
 
 	FileObject:     {FileObject, "file object address", kparams.Uint64, []string{"file.object = 18446738026482168384"}, nil},
 	FileName:       {FileName, "full file name", kparams.UnicodeString, []string{"file.name contains 'mimikatz'"}, nil},

--- a/pkg/kevent/backlog.go
+++ b/pkg/kevent/backlog.go
@@ -65,7 +65,7 @@ func (b *Backlog) Pop(evt *Kevent) *Kevent {
 	b.cache.Remove(key)
 	e := ev.(*Kevent)
 	e.Delayed = false
-	e.CopyParams(evt)
+	e.CopyState(evt)
 	return e
 }
 

--- a/pkg/kevent/kevent.go
+++ b/pkg/kevent/kevent.go
@@ -108,18 +108,6 @@ type Kevent struct {
 	Delayed bool `json:"delayed"`
 }
 
-// DelayKey returns the value that is used to
-// store and reference delayed events in the event
-// backlog state. The delayed event is indexed by
-// the sequence identifier.
-func (e *Kevent) DelayKey() uint64 {
-	switch e.Type {
-	case ktypes.CreateHandle, ktypes.CloseHandle:
-		return e.Kparams.MustGetUint64(kparams.HandleObject)
-	}
-	return 0
-}
-
 // String returns event's string representation.
 func (e *Kevent) String() string {
 	if e.PS != nil {

--- a/pkg/kevent/kevent_windows.go
+++ b/pkg/kevent/kevent_windows.go
@@ -368,6 +368,17 @@ func (e *Kevent) CopyParams(evt *Kevent) {
 			e.Kparams.Append(kparams.ImageFilename, kparams.UnicodeString, imageFilename)
 		}
 		_ = e.Kparams.SetValue(kparams.HandleObjectName, evt.GetParamAsString(kparams.HandleObjectName))
+		e.AppendParam(kparams.ImageCertIssuer, kparams.UnicodeString, evt.GetParamAsString(kparams.ImageCertIssuer))
+		e.AppendParam(kparams.ImageCertSubject, kparams.UnicodeString, evt.GetParamAsString(kparams.ImageCertSubject))
+		e.AppendParam(kparams.ImageCertSerial, kparams.UnicodeString, evt.GetParamAsString(kparams.ImageCertSerial))
+		after, err := e.Kparams.GetTime(kparams.ImageCertNotAfter)
+		if err == nil {
+			e.AppendParam(kparams.ImageCertNotAfter, kparams.Time, after)
+		}
+		before, err := e.Kparams.GetTime(kparams.ImageCertNotBefore)
+		if err == nil {
+			e.AppendParam(kparams.ImageCertNotBefore, kparams.Time, before)
+		}
 	}
 }
 

--- a/pkg/kevent/kevent_windows.go
+++ b/pkg/kevent/kevent_windows.go
@@ -131,6 +131,18 @@ func (e Kevent) IsDropped(capture bool) bool {
 	return DropCurrentProc && e.CurrentPid()
 }
 
+// DelayKey returns the value that is used to
+// store and reference delayed events in the event
+// backlog state. The delayed event is indexed by
+// the sequence identifier.
+func (e *Kevent) DelayKey() uint64 {
+	switch e.Type {
+	case ktypes.CreateHandle, ktypes.CloseHandle:
+		return e.Kparams.MustGetUint64(kparams.HandleObject)
+	}
+	return 0
+}
+
 // IsNetworkTCP determines whether the event pertains to network TCP events.
 func (e Kevent) IsNetworkTCP() bool {
 	return e.Category == ktypes.Net && !e.IsNetworkUDP()
@@ -359,26 +371,14 @@ func (e Kevent) PartialKey() uint64 {
 	return 0
 }
 
-// CopyParams appends parameters or other fields from the given event.
-func (e *Kevent) CopyParams(evt *Kevent) {
+// CopyState adds parameters, tags, or process state from the provided event.
+func (e *Kevent) CopyState(evt *Kevent) {
 	switch evt.Type {
 	case ktypes.CloseHandle:
 		if evt.Kparams.Contains(kparams.ImageFilename) {
-			imageFilename, _ := evt.Kparams.GetString(kparams.ImageFilename)
-			e.Kparams.Append(kparams.ImageFilename, kparams.UnicodeString, imageFilename)
+			e.Kparams.Append(kparams.ImageFilename, kparams.UnicodeString, evt.GetParamAsString(kparams.ImageFilename))
 		}
 		_ = e.Kparams.SetValue(kparams.HandleObjectName, evt.GetParamAsString(kparams.HandleObjectName))
-		e.AppendParam(kparams.ImageCertIssuer, kparams.UnicodeString, evt.GetParamAsString(kparams.ImageCertIssuer))
-		e.AppendParam(kparams.ImageCertSubject, kparams.UnicodeString, evt.GetParamAsString(kparams.ImageCertSubject))
-		e.AppendParam(kparams.ImageCertSerial, kparams.UnicodeString, evt.GetParamAsString(kparams.ImageCertSerial))
-		after, err := e.Kparams.GetTime(kparams.ImageCertNotAfter)
-		if err == nil {
-			e.AppendParam(kparams.ImageCertNotAfter, kparams.Time, after)
-		}
-		before, err := e.Kparams.GetTime(kparams.ImageCertNotBefore)
-		if err == nil {
-			e.AppendParam(kparams.ImageCertNotBefore, kparams.Time, before)
-		}
 	}
 }
 

--- a/pkg/kevent/kparams/fields_windows.go
+++ b/pkg/kevent/kparams/fields_windows.go
@@ -129,10 +129,21 @@ const (
 	ImageDefaultBase = "default_address"
 	// ImageFilename is the parameter name that denotes file name and extension of the DLL/executable image.
 	ImageFilename = "file_name"
-	// ImageSignatureLevel is the parameter denoting the loaded module signature level
+	// ImageSignatureLevel is the parameter denoting the loaded module signature level.
 	ImageSignatureLevel = "signature_level"
-	// ImageSignatureType is the parameter denoting the loaded module signature type
+	// ImageSignatureType is the parameter denoting the loaded module signature type.
 	ImageSignatureType = "signature_type"
+	// ImageCertSubject is the parameter that indicates the subject of the certificate is the entity its public key is associated with.
+	ImageCertSubject = "cert_subject"
+	// ImageCertIssuer is the parameter that represents the certificate authority (CA).
+	ImageCertIssuer = "cert_issuer"
+	// ImageCertSerial is the parameter that represents the serial number MUST be a positive integer assigned
+	// by the CA to each certificate.
+	ImageCertSerial = "cert_serial"
+	// ImageCertNotBefore  is the parameter that specifies the certificate won't be valid before this timestamp.
+	ImageCertNotBefore = "cert_not_before"
+	// ImageCertNotAfter is the parameter that specifies the certificate won't be valid after this timestamp.
+	ImageCertNotAfter = "cert_not_after"
 
 	// NetSize identifies the parameter name that represents the packet size.
 	NetSize = "size"

--- a/pkg/kstream/processors/fs_windows.go
+++ b/pkg/kstream/processors/fs_windows.go
@@ -123,10 +123,10 @@ func (f *fsProcessor) processEvent(e *kevent.Kevent) (*kevent.Kevent, error) {
 			opts := ev.Kparams.MustGetUint32(kparams.FileCreateOptions)
 			opts &= 0xFFFFFF
 			filename := ev.GetParamAsString(kparams.FileName)
-			f.devPathResolver.AddPath(filename)
 			fileinfo = f.getFileInfo(filename, opts)
 			f.files[fileObject] = fileinfo
 		}
+		f.devPathResolver.AddPath(ev.GetParamAsString(kparams.FileName))
 		ev.AppendParam(kparams.NTStatus, kparams.Status, status)
 		if fileinfo.Type != fs.Unknown {
 			ev.AppendEnum(kparams.FileType, uint32(fileinfo.Type), fs.FileTypes)

--- a/pkg/kstream/processors/handle_windows.go
+++ b/pkg/kstream/processors/handle_windows.go
@@ -26,7 +26,6 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/kevent/ktypes"
 	"github.com/rabbitstack/fibratus/pkg/ps"
 	"github.com/rabbitstack/fibratus/pkg/util/key"
-	"github.com/rabbitstack/fibratus/pkg/util/signature"
 	"strings"
 )
 
@@ -95,15 +94,6 @@ func (h *handleProcessor) processEvent(e *kevent.Kevent) (*kevent.Kevent, error)
 			}
 			h.devPathResolver.RemovePath(driverName)
 			e.Kparams.Append(kparams.ImageFilename, kparams.FilePath, driverPath)
-			// append driver certificate parameters
-			sign, err := signature.CheckWithOpts(driverPath, signature.OnlyCert())
-			if err == nil && sign.HasCertificate() {
-				e.AppendParam(kparams.ImageCertIssuer, kparams.UnicodeString, sign.Cert.Issuer)
-				e.AppendParam(kparams.ImageCertSubject, kparams.UnicodeString, sign.Cert.Subject)
-				e.AppendParam(kparams.ImageCertSerial, kparams.UnicodeString, sign.Cert.SerialNumber)
-				e.AppendParam(kparams.ImageCertNotAfter, kparams.Time, sign.Cert.NotAfter)
-				e.AppendParam(kparams.ImageCertNotBefore, kparams.Time, sign.Cert.NotBefore)
-			}
 		}
 		// assign the formatted handle name
 		if err := e.Kparams.SetValue(kparams.HandleObjectName, name); err != nil {

--- a/pkg/kstream/processors/handle_windows.go
+++ b/pkg/kstream/processors/handle_windows.go
@@ -26,6 +26,7 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/kevent/ktypes"
 	"github.com/rabbitstack/fibratus/pkg/ps"
 	"github.com/rabbitstack/fibratus/pkg/util/key"
+	"github.com/rabbitstack/fibratus/pkg/util/signature"
 	"strings"
 )
 
@@ -69,8 +70,10 @@ func (h *handleProcessor) processEvent(e *kevent.Kevent) (*kevent.Kevent, error)
 		}
 		return e, nil
 	}
+
 	name := e.GetParamAsString(kparams.HandleObjectName)
 	typ := e.GetParamAsString(kparams.HandleObjectTypeID)
+
 	if name != "" {
 		switch typ {
 		case handle.Key:
@@ -92,6 +95,15 @@ func (h *handleProcessor) processEvent(e *kevent.Kevent) (*kevent.Kevent, error)
 			}
 			h.devPathResolver.RemovePath(driverName)
 			e.Kparams.Append(kparams.ImageFilename, kparams.FilePath, driverPath)
+			// append driver certificate parameters
+			sign, err := signature.CheckWithOpts(driverPath, signature.OnlyCert())
+			if err == nil && sign.HasCertificate() {
+				e.AppendParam(kparams.ImageCertIssuer, kparams.UnicodeString, sign.Cert.Issuer)
+				e.AppendParam(kparams.ImageCertSubject, kparams.UnicodeString, sign.Cert.Subject)
+				e.AppendParam(kparams.ImageCertSerial, kparams.UnicodeString, sign.Cert.SerialNumber)
+				e.AppendParam(kparams.ImageCertNotAfter, kparams.Time, sign.Cert.NotAfter)
+				e.AppendParam(kparams.ImageCertNotBefore, kparams.Time, sign.Cert.NotBefore)
+			}
 		}
 		// assign the formatted handle name
 		if err := e.Kparams.SetValue(kparams.HandleObjectName, name); err != nil {

--- a/pkg/pe/parser.go
+++ b/pkg/pe/parser.go
@@ -297,6 +297,15 @@ func parse(path string, data []byte, options ...Option) (*PE, error) {
 
 	if opts.parseSecurity {
 		p.IsSigned = pe.IsSigned
+		if pe.HasCertificate {
+			p.Cert = &Cert{
+				Issuer:       pe.Certificates.Info.Issuer,
+				Subject:      pe.Certificates.Info.Subject,
+				NotBefore:    pe.Certificates.Info.NotBefore,
+				NotAfter:     pe.Certificates.Info.NotAfter,
+				SerialNumber: pe.Certificates.Info.SerialNumber,
+			}
+		}
 	}
 
 	return p, nil

--- a/pkg/pe/types.go
+++ b/pkg/pe/types.go
@@ -51,6 +51,30 @@ type Sec struct {
 	Md5     string
 }
 
+// Cert represents certificate information embedded in PE.
+type Cert struct {
+	// Issuer represents the certificate authority (CA) that charges customers to issue
+	// certificates for them.
+	Issuer string `json:"issuer"`
+
+	// Subject indicates the subject of the certificate is the entity its public key is associated
+	// with (i.e. the "owner" of the certificate).
+	Subject string `json:"subject"`
+
+	// NotBefore specifies the certificate won't be valid before this timestamp.
+	NotBefore time.Time `json:"not_before"`
+
+	// NotAfter specifies the certificate won't be valid after this timestamp.
+	NotAfter time.Time `json:"not_after"`
+
+	// SerialNumber represents the serial number MUST be a positive integer assigned
+	// by the CA to each certificate. It MUST be unique for each certificate issued by
+	// a given CA (i.e., the issuer name and serial number identify a unique certificate).
+	// CAs MUST force the serialNumber to be a non-negative integer.
+	// For convenience, we convert the big int to string.
+	SerialNumber string `json:"serial_number"`
+}
+
 // String returns the stirng representation of the section.
 func (s Sec) String() string {
 	return fmt.Sprintf("Name: %s, Size: %d, Entropy: %f, Md5: %s", s.Name, s.Size, s.Entropy, s.Md5)
@@ -78,6 +102,8 @@ type PE struct {
 	VersionResources map[string]string `json:"resources"`
 	// IsSigned determines if the PE contains the digital signature.
 	IsSigned bool `json:"is_signed"`
+	// Cert contains certificate information.
+	Cert *Cert `json:"cert"`
 }
 
 // String returns the string representation of the PE metadata.

--- a/pkg/ps/snapshotter_windows.go
+++ b/pkg/ps/snapshotter_windows.go
@@ -209,8 +209,8 @@ func (s *snapshotter) AddModule(e *kevent.Kevent) error {
 	module.Name = e.GetParamAsString(kparams.ImageFilename)
 	module.BaseAddress, _ = e.Kparams.GetHex(kparams.ImageBase)
 	module.DefaultBaseAddress, _ = e.Kparams.GetHex(kparams.ImageDefaultBase)
-	module.SignatureLevel = e.Kparams.MustGetUint32(kparams.ImageSignatureLevel)
-	module.SignatureType = e.Kparams.MustGetUint32(kparams.ImageSignatureType)
+	module.SignatureLevel, _ = e.Kparams.GetUint32(kparams.ImageSignatureLevel)
+	module.SignatureType, _ = e.Kparams.GetUint32(kparams.ImageSignatureType)
 	proc.AddModule(module)
 	return nil
 }

--- a/pkg/ps/snapshotter_windows.go
+++ b/pkg/ps/snapshotter_windows.go
@@ -196,6 +196,9 @@ func (s *snapshotter) AddModule(e *kevent.Kevent) error {
 	moduleCount.Add(1)
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if pid == 0 {
+		pid = e.PID
+	}
 	proc, ok := s.procs[pid]
 	if !ok {
 		return nil
@@ -206,6 +209,8 @@ func (s *snapshotter) AddModule(e *kevent.Kevent) error {
 	module.Name = e.GetParamAsString(kparams.ImageFilename)
 	module.BaseAddress, _ = e.Kparams.GetHex(kparams.ImageBase)
 	module.DefaultBaseAddress, _ = e.Kparams.GetHex(kparams.ImageDefaultBase)
+	module.SignatureLevel = e.Kparams.MustGetUint32(kparams.ImageSignatureLevel)
+	module.SignatureType = e.Kparams.MustGetUint32(kparams.ImageSignatureType)
 	proc.AddModule(module)
 	return nil
 }

--- a/pkg/ps/snapshotter_windows_test.go
+++ b/pkg/ps/snapshotter_windows_test.go
@@ -399,7 +399,7 @@ func TestAddModule(t *testing.T) {
 			ok, proc := psnap.Find(evt.Kparams.MustGetPid())
 			require.Equal(t, exists, ok)
 			if ok {
-				require.NotNil(t, proc.FindModule(filepath.Base(evt.GetParamAsString(kparams.ImageFilename))))
+				require.NotNil(t, proc.FindModule(evt.GetParamAsString(kparams.ImageFilename)))
 			}
 		})
 	}

--- a/pkg/ps/types/types_windows.go
+++ b/pkg/ps/types/types_windows.go
@@ -208,6 +208,10 @@ type Module struct {
 	BaseAddress kparams.Hex
 	// DefaultBaseAddress is the default base address.
 	DefaultBaseAddress kparams.Hex
+	// SignatureLevel designates the image signature level. (e.g. MICROSOFT)
+	SignatureLevel uint32
+	// SignatureType designates the image signature type (e.g. EMBEDDED)
+	SignatureType uint32
 }
 
 // String returns the string representation of the module.

--- a/pkg/ps/types/types_windows.go
+++ b/pkg/ps/types/types_windows.go
@@ -284,17 +284,17 @@ func (ps *PS) RemoveHandle(handle windows.Handle) {
 
 // AddModule adds a new module to this process state.
 func (ps *PS) AddModule(mod Module) {
-	m := ps.FindModule(filepath.Base(mod.Name))
+	m := ps.FindModule(mod.Name)
 	if m != nil {
 		return
 	}
 	ps.Modules = append(ps.Modules, mod)
 }
 
-// RemoveModule removes a module with specified full-path from this process state.
-func (ps *PS) RemoveModule(name string) {
+// RemoveModule removes a specified module from this process state.
+func (ps *PS) RemoveModule(path string) {
 	for i, mod := range ps.Modules {
-		if mod.Name == name {
+		if filepath.Base(mod.Name) == filepath.Base(path) {
 			ps.Modules = append(ps.Modules[:i], ps.Modules[i+1:]...)
 			break
 		}
@@ -302,9 +302,9 @@ func (ps *PS) RemoveModule(name string) {
 }
 
 // FindModule finds the module by name.
-func (ps *PS) FindModule(name string) *Module {
+func (ps *PS) FindModule(path string) *Module {
 	for _, mod := range ps.Modules {
-		if filepath.Base(mod.Name) == name {
+		if filepath.Base(mod.Name) == filepath.Base(path) {
 			return &mod
 		}
 	}


### PR DESCRIPTION
In addition to signature type and signature level parameters, it is valuable to gain access to the certificate parameters. This PR decorated image load events with signature certificate params and exposes a set of filter fields to access the certificate info.