### PR TITLE
fix: Diagnose Yara scanner hanging indefinitely 

### DIFF
--- a/pkg/filter/ql/functions/yara.go
+++ b/pkg/filter/ql/functions/yara.go
@@ -62,7 +62,6 @@ func (f Yara) Call(args []interface{}) (interface{}, bool) {
 		log.Warnf("erroneous scanner in YARA function: %v: %s", err, rules)
 		return false, true
 	}
-	defer scanner.Destroy()
 
 	var cb yara.MatchRules
 	switch n := args[0].(type) {
@@ -107,7 +106,6 @@ func (f Yara) newScanner(rules string, vars map[string]interface{}) (*yara.Scann
 	if err != nil {
 		return nil, err
 	}
-	defer c.Destroy()
 	if err := c.AddString(rules, ""); err != nil {
 		return nil, err
 	}

--- a/pkg/yara/scanner.go
+++ b/pkg/yara/scanner.go
@@ -192,11 +192,11 @@ func (s scanner) Scan(evt *kevent.Kevent) (bool, error) {
 			return false, nil
 		}
 		alertCtx.PS = proc
-		err = sn.SetCallback(&matches).ScanProc(int(pid))
+		//err = sn.SetCallback(&matches).ScanProc(int(pid))
 	case ktypes.LoadImage:
 		filename := evt.GetParamAsString(kparams.ImageFilename)
 		alertCtx.Filename = filename
-		err = sn.SetCallback(&matches).ScanFile(filename)
+		//err = sn.SetCallback(&matches).ScanFile(filename)
 	}
 
 	if err != nil {

--- a/pkg/yara/scanner.go
+++ b/pkg/yara/scanner.go
@@ -172,11 +172,13 @@ func (s scanner) Scan(evt *kevent.Kevent) (bool, error) {
 	if !evt.IsCreateProcess() && !evt.IsLoadImage() {
 		return false, nil
 	}
+
 	var matches yara.MatchRules
 	sn, err := s.newInternalScanner()
 	if err != nil {
 		return false, err
 	}
+
 	alertCtx := AlertContext{
 		Timestamp: time.Now().Format(tsLayout),
 	}
@@ -192,11 +194,11 @@ func (s scanner) Scan(evt *kevent.Kevent) (bool, error) {
 			return false, nil
 		}
 		alertCtx.PS = proc
-		//err = sn.SetCallback(&matches).ScanProc(int(pid))
+		err = sn.SetCallback(&matches).ScanProc(int(pid))
 	case ktypes.LoadImage:
 		filename := evt.GetParamAsString(kparams.ImageFilename)
 		alertCtx.Filename = filename
-		//err = sn.SetCallback(&matches).ScanFile(filename)
+		err = sn.SetCallback(&matches).ScanFile(filename)
 	}
 
 	if err != nil {

--- a/pkg/yara/scanner.go
+++ b/pkg/yara/scanner.go
@@ -177,7 +177,6 @@ func (s scanner) Scan(evt *kevent.Kevent) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer sn.Destroy()
 	alertCtx := AlertContext{
 		Timestamp: time.Now().Format(tsLayout),
 	}

--- a/pkg/yara/scanner_test.go
+++ b/pkg/yara/scanner_test.go
@@ -202,13 +202,13 @@ func TestScan(t *testing.T) {
 
 	// test file scanning on DLL that merely contains
 	// the fmt.Println("Go Yara DLL Test") statement
-	match, err = s.Scan(kevt)
-	require.NoError(t, err)
-	require.True(t, match)
-	require.NotNil(t, yaraAlert)
-
-	assert.Equal(t, "YARA alert on file _fixtures/yara-test.dll", yaraAlert.Title)
-	assert.Contains(t, yaraAlert.Tags, "dll")
+	//match, err = s.Scan(kevt)
+	//require.NoError(t, err)
+	//require.True(t, match)
+	//require.NotNil(t, yaraAlert)
+	//
+	//assert.Equal(t, "YARA alert on file _fixtures/yara-test.dll", yaraAlert.Title)
+	//assert.Contains(t, yaraAlert.Tags, "dll")
 }
 
 func TestMatchesMeta(t *testing.T) {

--- a/pkg/yara/scanner_test.go
+++ b/pkg/yara/scanner_test.go
@@ -191,24 +191,24 @@ func TestScan(t *testing.T) {
 	}
 
 	// test attaching on pid
-	match, err := s.Scan(kevt)
-	require.NoError(t, err)
-	require.True(t, match)
-	require.NotNil(t, yaraAlert)
-
-	assert.Equal(t, "YARA alert on process notepad.exe", yaraAlert.Title)
-	assert.NotEmpty(t, yaraAlert.Text)
-	assert.Contains(t, yaraAlert.Tags, "notepad")
-
-	// test file scanning on DLL that merely contains
-	// the fmt.Println("Go Yara DLL Test") statement
-	//match, err = s.Scan(kevt)
+	//match, err := s.Scan(kevt)
 	//require.NoError(t, err)
 	//require.True(t, match)
 	//require.NotNil(t, yaraAlert)
 	//
-	//assert.Equal(t, "YARA alert on file _fixtures/yara-test.dll", yaraAlert.Title)
-	//assert.Contains(t, yaraAlert.Tags, "dll")
+	//assert.Equal(t, "YARA alert on process notepad.exe", yaraAlert.Title)
+	//assert.NotEmpty(t, yaraAlert.Text)
+	//assert.Contains(t, yaraAlert.Tags, "notepad")
+
+	// test file scanning on DLL that merely contains
+	// the fmt.Println("Go Yara DLL Test") statement
+	match, err = s.Scan(kevt)
+	require.NoError(t, err)
+	require.True(t, match)
+	require.NotNil(t, yaraAlert)
+
+	assert.Equal(t, "YARA alert on file _fixtures/yara-test.dll", yaraAlert.Title)
+	assert.Contains(t, yaraAlert.Tags, "dll")
 }
 
 func TestMatchesMeta(t *testing.T) {

--- a/pkg/yara/scanner_test.go
+++ b/pkg/yara/scanner_test.go
@@ -191,18 +191,18 @@ func TestScan(t *testing.T) {
 	}
 
 	// test attaching on pid
-	//match, err := s.Scan(kevt)
-	//require.NoError(t, err)
-	//require.True(t, match)
-	//require.NotNil(t, yaraAlert)
-	//
-	//assert.Equal(t, "YARA alert on process notepad.exe", yaraAlert.Title)
-	//assert.NotEmpty(t, yaraAlert.Text)
-	//assert.Contains(t, yaraAlert.Tags, "notepad")
+	match, err := s.Scan(kevt)
+	require.NoError(t, err)
+	require.True(t, match)
+	require.NotNil(t, yaraAlert)
+
+	assert.Equal(t, "YARA alert on process notepad.exe", yaraAlert.Title)
+	assert.NotEmpty(t, yaraAlert.Text)
+	assert.Contains(t, yaraAlert.Tags, "notepad")
 
 	// test file scanning on DLL that merely contains
 	// the fmt.Println("Go Yara DLL Test") statement
-	match, err := s.Scan(kevt)
+	match, err = s.Scan(kevt)
 	require.NoError(t, err)
 	require.True(t, match)
 	require.NotNil(t, yaraAlert)

--- a/pkg/yara/scanner_test.go
+++ b/pkg/yara/scanner_test.go
@@ -202,7 +202,7 @@ func TestScan(t *testing.T) {
 
 	// test file scanning on DLL that merely contains
 	// the fmt.Println("Go Yara DLL Test") statement
-	match, err = s.Scan(kevt)
+	match, err := s.Scan(kevt)
 	require.NoError(t, err)
 	require.True(t, match)
 	require.NotNil(t, yaraAlert)

--- a/pkg/yara/scanner_test.go
+++ b/pkg/yara/scanner_test.go
@@ -68,7 +68,6 @@ func init() {
 }
 
 func TestScan(t *testing.T) {
-	t.SkipNow()
 	psnap := new(ps.SnapshotterMock)
 	require.NoError(t, alertsender.LoadAll([]alertsender.Config{{Type: alertsender.Noop}}))
 


### PR DESCRIPTION
One possible cause of Yara scanner stalls could be the explicit disposal of the scanner instance. Thus, let's try to delegate the scanner destruction to the runtime finalizer and check if the issue persists.