### PR TITLE
feat(kevent): DNS events

### DIFF
--- a/configs/fibratus.yml
+++ b/configs/fibratus.yml
@@ -187,6 +187,9 @@ kstream:
   # Determines whether kernel Audit API calls events are collected
   #enable-audit-api: true
 
+  # Determines whether DNS client events are collected
+  #enable-dns: true
+
   # Determines which events are dropped either by the event name or the process' image
   # name that triggered the event.
   blacklist:

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -344,6 +344,7 @@ func (c *Config) addFlags() {
 		c.flags.Bool(enableHandleKevents, false, "Determines whether object manager kernel events (handle creation/destruction) are collected by Kernel Logger provider")
 		c.flags.Bool(enableMemKevents, true, "Determines whether memory manager kernel events are collected by Kernel Logger provider")
 		c.flags.Bool(enableAuditAPIEvents, true, "Determines whether kernel audit API calls events are published")
+		c.flags.Bool(enableDNSEvents, true, "Determines whether DNS client events are enabled")
 		c.flags.Int(bufferSize, int(maxBufferSize), "Represents the amount of memory allocated for each event tracing session buffer, in kilobytes. The buffer size affects the rate at which buffers fill and must be flushed (small buffer size requires less memory but it increases the rate at which buffers must be flushed)")
 		c.flags.Int(minBuffers, int(defaultMinBuffers), "Determines the minimum number of buffers allocated for the event tracing session's buffer pool")
 		c.flags.Int(maxBuffers, int(defaultMaxBuffers), "Determines the maximum number of buffers allocated for the event tracing session's buffer pool")

--- a/pkg/config/kstream.go
+++ b/pkg/config/kstream.go
@@ -40,6 +40,7 @@ const (
 	enableHandleKevents   = "kstream.enable-handle"
 	enableMemKevents      = "kstream.enable-mem"
 	enableAuditAPIEvents  = "kstream.enable-audit-api"
+	enableDNSEvents       = "kstream.enable-dns"
 	bufferSize            = "kstream.buffer-size"
 	minBuffers            = "kstream.min-buffers"
 	maxBuffers            = "kstream.max-buffers"
@@ -75,6 +76,8 @@ type KstreamConfig struct {
 	EnableMemKevents bool `json:"enable-memory" yaml:"enable-memory"`
 	// EnableAuditAPIEvents indicates if kernel audit API calls events are enabled
 	EnableAuditAPIEvents bool `json:"enable-audit-api" yaml:"enable-audit-api"`
+	// EnableDNSEvents indicates if DNS client events are enabled
+	EnableDNSEvents bool `json:"enable-dns" yaml:"enable-dns"`
 	// BufferSize represents the amount of memory allocated for each event tracing session buffer, in kilobytes.
 	// The buffer size affects the rate at which buffers fill and must be flushed (small buffer size requires
 	// less memory, but it increases the rate at which buffers must be flushed).
@@ -103,6 +106,7 @@ func (c *KstreamConfig) initFromViper(v *viper.Viper) {
 	c.EnableHandleKevents = v.GetBool(enableHandleKevents)
 	c.EnableMemKevents = v.GetBool(enableMemKevents)
 	c.EnableAuditAPIEvents = v.GetBool(enableAuditAPIEvents)
+	c.EnableDNSEvents = v.GetBool(enableDNSEvents)
 	c.BufferSize = uint32(v.GetInt(bufferSize))
 	c.MinBuffers = uint32(v.GetInt(minBuffers))
 	c.MaxBuffers = uint32(v.GetInt(maxBuffers))

--- a/pkg/config/schema_windows.go
+++ b/pkg/config/schema_windows.go
@@ -163,6 +163,7 @@ var schema = `
 				"enable-net": 		{"type": "boolean"},
 				"enable-mem": 		{"type": "boolean"},
 				"enable-audit-api": {"type": "boolean"},
+				"enable-dns": 		{"type": "boolean"},
 				"min-buffers": 		{"type": "integer", "minimum": 1, "maximum": {{ .MinBuffers }}},
 				"max-buffers": 		{"type": "integer", "minimum": 2, "maximum": {{ .MaxBuffers }}},
 				"buffer-size":		{"type": "integer", "maximum": {{ .MaxBufferSize }}},

--- a/pkg/filter/accessor.go
+++ b/pkg/filter/accessor.go
@@ -129,6 +129,7 @@ func (f *filter) narrowAccessors() {
 		removeHandleAccessor   = true
 		removePEAccessor       = true
 		removeMemAccessor      = true
+		removeDNSAccessor      = true
 	)
 	allFields := make([]fields.Field, 0)
 	allFields = append(allFields, f.fields...)
@@ -157,6 +158,8 @@ func (f *filter) narrowAccessors() {
 			removePEAccessor = false
 		case field.IsMemField():
 			removeMemAccessor = false
+		case field.IsDNSField():
+			removeDNSAccessor = false
 		}
 	}
 	if removeKevtAccessor {
@@ -188,6 +191,9 @@ func (f *filter) narrowAccessors() {
 	}
 	if removeMemAccessor {
 		f.removeAccessor(&memAccessor{})
+	}
+	if removeDNSAccessor {
+		f.removeAccessor(&dnsAccessor{})
 	}
 }
 

--- a/pkg/filter/accessor_windows.go
+++ b/pkg/filter/accessor_windows.go
@@ -47,6 +47,7 @@ func getAccessors() []accessor {
 		newPSAccessor(nil),
 		newPEAccessor(),
 		newMemAccessor(),
+		newDNSAccessor(),
 		newFileAccessor(),
 		newKevtAccessor(),
 		newImageAccessor(),
@@ -833,6 +834,29 @@ func (*memAccessor) get(f fields.Field, kevt *kevent.Kevent) (kparams.Value, err
 		return kevt.Kparams.GetUint64(kparams.MemRegionSize)
 	case fields.MemProtectionMask:
 		return kevt.Kparams.GetString(kparams.MemProtectMask)
+	}
+	return nil, nil
+}
+
+// dnsAccessor extracts values from DNS query/response event parameters.
+type dnsAccessor struct{}
+
+func newDNSAccessor() accessor {
+	return &dnsAccessor{}
+}
+
+func (*dnsAccessor) get(f fields.Field, kevt *kevent.Kevent) (kparams.Value, error) {
+	switch f {
+	case fields.DNSName:
+		return kevt.GetParamAsString(kparams.DNSName), nil
+	case fields.DNSRR:
+		return kevt.GetParamAsString(kparams.DNSRR), nil
+	case fields.DNSRcode:
+		return kevt.GetParamAsString(kparams.DNSRcode), nil
+	case fields.DNSOptions:
+		return kevt.GetFlagsAsSlice(kparams.DNSOpts), nil
+	case fields.DNSAnswers:
+		return kevt.Kparams.GetSlice(kparams.DNSAnswers)
 	}
 	return nil, nil
 }

--- a/pkg/filter/fields/fields_windows.go
+++ b/pkg/filter/fields/fields_windows.go
@@ -367,6 +367,17 @@ const (
 	// MemProtectionMask identifies the field that represents the memory protection in mask notation
 	MemProtectionMask Field = "mem.protection.mask"
 
+	// DNSName identifies the field that represents the DNS name
+	DNSName Field = "dns.name"
+	// DNSRR identifies the field that represents the DNS record type
+	DNSRR Field = "dns.rr"
+	// DNSOptions identifies the field that represents the DNS options
+	DNSOptions Field = "dns.options"
+	// DNSAnswers identifies the field that represents the DNS answers
+	DNSAnswers Field = "dns.answers"
+	// DNSRcode identifies the field that represents the DNS response code
+	DNSRcode Field = "dns.rcode"
+
 	// None represents the unknown field
 	None Field = ""
 )
@@ -384,6 +395,7 @@ func (f Field) IsNetworkField() bool  { return strings.HasPrefix(string(f), "net
 func (f Field) IsHandleField() bool   { return strings.HasPrefix(string(f), "handle.") }
 func (f Field) IsPeField() bool       { return strings.HasPrefix(string(f), "pe.") }
 func (f Field) IsMemField() bool      { return strings.HasPrefix(string(f), "mem.") }
+func (f Field) IsDNSField() bool      { return strings.HasPrefix(string(f), "dns.") }
 
 // Segment represents the type alias for the segment. Segment
 // denotes the location of the value within an indexed field.

--- a/pkg/filter/fields/fields_windows.go
+++ b/pkg/filter/fields/fields_windows.go
@@ -610,6 +610,12 @@ var fields = map[Field]FieldInfo{
 	MemPageType:       {MemPageType, "page type of the allocated region", kparams.Enum, []string{"mem.type = 'PRIVATE'"}, nil},
 	MemProtection:     {MemProtection, "allocated region protection type", kparams.Enum, []string{"mem.protection = 'READWRITE'"}, nil},
 	MemProtectionMask: {MemProtectionMask, "allocated region protection in mask notation", kparams.Enum, []string{"mem.protection.mask = 'RWX'"}, nil},
+
+	DNSName:    {DNSName, "dns query name", kparams.UnicodeString, []string{"dns.name = 'example.org'"}, nil},
+	DNSRR:      {DNSRR, "dns resource record type", kparams.AnsiString, []string{"dns.rr = 'AA'"}, nil},
+	DNSOptions: {DNSOptions, "dns query options", kparams.Flags64, []string{"dns.options in ('ADDRCONFIG', 'DUAL_ADDR')"}, nil},
+	DNSRcode:   {DNSRR, "dns response status", kparams.AnsiString, []string{"dns.rcode = 'NXDOMAIN'"}, nil},
+	DNSAnswers: {DNSAnswers, "dns response answers", kparams.Slice, []string{"dns.answers in ('o.lencr.edgesuite.net', 'a1887.dscq.akamai.net')"}, nil},
 }
 
 // Lookup finds the field literal in the map. For the nested fields, it checks the pattern matches

--- a/pkg/filter/filter_windows.go
+++ b/pkg/filter/filter_windows.go
@@ -79,6 +79,9 @@ func New(expr string, config *config.Config, options ...Option) Filter {
 	if kconfig.EnableMemKevents {
 		accessors = append(accessors, newMemAccessor())
 	}
+	if kconfig.EnableDNSEvents {
+		accessors = append(accessors, newDNSAccessor())
+	}
 	if config.PE.Enabled {
 		accessors = append(accessors, newPEAccessor())
 	}

--- a/pkg/kcap/reader_windows.go
+++ b/pkg/kcap/reader_windows.go
@@ -134,7 +134,7 @@ func (r *reader) Read(ctx context.Context) (chan *kevent.Kevent, chan error) {
 				}
 				break
 			}
-			kevt, err := kevent.NewFromKcap(buf)
+			kevt, err := kevent.NewFromKcap(buf, sec.Version())
 			if err != nil {
 				errsc <- fmt.Errorf("fail to unmarshal kevent: %v", err)
 				kcapKeventUnmarshalErrors.Add(1)

--- a/pkg/kcap/version/version_windows.go
+++ b/pkg/kcap/version/version_windows.go
@@ -22,8 +22,10 @@ package version
 type Version uint16
 
 const (
-	// KevtSecV1 is the v1 of the kernel event section
+	// KevtSecV1 is the v1 of the event section
 	KevtSecV1 Version = iota + 1
+	// KevtSecV2 is the v2 of the event section
+	KevtSecV2
 )
 
 const (

--- a/pkg/kevent/enum.go
+++ b/pkg/kevent/enum.go
@@ -18,7 +18,10 @@
 
 package kevent
 
-import "github.com/rabbitstack/fibratus/pkg/util/va"
+import (
+	"github.com/rabbitstack/fibratus/pkg/util/va"
+	"golang.org/x/sys/windows"
+)
 
 // ViewSectionTypes describes possible values for process mapped sections.
 var ViewSectionTypes = ParamEnum{
@@ -27,4 +30,87 @@ var ViewSectionTypes = ParamEnum{
 	va.SectionImageNoExecute: "IMAGE_NO_EXECUTE",
 	va.SectionPagefile:       "PAGEFILE",
 	va.SectionPhysical:       "PHYSICAL",
+}
+
+// DNSRecordTypes describes DNS record type values.
+var DNSRecordTypes = ParamEnum{
+	windows.DNS_TYPE_A:       "A",
+	windows.DNS_TYPE_NS:      "NS",
+	windows.DNS_TYPE_MD:      "MD",
+	windows.DNS_TYPE_MF:      "MF",
+	windows.DNS_TYPE_CNAME:   "CNAME",
+	windows.DNS_TYPE_SOA:     "SOA",
+	windows.DNS_TYPE_MB:      "MB",
+	windows.DNS_TYPE_MG:      "MG",
+	windows.DNS_TYPE_MR:      "MR",
+	windows.DNS_TYPE_NULL:    "NULL",
+	windows.DNS_TYPE_WKS:     "WKS",
+	windows.DNS_TYPE_PTR:     "PTR",
+	windows.DNS_TYPE_HINFO:   "HINFO",
+	windows.DNS_TYPE_MINFO:   "MINFO",
+	windows.DNS_TYPE_MX:      "MX",
+	windows.DNS_TYPE_TEXT:    "TEXT",
+	windows.DNS_TYPE_RP:      "RP",
+	windows.DNS_TYPE_AFSDB:   "AFSDB",
+	windows.DNS_TYPE_X25:     "X25",
+	windows.DNS_TYPE_ISDN:    "ISDN",
+	windows.DNS_TYPE_NSAPPTR: "NSAPPTR",
+	windows.DNS_TYPE_SIG:     "SIG",
+	windows.DNS_TYPE_KEY:     "KEY",
+	windows.DNS_TYPE_PX:      "PX",
+	windows.DNS_TYPE_GPOS:    "GPOS",
+	windows.DNS_TYPE_AAAA:    "AAAA",
+	windows.DNS_TYPE_LOC:     "LOC",
+	windows.DNS_TYPE_NXT:     "NXT",
+	windows.DNS_TYPE_EID:     "EID",
+	windows.DNS_TYPE_NIMLOC:  "NIMLOC",
+	windows.DNS_TYPE_SRV:     "SRV",
+	windows.DNS_TYPE_ATMA:    "ATMA",
+	windows.DNS_TYPE_NAPTR:   "NAPTR",
+	windows.DNS_TYPE_KX:      "KX",
+	windows.DNS_TYPE_CERT:    "CERT",
+	windows.DNS_TYPE_A6:      "A6",
+	windows.DNS_TYPE_DNAME:   "DNAME",
+	windows.DNS_TYPE_SINK:    "SINK",
+	windows.DNS_TYPE_OPT:     "OPT",
+	windows.DNS_TYPE_DS:      "DS",
+	windows.DNS_TYPE_RRSIG:   "RRSIG",
+	windows.DNS_TYPE_NSEC:    "NSEC",
+	windows.DNS_TYPE_DNSKEY:  "DNSKEY",
+	windows.DNS_TYPE_DHCID:   "DHCID",
+	windows.DNS_TYPE_UINFO:   "UINFO",
+	windows.DNS_TYPE_UID:     "UID",
+	windows.DNS_TYPE_GID:     "GID",
+	windows.DNS_TYPE_UNSPEC:  "UNSPEC",
+	windows.DNS_TYPE_ADDRS:   "ADDRS",
+	windows.DNS_TYPE_TKEY:    "TKEY",
+	windows.DNS_TYPE_TSIG:    "TSIG",
+	windows.DNS_TYPE_IXFR:    "IXFR",
+	windows.DNS_TYPE_AXFR:    "AXFR",
+	windows.DNS_TYPE_MAILB:   "MAILB",
+	windows.DNS_TYPE_MAILA:   "MAILA",
+	windows.DNS_TYPE_ANY:     "ANY",
+	windows.DNS_TYPE_WINS:    "WINS",
+	windows.DNS_TYPE_WINSR:   "WINSR",
+}
+
+// DNSResponseCodes describes DNS response codes.
+var DNSResponseCodes = ParamEnum{
+	uint32(windows.DNS_ERROR_RCODE_NO_ERROR):        "NOERROR",
+	uint32(windows.DNS_ERROR_RCODE_FORMAT_ERROR):    "FORMERR",
+	uint32(windows.DNS_ERROR_RCODE_SERVER_FAILURE):  "SERVFAIL",
+	uint32(windows.DNS_ERROR_RCODE_NAME_ERROR):      "NXDOMAIN",
+	uint32(windows.DNS_ERROR_RCODE_NOT_IMPLEMENTED): "NOTIMP",
+	uint32(windows.DNS_ERROR_RCODE_REFUSED):         "REFUSED",
+	uint32(windows.DNS_ERROR_RCODE_YXDOMAIN):        "YXDOMAIN",
+	uint32(windows.DNS_ERROR_RCODE_YXRRSET):         "YXRRSET",
+	uint32(windows.DNS_ERROR_RCODE_NXRRSET):         "NXRRSET",
+	uint32(windows.DNS_ERROR_RCODE_NOTAUTH):         "NOTAUTH",
+	uint32(windows.DNS_ERROR_RCODE_NOTZONE):         "NOTZONE",
+	uint32(windows.DNS_ERROR_RCODE_BADSIG):          "BADSIG",
+	uint32(windows.DNS_ERROR_RCODE_BADKEY):          "BADKEY",
+	uint32(windows.DNS_ERROR_RCODE_BADTIME):         "BADTIME",
+	uint32(windows.DNS_ERROR_INVALID_NAME):          "BADNAME",
+	uint32(windows.ERROR_INVALID_PARAMETER):         "INVALID",
+	uint32(windows.DNS_INFO_NO_RECORDS):             "NXDOMAIN",
 }

--- a/pkg/kevent/flags.go
+++ b/pkg/kevent/flags.go
@@ -26,10 +26,10 @@ import (
 // ParamFlag defines the mapping between the flag value and its symbolical name.
 type ParamFlag struct {
 	Name  string
-	Value uint32
+	Value uint64
 }
 
-func (f ParamFlag) eval(v uint32) bool {
+func (f ParamFlag) eval(v uint64) bool {
 	return (v == 0 && f.Value == 0) || (f.Value != 0 && (v&f.Value) == f.Value && v != 0)
 }
 
@@ -38,7 +38,7 @@ type ParamFlags []ParamFlag
 
 // String produces a string with all flags present in the bitmask and delimited
 // with the `|` separator.
-func (flags ParamFlags) String(f uint32) string {
+func (flags ParamFlags) String(f uint64) string {
 	var (
 		n strings.Builder
 		s string
@@ -203,4 +203,28 @@ var ViewProtectionFlags = []ParamFlag{
 	{"EXECUTE_READ", 0x30000},
 	{"READWRITE", 0x40000},
 	{"WRITECOPY", 0x50000},
+}
+
+// DNSOptsFlags describes DNS query/response options.
+var DNSOptsFlags = []ParamFlag{
+	{"STANDARD", 0x00000000},
+	{"ACCEPT_TRUNCATED_RESPONSE", 0x00000001},
+	{"USE_TCP_ONLY", 0x00000002},
+	{"NO_RECURSION", 0x00000004},
+	{"BYPASS_CACHE", 0x00000008},
+	{"NO_WIRE_QUERY", 0x00000010},
+	{"NO_LOCAL_NAME", 0x00000020},
+	{"NO_NETBT", 0x00000080},
+	{"WIRE_ONLY", 0x00000100},
+	{"RETURN_MESSAGE", 0x00000200},
+	{"MULTICAST_ONLY", 0x00000400},
+	{"NO_MULTICAST", 0x00000800},
+	{"TREAT_AS_FQDN", 0x00001000},
+	{"ADDRCONFIG", 0x00002000},
+	{"DUAL_ADDR", 0x00004000},
+	{"MULTICAST_WAIT", 0x00020000},
+	{"MULTICAST_VERIFY", 0x00040000},
+	{"DONT_RESET_TTL_VALUES", 0x00100000},
+	{"DISABLE_IDN_ENCODING", 0x00200000},
+	{"APPEND_MULTILABEL", 0x00800000},
 }

--- a/pkg/kevent/flags_test.go
+++ b/pkg/kevent/flags_test.go
@@ -22,7 +22,7 @@ import "testing"
 
 func TestParamFlags(t *testing.T) {
 	var tests = []struct {
-		flag     uint32
+		flag     uint64
 		flags    ParamFlags
 		expected string
 	}{

--- a/pkg/kevent/kevent.go
+++ b/pkg/kevent/kevent.go
@@ -176,12 +176,12 @@ func Empty() *Kevent {
 }
 
 // NewFromKcap recovers the event instance from the capture byte buffer.
-func NewFromKcap(buf []byte) (*Kevent, error) {
+func NewFromKcap(buf []byte, ver kcapver.Version) (*Kevent, error) {
 	e := &Kevent{
 		Kparams:  make(Kparams),
 		Metadata: make(map[MetadataKey]any),
 	}
-	if err := e.UnmarshalRaw(buf, kcapver.KevtSecV2); err != nil {
+	if err := e.UnmarshalRaw(buf, ver); err != nil {
 		return nil, err
 	}
 	return e, nil

--- a/pkg/kevent/kevent.go
+++ b/pkg/kevent/kevent.go
@@ -181,7 +181,7 @@ func NewFromKcap(buf []byte) (*Kevent, error) {
 		Kparams:  make(Kparams),
 		Metadata: make(map[MetadataKey]any),
 	}
-	if err := e.UnmarshalRaw(buf, kcapver.KevtSecV1); err != nil {
+	if err := e.UnmarshalRaw(buf, kcapver.KevtSecV2); err != nil {
 		return nil, err
 	}
 	return e, nil

--- a/pkg/kevent/kevent_windows.go
+++ b/pkg/kevent/kevent_windows.go
@@ -391,11 +391,11 @@ func (e Kevent) PartialKey() uint64 {
 		binary.LittleEndian.PutUint64(b, object)
 		return hashers.FnvUint64(b)
 	case ktypes.QueryDNS, ktypes.ReplyDNS:
-		key, _ := e.Kparams.GetString(kparams.DNSName)
-		b := make([]byte, 4+len(key))
+		n, _ := e.Kparams.GetString(kparams.DNSName)
+		b := make([]byte, 4+len(n))
 
 		binary.LittleEndian.PutUint32(b, e.PID)
-		b = append(b, key...)
+		b = append(b, n...)
 		return hashers.FnvUint64(b)
 	}
 	return 0
@@ -557,6 +557,12 @@ func (e *Kevent) Summary() string {
 	case ktypes.DuplicateHandle:
 		handleType := e.GetParamAsString(kparams.HandleObjectTypeID)
 		return printSummary(e, fmt.Sprintf("duplicated <code>%s</code> handle", handleType))
+	case ktypes.QueryDNS:
+		dnsName := e.GetParamAsString(kparams.DNSName)
+		return printSummary(e, fmt.Sprintf("sent <code>%s</code> DNS query", dnsName))
+	case ktypes.ReplyDNS:
+		dnsName := e.GetParamAsString(kparams.DNSName)
+		return printSummary(e, fmt.Sprintf("received DNS response for <code>%s</code> query", dnsName))
 	}
 	return ""
 }

--- a/pkg/kevent/kparams/fields_windows.go
+++ b/pkg/kevent/kparams/fields_windows.go
@@ -195,6 +195,17 @@ const (
 	// NetDIPNames is the field that denotes the destination IP address names.
 	NetDIPNames = "dip_names"
 
+	// DNSName is the field that represents the DNS query name
+	DNSName = "name"
+	// DNSRR is the field that represents the DNS record type
+	DNSRR = "rr"
+	// DNSOpts is the field that represents the DNS options
+	DNSOpts = "options"
+	// DNSRcode is the field that represents the DNS response code
+	DNSRcode = "rcode"
+	// DNSAnswers is the field that represents DNS response answers
+	DNSAnswers = "answers"
+
 	// HandleID identifies the parameter that specifies the handle identifier.
 	HandleID = "handle_id"
 	// HandleSourceID identifies the parameter that specifies the source handle identifier.

--- a/pkg/kevent/kparams/types_windows.go
+++ b/pkg/kevent/kparams/types_windows.go
@@ -161,6 +161,8 @@ const (
 	Key
 	// Flags represents a bitmask of flags
 	Flags
+	// Flags64 represents an extended (64 bits) bitmask of flags
+	Flags64
 	// Address is the memory address reference
 	Address
 	// HandleType represents the handle type such as Mutex or File

--- a/pkg/kevent/ktypes/category.go
+++ b/pkg/kevent/ktypes/category.go
@@ -25,6 +25,9 @@ import (
 // Category is the type alias for event categories
 type Category string
 
+// Subcategory is the type alias for event subcategories
+type Subcategory string
+
 const (
 	// Registry is the category for registry related kernel events
 	Registry Category = "registry"
@@ -48,6 +51,13 @@ const (
 	Other Category = "other"
 	// Unknown is the category for events that couldn't match any of the previous categories
 	Unknown Category = "unknown"
+)
+
+const (
+	// DNS designates the DNS (Domain Name Service) event subcategory
+	DNS Subcategory = "dns"
+	// None identifies no subcategory
+	None Subcategory = "none"
 )
 
 // Hash obtains the hash of the category string.

--- a/pkg/kevent/ktypes/ktypes_windows_test.go
+++ b/pkg/kevent/ktypes/ktypes_windows_test.go
@@ -46,7 +46,11 @@ func TestPackAllBytes(t *testing.T) {
 	assert.Equal(t, byte(0xd7), CreateProcess[13])
 	assert.Equal(t, byte(0xba), CreateProcess[14])
 	assert.Equal(t, byte(0x7c), CreateProcess[15])
-	assert.Equal(t, byte(0x1), CreateProcess[16])
+	assert.Equal(t, byte(0x0), CreateProcess[16])
+	assert.Equal(t, byte(0x1), CreateProcess[17])
+
+	assert.Equal(t, byte(0x0b), QueryDNS[16])
+	assert.Equal(t, byte(0xbe), QueryDNS[17])
 }
 
 func TestKtypeComparision(t *testing.T) {

--- a/pkg/kevent/ktypes/metainfo_windows.go
+++ b/pkg/kevent/ktypes/metainfo_windows.go
@@ -83,6 +83,8 @@ var kevents = map[Ktype]KeventInfo{
 	VirtualFree:        {"VirtualFree", Mem, "Releases or decommits a region of memory within the process virtual address space"},
 	MapViewFile:        {"MapViewFile", File, "Maps a view of a file mapping into the address space of a calling process"},
 	UnmapViewFile:      {"UnmapViewFile", File, "Unmaps a mapped view of a file from the calling process's address space"},
+	QueryDNS:           {"QueryDns", Net, "Sends a DNS query to the name server"},
+	ReplyDNS:           {"ReplyDNS", Net, "Receives the response from the DNS server"},
 }
 
 var ktypes = map[string]Ktype{
@@ -134,6 +136,8 @@ var ktypes = map[string]Ktype{
 	"VirtualFree":        VirtualFree,
 	"MapViewFile":        MapViewFile,
 	"UnmapViewFile":      UnmapViewFile,
+	"QueryDns":           QueryDNS,
+	"ReplyDns":           ReplyDNS,
 }
 
 // KtypeToKeventInfo maps the event type to the structure storing detailed information about the event.

--- a/pkg/kevent/marshaller_test.go
+++ b/pkg/kevent/marshaller_test.go
@@ -20,6 +20,7 @@ package kevent
 
 import (
 	"encoding/json"
+	kcapver "github.com/rabbitstack/fibratus/pkg/kcap/version"
 	"golang.org/x/sys/windows"
 	"os"
 	"testing"
@@ -75,7 +76,7 @@ func TestMarshaller(t *testing.T) {
 	b := kevt.MarshalRaw()
 	require.NotEmpty(t, b)
 
-	clone, err := NewFromKcap(b)
+	clone, err := NewFromKcap(b, kcapver.KevtSecV2)
 	require.NoError(t, err)
 
 	assert.Equal(t, uint64(2), clone.Seq)
@@ -275,7 +276,7 @@ func TestUnmarshalHugeHandles(t *testing.T) {
 	}
 
 	s := kevt.MarshalRaw()
-	clone, err := NewFromKcap(s)
+	clone, err := NewFromKcap(s, kcapver.KevtSecV2)
 	require.NoError(t, err)
 	require.NotNil(t, clone)
 }
@@ -583,7 +584,7 @@ func BenchmarkUnmarshal(b *testing.B) {
 	buf := kevt.MarshalRaw()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		ke, err := NewFromKcap(buf)
+		ke, err := NewFromKcap(buf, kcapver.KevtSecV2)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/kstream/consumer_windows.go
+++ b/pkg/kstream/consumer_windows.go
@@ -33,6 +33,7 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/sys/etw"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
+	"strings"
 )
 
 const (
@@ -222,6 +223,9 @@ func (k *consumer) isEventDropped(evt *kevent.Kevent) bool {
 }
 
 func (k *consumer) processEvent(ev *etw.EventRecord) error {
+	if strings.EqualFold(ev.Header.ProviderID.String(), "{1c95126e") {
+		fmt.Println(ev)
+	}
 	ktype := ktypes.NewFromEventRecord(ev)
 	if !ktype.Exists() {
 		keventsUnknown.Add(1)

--- a/pkg/kstream/consumer_windows.go
+++ b/pkg/kstream/consumer_windows.go
@@ -33,6 +33,7 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/sys/etw"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
+	"strings"
 )
 
 const (
@@ -108,6 +109,9 @@ func (k *consumer) Open() error {
 	traces = append(traces, etw.KernelLoggerSession)
 	if k.config.Kstream.EnableAuditAPIEvents {
 		traces = append(traces, etw.KernelAuditAPICallsSession)
+	}
+	if k.config.Kstream.EnableDNSEvents {
+		traces = append(traces, etw.DNSClientSession)
 	}
 
 	for _, name := range traces {
@@ -219,13 +223,16 @@ func (k *consumer) isEventDropped(evt *kevent.Kevent) bool {
 }
 
 func (k *consumer) processEvent(ev *etw.EventRecord) error {
-	typ := ktypes.NewFromEventRecord(ev)
-	if !typ.Exists() {
+	if strings.EqualFold(ev.Header.ProviderID.String(), "{1c95126e") {
+		fmt.Println(ev)
+	}
+	ktype := ktypes.NewFromEventRecord(ev)
+	if !ktype.Exists() {
 		keventsUnknown.Add(1)
 		return nil
 	}
 	keventsProcessed.Add(1)
-	evt := kevent.New(k.sequencer.Get(), typ, ev)
+	evt := kevent.New(k.sequencer.Get(), ktype, ev)
 	// Dispatch each event to the processor chain.
 	// Processors may further augment the event with
 	// useful fields or play the role of state managers.

--- a/pkg/kstream/consumer_windows.go
+++ b/pkg/kstream/consumer_windows.go
@@ -33,7 +33,6 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/sys/etw"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
-	"strings"
 )
 
 const (
@@ -223,9 +222,6 @@ func (k *consumer) isEventDropped(evt *kevent.Kevent) bool {
 }
 
 func (k *consumer) processEvent(ev *etw.EventRecord) error {
-	if strings.EqualFold(ev.Header.ProviderID.String(), "{1c95126e") {
-		fmt.Println(ev)
-	}
 	ktype := ktypes.NewFromEventRecord(ev)
 	if !ktype.Exists() {
 		keventsUnknown.Add(1)

--- a/pkg/kstream/consumer_windows_test.go
+++ b/pkg/kstream/consumer_windows_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/windows"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -422,6 +423,36 @@ func TestConsumerEvents(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"query dns",
+			func() error {
+				_, err := net.LookupHost("dns.google")
+				return err
+			},
+			func(e *kevent.Kevent) bool {
+				return e.CurrentPid() && e.Type == ktypes.QueryDNS && e.IsDNS() &&
+					e.Type.Subcategory() == ktypes.DNS &&
+					e.GetParamAsString(kparams.DNSName) == "dns.google" &&
+					e.GetParamAsString(kparams.DNSRR) == "A"
+			},
+			false,
+		},
+		{
+			"reply dns",
+			func() error {
+				_, err := net.LookupHost("dns.google")
+				return err
+			},
+			func(e *kevent.Kevent) bool {
+				return e.CurrentPid() && e.Type == ktypes.ReplyDNS && e.IsDNS() &&
+					e.Type.Subcategory() == ktypes.DNS &&
+					e.GetParamAsString(kparams.DNSName) == "dns.google" &&
+					e.GetParamAsString(kparams.DNSRR) == "AAAA" &&
+					e.GetParamAsString(kparams.DNSRcode) == "NOERROR" &&
+					e.GetParamAsString(kparams.DNSAnswers) != ""
+			},
+			false,
+		},
 	}
 
 	psnap := new(ps.SnapshotterMock)
@@ -448,6 +479,7 @@ func TestConsumerEvents(t *testing.T) {
 		EnableRegistryKevents: true,
 		EnableMemKevents:      true,
 		EnableHandleKevents:   true,
+		EnableDNSEvents:       true,
 	}
 
 	kctrl := NewController(kstreamConfig)

--- a/pkg/kstream/controller_windows.go
+++ b/pkg/kstream/controller_windows.go
@@ -90,7 +90,7 @@ func NewController(cfg config.KstreamConfig) *Controller {
 			// core system events
 			etw.KernelLoggerSession,
 			etw.KernelTraceControlGUID,
-			0x0, // no keywords
+			0x0, // no keywords for system provider
 			true,
 		},
 		{
@@ -99,6 +99,12 @@ func NewController(cfg config.KstreamConfig) *Controller {
 			etw.KernelAuditAPICallsGUID,
 			0x0, // no keywords, so we accept all events
 			cfg.EnableAuditAPIEvents,
+		},
+		{
+			etw.DNSClientSession,
+			etw.DNSClientGUID,
+			0x0, // enables DNS query/reply events
+			cfg.EnableDNSEvents,
 		},
 	}
 	controller := &Controller{

--- a/pkg/kstream/processors/net_windows.go
+++ b/pkg/kstream/processors/net_windows.go
@@ -48,11 +48,14 @@ func (n netProcessor) Close() {
 
 func (n *netProcessor) ProcessEvent(e *kevent.Kevent) (*kevent.Kevent, bool, error) {
 	if e.Category == ktypes.Net {
-		if e.IsNetworkTCP() {
+		if e.IsNetworkTCP() && !e.IsDNS() {
 			e.AppendEnum(kparams.NetL4Proto, uint32(network.TCP), network.ProtoNames)
 		}
-		if e.IsNetworkUDP() {
+		if e.IsNetworkUDP() && !e.IsDNS() {
 			e.AppendEnum(kparams.NetL4Proto, uint32(network.UDP), network.ProtoNames)
+		}
+		if e.IsDNS() {
+			return e, false, nil
 		}
 		n.resolvePortName(e)
 		names := n.resolveNamesForIP(unwrapIP(e.Kparams.GetIP(kparams.NetDIP)))

--- a/pkg/outputs/eventlog/eventlog.go
+++ b/pkg/outputs/eventlog/eventlog.go
@@ -245,6 +245,10 @@ func ktypeToEventID(kevt *kevent.Kevent) uint32 {
 		return 52
 	case ktypes.DuplicateHandle:
 		return 53
+	case ktypes.QueryDNS:
+		return 54
+	case ktypes.ReplyDNS:
+		return 55
 	}
 	return unknownEventID
 }

--- a/pkg/outputs/eventlog/mc/fibratus.mc
+++ b/pkg/outputs/eventlog/mc/fibratus.mc
@@ -236,3 +236,13 @@ SymbolicName=DuplicateHandle
 Language=English
 Duplicates handle.
 .
+MessageId=54
+SymbolicName=DuplicateHandle
+Language=English
+Query DNS.
+.
+MessageId=55
+SymbolicName=DuplicateHandle
+Language=English
+Receives DNS response.
+.

--- a/rules/macros/macros.yml
+++ b/rules/macros/macros.yml
@@ -70,6 +70,12 @@
 - macro: create_handle
   expr: kevt.name = 'CreateHandle'
 
+- macro: query_dns
+  expr: kevt.name = 'QueryDns'
+
+- macro: reply_dns
+  expr: kevt.name = 'ReplyDns'
+
 - macro: load_driver
   expr: >
     (load_module and image.name iendswith '.sys')


### PR DESCRIPTION
DNS events are valuable telemetry for detecting adversary activity. This PR introduces two new event types:

- `QueryDns`: represents the event that the process generates when sending a DNS query to the name server.
- `ReplyDns`: is the event denoting the DNS response that is sent back to the client.

Apart from containing the query name, both events also have parameters that identify the DNS resource record (e.g. A|AAA) and the query options. Additionally, the `ReplyDns` event has the DNS response code (e.g. NXDOMAIN) and the sequence of answers comprising the DNS response.