### PR TITLE
fix: Make sure PE is initialized during the goto jump

### DIFF
--- a/pkg/filter/accessor_windows.go
+++ b/pkg/filter/accessor_windows.go
@@ -36,6 +36,11 @@ import (
 	pstypes "github.com/rabbitstack/fibratus/pkg/ps/types"
 )
 
+var (
+	// ErrPENil indicates the PE (Portable Executable) data is nil
+	ErrPENil = errors.New("pe state is nil")
+)
+
 // accessor dictates the behaviour of the field accessors. One of the main responsibilities of the accessor is
 // to extract the underlying parameter for the field given in the filter expression. It can also produce a value
 // from the non-params constructs such as process' state or PE metadata.
@@ -840,14 +845,15 @@ func (pa *peAccessor) get(f fields.Field, kevt *kevent.Kevent) (kparams.Value, e
 				}
 			}
 		}
-		kevt.PS.PE = p
 	}
 
 	if p == nil {
-		return nil, nil
+		return nil, ErrPENil
 	}
 
 cmp:
+	kevt.PS.PE = p
+
 	switch f {
 	case fields.PeEntrypoint:
 		return p.EntryPoint, nil

--- a/pkg/pe/parser.go
+++ b/pkg/pe/parser.go
@@ -19,7 +19,6 @@
 package pe
 
 import (
-	"bytes"
 	"crypto/md5"
 	"encoding/hex"
 	"errors"
@@ -28,7 +27,6 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/util/va"
 	peparser "github.com/saferwall/pe"
 	"golang.org/x/sys/windows"
-	"golang.org/x/text/encoding/unicode"
 	"os"
 	"path/filepath"
 	"strings"
@@ -347,23 +345,4 @@ func parse(path string, data []byte, options ...Option) (*PE, error) {
 	p.Anomalies = pe.Anomalies
 
 	return p, nil
-}
-
-// DecodeUTF16String decodes the UTF16 string from the byte slice.
-func DecodeUTF16String(b []byte) (string, error) {
-	n := bytes.Index(b, []byte{0, 0})
-	if n == 0 {
-		return "", nil
-	}
-	decoder := unicode.UTF16(unicode.LittleEndian, unicode.UseBOM).NewDecoder()
-	s, err := decoder.Bytes(b[0 : n+1])
-	if err != nil {
-		return "", err
-	}
-	return string(s), nil
-}
-
-// AlignDword aligns the offset on a 32-bit boundary.
-func AlignDword(offset, base uint32) uint32 {
-	return ((offset + base + 3) & 0xfffffffc) - (base & 0xfffffffc)
 }


### PR DESCRIPTION
 Initialize PE data as part of the `goto` jump and remove unused PE functions that were leftovers of the previous resource parsing functionality.