### PR TITLE
refactor(rules): Move registry keys into macro lists

### DIFF
--- a/rules/macros/macros.yml
+++ b/rules/macros/macros.yml
@@ -215,5 +215,51 @@
   description: |
     Contains wildcard patterns of commonly abused registry run keys.
 
+- macro: registry_persistence_keys
+  list: [
+    "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Userinit",
+    "HKEY_USERS\\*\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\Load",
+    "HKEY_USERS\\*\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\Run",
+    "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\Load",
+    "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\Run",
+    "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Shell",
+    "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Shell",
+    "HKEY_USERS\\*\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Shell",
+    "HKEY_USERS\\*\\Environment\\UserInitMprLogonScript",
+    "HKEY_USERS\\*\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Shell",
+    "HKEY_USERS\\*\\SOFTWARE\\Policies\\Microsoft\\Windows\\System\\Scripts\\Logoff\\Script",
+    "HKEY_USERS\\*\\SOFTWARE\\Policies\\Microsoft\\Windows\\System\\Scripts\\Logon\\Script",
+    "HKEY_USERS\\*\\SOFTWARE\\Policies\\Microsoft\\Windows\\System\\Scripts\\Shutdown\\Script",
+    "HKEY_USERS\\*\\SOFTWARE\\Policies\\Microsoft\\Windows\\System\\Scripts\\Startup\\Script",
+    "HKEY_USERS\\*\\SOFTWARE\\Microsoft\\Ctf\\LangBarAddin\\*\\FilePath",
+    "HKEY_USERS\\*\\SOFTWARE\\Microsoft\\Internet Explorer\\Extensions\\*\\Exec",
+    "HKEY_USERS\\*\\SOFTWARE\\Microsoft\\Command Processor\\Autorun",
+    "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Shell",
+    "HKEY_CURRENT_USER\\Environment\\UserInitMprLogonScript",
+    "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Shell",
+    "HKEY_CURRENT_USER\\SOFTWARE\\Policies\\Microsoft\\Windows\\System\\Scripts\\Logoff\\Script",
+    "HKEY_CURRENT_USER\\SOFTWARE\\Policies\\Microsoft\\Windows\\System\\Scripts\\Logon\\Script",
+    "HKEY_CURRENT_USER\\SOFTWARE\\Policies\\Microsoft\\Windows\\System\\Scripts\\Shutdown\\Script",
+    "HKEY_CURRENT_USER\\SOFTWARE\\Policies\\Microsoft\\Windows\\System\\Scripts\\Startup\\Script",
+    "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Ctf\\LangBarAddin\\*\\FilePath",
+    "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Internet Explorer\\Extensions\\*\\Exec",
+    "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Command Processor\\Autorun"
+   ]
+  description: |
+    Contains the patterns for the registry keys which are commonly abused for
+    gaining persistence on the compromised endpoint.
+
 - macro: script_interpreters
   list: ["powershell.exe", "pwsh.exe", "cscript.exe", "wscript.exe", "mshta.exe"]
+
+- macro: startup_shell_folder_registry_keys
+  list: [
+    "HKEY_USERS\\*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\User Shell Folders\\Startup",
+    "HKEY_USERS\\*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders\\Startup",
+    "HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders\\Startup",
+    "HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders\\Startup",
+    "HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\User Shell Folders\\Common Startup",
+    "HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders\\Common Startup"
+   ]
+  description: |
+    Registry keys that permit setting up alternative Startup folder locations.

--- a/rules/persistence_boot_or_logon_autostart_execution.yml
+++ b/rules/persistence_boot_or_logon_autostart_execution.yml
@@ -126,36 +126,7 @@
             not (pe.is_signed or pe.is_trusted)
           )
             and
-        registry.key.name imatches
-          (
-            'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Userinit',
-            'HKEY_USERS\\*\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\Load',
-            'HKEY_USERS\\*\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\Run',
-            'HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\Load',
-            'HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\Run',
-            'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Shell',
-            'HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Shell',
-            'HKEY_USERS\\*\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Shell',
-            'HKEY_USERS\\*\\Environment\\UserInitMprLogonScript',
-            'HKEY_USERS\\*\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Shell',
-            'HKEY_USERS\\*\\SOFTWARE\\Policies\\Microsoft\\Windows\\System\\Scripts\\Logoff\\Script',
-            'HKEY_USERS\\*\\SOFTWARE\\Policies\\Microsoft\\Windows\\System\\Scripts\\Logon\\Script',
-            'HKEY_USERS\\*\\SOFTWARE\\Policies\\Microsoft\\Windows\\System\\Scripts\\Shutdown\\Script',
-            'HKEY_USERS\\*\\SOFTWARE\\Policies\\Microsoft\\Windows\\System\\Scripts\\Startup\\Script',
-            'HKEY_USERS\\*\\SOFTWARE\\Microsoft\\Ctf\\LangBarAddin\\*\\FilePath',
-            'HKEY_USERS\\*\\SOFTWARE\\Microsoft\\Internet Explorer\\Extensions\\*\\Exec',
-            'HKEY_USERS\\*\\SOFTWARE\\Microsoft\\Command Processor\\Autorun',
-            'HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Shell',
-            'HKEY_CURRENT_USER\\Environment\\UserInitMprLogonScript',
-            'HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Shell',
-            'HKEY_CURRENT_USER\\SOFTWARE\\Policies\\Microsoft\\Windows\\System\\Scripts\\Logoff\\Script',
-            'HKEY_CURRENT_USER\\SOFTWARE\\Policies\\Microsoft\\Windows\\System\\Scripts\\Logon\\Script',
-            'HKEY_CURRENT_USER\\SOFTWARE\\Policies\\Microsoft\\Windows\\System\\Scripts\\Shutdown\\Script',
-            'HKEY_CURRENT_USER\\SOFTWARE\\Policies\\Microsoft\\Windows\\System\\Scripts\\Startup\\Script',
-            'HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Ctf\\LangBarAddin\\*\\FilePath',
-            'HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Internet Explorer\\Extensions\\*\\Exec',
-            'HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Command Processor\\Autorun'
-          )
+        registry.key.name imatches registry_persistence_keys
       action: >
         {{
             emit . "Suspicious persistence via registry modification" ""
@@ -168,15 +139,7 @@
       condition: >
         modify_registry
             and
-        registry.key.name imatches
-            (
-              'HKEY_USERS\\*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\User Shell Folders\\Startup',
-              'HKEY_USERS\\*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders\\Startup',
-              'HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders\\Startup',
-              'HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders\\Startup',
-              'HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\User Shell Folders\\Common Startup',
-              'HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders\\Common Startup'
-            )
+        registry.key.name imatches startup_shell_folder_registry_keys
             and
             not
           (


### PR DESCRIPTION
For the sake of keeping the rules files as readable as possible, we're moving the persistence registry keys and startup shell folder keys into respective macro lists.