### PR TITLE
chore: Lift config file obligation

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -161,7 +161,7 @@ func (f *App) Run(args []string) error {
 	}
 
 	log.Infof("bootstrapping with pid %d", os.Getpid())
-	log.Infof("configuration state %s", cfg.Print())
+	log.Infof("configuration settings %s", cfg.Print())
 
 	err := f.controller.Start()
 	if err != nil {

--- a/internal/bootstrap/config.go
+++ b/internal/bootstrap/config.go
@@ -29,12 +29,11 @@ import (
 // loading fails. In this situation, the default config flag values are used
 // to tweak any of the internal behaviours.
 func InitConfigAndLogger(cfg *config.Config) error {
-	var cerr error
-	cerr = cfg.TryLoadFile(cfg.File())
+	isLoaded := cfg.TryLoadFile(cfg.File()) == nil
 	if err := cfg.Init(); err != nil {
 		return err
 	}
-	if cerr == nil {
+	if isLoaded {
 		if err := cfg.Validate(); err != nil {
 			return err
 		}
@@ -42,10 +41,10 @@ func InitConfigAndLogger(cfg *config.Config) error {
 	if err := log.InitFromConfig(cfg.Log); err != nil {
 		return err
 	}
-	if cerr != nil {
+	if !isLoaded {
 		logrus.Warnf("unable to load configuration "+
-			"from %s file: %v Continuing with default "+
-			"settings...", cfg.File(), cerr)
+			"from %s file. Falling back to default "+
+			"settings...", cfg.File())
 	}
 	return nil
 }


### PR DESCRIPTION
To eliminate the dependency on the configuration file, this change permits starting Fibratus without a config file. In this case, sane default config values will be used and the log message is emitted to inform about this situation.