### PR TITLE
chore: Initialize default rules paths and override logger settings

### DIFF
--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -317,7 +317,17 @@ func (c *Config) addFlags() {
 	c.flags.String(configFile, filepath.Join(os.Getenv("PROGRAMFILES"), "fibratus", "config", "fibratus.yml"), "Indicates the location of the configuration file")
 	if c.opts.run || c.opts.replay {
 		c.flags.StringP(filamentName, "f", "", "Specifies the filament to execute")
-		c.flags.StringSlice(rulesFromPaths, []string{}, "Comma-separated list of rules files")
+
+		// initialize default rules paths
+		exe, err := os.Executable()
+		if err != nil {
+			// fallback to default install directory
+			exe = filepath.Join(os.Getenv("ProgramFiles"), "Fibratus", "Bin", "fibratus.exe")
+		}
+		dir := filepath.Join(filepath.Dir(exe), "..", "Rules")
+
+		c.flags.StringSlice(rulesFromPaths, []string{filepath.Join(dir, "*")}, "Comma-separated list of rules files")
+		c.flags.StringSlice(macrosFromPaths, []string{filepath.Join(dir, "Macros", "*")}, "Comma-separated list of macro files")
 		c.flags.StringSlice(rulesFromURLs, []string{}, "Comma-separated list of rules URL resources")
 	}
 	if c.opts.capture {

--- a/pkg/util/log/config.go
+++ b/pkg/util/log/config.go
@@ -70,7 +70,7 @@ func (c *Config) AddFlags(flags *pflag.FlagSet) {
 	flags.Int(logMaxAge, 0, "Sets he maximum number of days to retain old log files based on the timestamp encoded in their filename. By default no old log files will be removed")
 	flags.Int(logMaxBackups, 15, "Specifies the maximum number of old log files to retain")
 	flags.Int(logMaxSize, 100, "Specifies the maximum size in megabytes of the log file before it gets rotated")
-	flags.String(logFormatter, "json", "Represents the log formatter (json|text )")
+	flags.String(logFormatter, "text", "Represents the log formatter (json|text )")
 	flags.String(logPath, "", "Specifies the alternative paths for storing the logs")
 	flags.Bool(logStdout, false, "Indicates whether log lines are written to standard output in addition to writing them to log files")
 }

--- a/pkg/util/log/logger.go
+++ b/pkg/util/log/logger.go
@@ -40,9 +40,9 @@ func InitFromConfig(c Config) error {
 	exe, err := os.Executable()
 	var path string
 	if err != nil {
-		path = filepath.Join(os.Getenv("PROGRAMFILES"), "fibratus", "logs")
+		path = filepath.Join(os.Getenv("PROGRAMFILES"), "Fibratus", "Logs")
 	} else {
-		path = filepath.Join(filepath.Dir(exe), "..", "logs")
+		path = filepath.Join(filepath.Dir(exe), "..", "Logs")
 	}
 	if c.Path != "" {
 		path = c.Path


### PR DESCRIPTION
Rules and macros are loaded from the installation path by default. This will ease the onboarding of future users.