### PR TITLE
chore(rules): Improve inbound/outbound network macros

### DIFF
--- a/rules/macros/macros.yml
+++ b/rules/macros/macros.yml
@@ -54,12 +54,20 @@
 
 - macro: accept_socket
   expr: kevt.name = 'Accept'
-  
+
 - macro: inbound_network
-  expr: (recv_socket or accept_socket)
+  expr: (recv_socket or accept_socket) and ((net.sip != 0.0.0.0 or net.dip != 0.0.0.0) and (net.sip not in ('0:0:0:0:0:0:0:1', '::1') or net.dip not in ('0:0:0:0:0:0:0:1', '::1')) and not (cidr_contains(net.sip, '127.0.0.0/8') or cidr_contains(net.dip, '127.0.0.0/8')))
+  description: |
+    Detects inbound network traffic excluding source/destination loopback addresses/address spaces.
 
 - macro: outbound_network
-  expr: (send_socket or connect_socket)
+  expr: >
+    (send_socket or connect_socket)
+        and
+    (net.dip != 0.0.0.0 and net.dip not in ('0:0:0:0:0:0:0:1', '::1') and not cidr_contains(net.dip, '127.0.0.0/8', '10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16'))
+  description: |
+    Detects outbound network traffic excluding unspecified destination IP addresses,
+    loopback addresses, and IP addresses pertaining to the RFC1918 address space.
 
 - macro: virtual_alloc
   expr: kevt.name = 'VirtualAlloc'
@@ -119,8 +127,8 @@
 
 - macro: load_untrusted_executable
   expr: >
-    load_executable 
-      and 
+    load_executable
+      and
     (image.signature.level = 'UNCHECKED' or image.signature.level = 'UNSIGNED')
   description:
     Detects when untrusted executable is loaded into process address space.


### PR DESCRIPTION
The conditions are refined to improve the efficiency of rule matching by discarding unspecified, loopback addresses, and RFC1918 address spaces.