### PR TITLE
chore(ci): Upgrade Go and update deprecated actions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -9,16 +9,19 @@ on:
       - "CONTRIBUTING.md"
       - "docs/**"
 
+env:
+  GO_VERSION: 1.21.x
+
 jobs:
   build:
       runs-on: windows-latest
       steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-           go-version: 1.19.x
+           go-version: ${{ env.GO_VERSION }}
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Adjust pkg-config prefix
         shell: bash
         run: |
@@ -37,7 +40,7 @@ jobs:
             libtool
             autoconf
       - name: Cache yara
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           path: |
@@ -94,7 +97,7 @@ jobs:
            export PATH="/c/wix:$PATH"
            export VERSION=0.0.0
            ./make.bat pkg
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "fibratus-amd64.msi"
           path: "./build/msi/fibratus-0.0.0-amd64.msi"
@@ -103,17 +106,17 @@ jobs:
       runs-on: windows-latest
       steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-           go-version: 1.19.x
+           go-version: ${{ env.GO_VERSION }}
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build
         shell: bash
         run: |
           export COMMIT=$(echo $GITHUB_SHA | cut -c1-8)
           ./make.bat
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: "fibratus-amd64-slim.exe"
           path: "./cmd/fibratus/fibratus.exe"
@@ -126,15 +129,15 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Adjust pkg-config prefix
         shell: bash
         run: |
            sed -i 's/C:\/Python37/C:\/hostedtoolcache\/windows\/Python\/3.7.9\/x64/' pkg-config/python-37.pc
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-           go-version: 1.19.x
+           go-version: ${{ env.GO_VERSION }}
       - name: Setup msys2
         uses: msys2/setup-msys2@v2
         with:
@@ -148,7 +151,7 @@ jobs:
            libtool
            autoconf
       - name: Cache yara
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           path: |
@@ -176,15 +179,15 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Adjust pkg-config prefix
         shell: bash
         run: |
            sed -i 's/C:\/Python37/C:\/hostedtoolcache\/windows\/Python\/3.7.9\/x64/' pkg-config/python-37.pc
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-           go-version: 1.19.x
+           go-version: ${{ env.GO_VERSION }}
       - name: Setup msys2
         uses: msys2/setup-msys2@v2
         with:
@@ -198,7 +201,7 @@ jobs:
            libtool
            autoconf
       - name: Cache yara
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           path: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -219,7 +219,7 @@ jobs:
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $GOLANGCI_LINT_VER
         env:
-          GOLANGCI_LINT_VER: v1.50.1
+          GOLANGCI_LINT_VER: v1.55.1
       - name: Lint
         shell: bash
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -172,7 +172,7 @@ jobs:
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $GOLANGCI_LINT_VER
         env:
-          GOLANGCI_LINT_VER: v1.50.1
+          GOLANGCI_LINT_VER: v1.55.1
       - name: Lint
         shell: bash
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,16 +7,19 @@ on:
     paths-ignore:
       - "docs/**"
 
+env:
+  GO_VERSION: 1.21.x
+
 jobs:
   build:
       runs-on: windows-latest
       steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-           go-version: 1.19.x
+           go-version: ${{ env.GO_VERSION }}
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Adjust pkg-config prefix
         shell: bash
         run: |
@@ -35,7 +38,7 @@ jobs:
             libtool
             autoconf
       - name: Cache yara
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           path: |
@@ -79,15 +82,15 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Adjust pkg-config prefix
         shell: bash
         run: |
            sed -i 's/C:\/Python37/C:\/hostedtoolcache\/windows\/Python\/3.7.9\/x64/' pkg-config/python-37.pc
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-           go-version: 1.19.x
+           go-version: ${{ env.GO_VERSION }}
       - name: Setup msys2
         uses: msys2/setup-msys2@v2
         with:
@@ -101,7 +104,7 @@ jobs:
            libtool
            autoconf
       - name: Cache yara
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           path: |
@@ -129,15 +132,15 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Adjust pkg-config prefix
         shell: bash
         run: |
            sed -i 's/C:\/Python37/C:\/hostedtoolcache\/windows\/Python\/3.7.9\/x64/' pkg-config/python-37.pc
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-           go-version: 1.19.x
+           go-version: ${{ env.GO_VERSION }}
       - name: Setup msys2
         uses: msys2/setup-msys2@v2
         with:
@@ -151,7 +154,7 @@ jobs:
            libtool
            autoconf
       - name: Cache yara
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,16 +5,19 @@ on:
     tags:
       - 'v*'
 
+env:
+  GO_VERSION: 1.21.x
+
 jobs:
   build:
       runs-on: windows-latest
       steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-           go-version: 1.19.x
+           go-version:  ${{ env.GO_VERSION }}
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Adjust pkg-config prefix
         shell: bash
         run: |
@@ -33,7 +36,7 @@ jobs:
             libtool
             autoconf
       - name: Cache yara
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache
         with:
           path: |
@@ -91,7 +94,7 @@ jobs:
            export PATH="/c/wix:$PATH"
            export VERSION=${{ steps.get_version.outputs.VERSION }}
            ./make.bat pkg
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: fibratus-${{ steps.get_version.outputs.VERSION }}-amd64.msi
           path: "./build/msi/fibratus-${{ steps.get_version.outputs.VERSION }}-amd64.msi"
@@ -100,11 +103,11 @@ jobs:
       runs-on: windows-latest
       steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-           go-version: 1.19.x
+           go-version:  ${{ env.GO_VERSION }}
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Get version
         id: get_version
         shell: bash
@@ -133,7 +136,7 @@ jobs:
            export PATH="/c/wix:$PATH"
            export VERSION=${{ steps.get_version.outputs.VERSION }}
            ./make.bat pkg-slim
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: fibratus-${{ steps.get_version.outputs.VERSION }}-slim-amd64.msi
           path: "./build/msi/fibratus-${{ steps.get_version.outputs.VERSION }}-slim-amd64.msi"
@@ -145,17 +148,17 @@ jobs:
         - build-slim
       steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Get version
         id: get_version
         shell: bash
         run: |
           echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3 | cut -c2-)
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: fibratus-${{ steps.get_version.outputs.VERSION }}-amd64.msi
           path: build
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: fibratus-${{ steps.get_version.outputs.VERSION }}-slim-amd64.msi
           path: build

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,6 @@ linters:
   enable:
     - bodyclose
     - deadcode
-    - depguard
     - errcheck
     - goconst
     - golint
@@ -45,3 +44,4 @@ issues:
       linters:
         - errcheck
         - scopelint
+        - nolintlint

--- a/go.mod
+++ b/go.mod
@@ -82,4 +82,4 @@ require (
 	www.velocidex.com/golang/go-ntfs v0.1.2-0.20230922133004-33eadbbaf1f2
 )
 
-go 1.19
+go 1.21

--- a/pkg/util/fasttemplate/unsafe.go
+++ b/pkg/util/fasttemplate/unsafe.go
@@ -21,7 +21,6 @@ func bytesToString(b []byte) string {
 	return *(*string)(unsafe.Pointer(&b))
 }
 
-//nolint:govet
 func stringToBytes(s string) []byte {
 	return unsafe.Slice(unsafe.StringData(s), len(s))
 }

--- a/pkg/util/fasttemplate/unsafe.go
+++ b/pkg/util/fasttemplate/unsafe.go
@@ -14,7 +14,6 @@
 package fasttemplate
 
 import (
-	"reflect"
 	"unsafe"
 )
 
@@ -24,11 +23,5 @@ func bytesToString(b []byte) string {
 
 //nolint:govet
 func stringToBytes(s string) []byte {
-	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	bh := reflect.SliceHeader{
-		Data: sh.Data,
-		Len:  sh.Len,
-		Cap:  sh.Len,
-	}
-	return *(*[]byte)(unsafe.Pointer(&bh))
+	return unsafe.Slice(unsafe.StringData(s), len(s))
 }

--- a/pkg/util/typesize/typesize.go
+++ b/pkg/util/typesize/typesize.go
@@ -20,7 +20,6 @@ package typesize
 
 import "unsafe"
 
-//nolint:unused
 var ptr uintptr
 
 // Pointer returns the pointer size on this machine.


### PR DESCRIPTION
The Go version is indicated by the global env variable, in addition to bumping the deprecated actions. This also required upgrading the golangci-lint tool as it is apparently not compatible with the newer Go version.