### PR TITLE
fix: Harden command line parsing and exe enrichment

### DIFF
--- a/pkg/kevent/kevent_windows.go
+++ b/pkg/kevent/kevent_windows.go
@@ -211,6 +211,7 @@ func (e Kevent) IsTerminateProcess() bool { return e.Type == ktypes.TerminatePro
 func (e Kevent) IsTerminateThread() bool  { return e.Type == ktypes.TerminateThread }
 func (e Kevent) IsUnloadImage() bool      { return e.Type == ktypes.UnloadImage }
 func (e Kevent) IsLoadImage() bool        { return e.Type == ktypes.LoadImage }
+func (e Kevent) IsImageRundown() bool     { return e.Type == ktypes.ImageRundown }
 func (e Kevent) IsFileOpEnd() bool        { return e.Type == ktypes.FileOpEnd }
 func (e Kevent) IsRegSetValue() bool      { return e.Type == ktypes.RegSetValue }
 func (e Kevent) IsProcessRundown() bool   { return e.Type == ktypes.ProcessRundown }

--- a/pkg/kstream/processors/image_windows.go
+++ b/pkg/kstream/processors/image_windows.go
@@ -90,7 +90,7 @@ func (m *imageProcessor) ProcessEvent(e *kevent.Kevent) (*kevent.Kevent, bool, e
 		}
 		return e, false, m.psnap.RemoveModule(pid, mod)
 	}
-	if e.IsLoadImage() {
+	if e.IsLoadImage() || e.IsImageRundown() {
 		return e, false, m.psnap.AddModule(e)
 	}
 	return e, true, nil

--- a/pkg/kstream/processors/ps_windows.go
+++ b/pkg/kstream/processors/ps_windows.go
@@ -93,7 +93,11 @@ func (p psProcessor) processEvent(e *kevent.Kevent) (*kevent.Kevent, error) {
 		CompleteSysProc(e.GetParamAsString(kparams.ProcessName))
 
 	// append executable path parameter
-	e.AppendParam(kparams.Exe, kparams.FilePath, cmndline.Exeline())
+	exe := cmndline.Exeline()
+	if exe == "" {
+		exe = e.GetParamAsString(kparams.ProcessName)
+	}
+	e.AppendParam(kparams.Exe, kparams.FilePath, exe)
 
 	if e.IsTerminateProcess() {
 		return e, nil

--- a/pkg/ps/snapshotter_windows.go
+++ b/pkg/ps/snapshotter_windows.go
@@ -211,6 +211,9 @@ func (s *snapshotter) AddModule(e *kevent.Kevent) error {
 	module.DefaultBaseAddress, _ = e.Kparams.GetHex(kparams.ImageDefaultBase)
 	module.SignatureLevel, _ = e.Kparams.GetUint32(kparams.ImageSignatureLevel)
 	module.SignatureType, _ = e.Kparams.GetUint32(kparams.ImageSignatureType)
+	if module.IsExecutable() && len(proc.Exe) < len(module.Name) {
+		proc.Exe = module.Name
+	}
 	proc.AddModule(module)
 	return nil
 }

--- a/pkg/ps/snapshotter_windows.go
+++ b/pkg/ps/snapshotter_windows.go
@@ -38,6 +38,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// SystemPID designates the pid of the system process that acts as the container for system threads
+const SystemPID uint32 = 4
+
 var (
 	// reapPeriod specifies the interval for triggering the housekeeping of dead processes
 	reapPeriod = time.Minute * 2
@@ -196,8 +199,9 @@ func (s *snapshotter) AddModule(e *kevent.Kevent) error {
 	moduleCount.Add(1)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if pid == 0 {
-		pid = e.PID
+	if pid == 0 && e.IsImageRundown() {
+		// assume system process if pid is zero
+		pid = SystemPID
 	}
 	proc, ok := s.procs[pid]
 	if !ok {

--- a/pkg/ps/snapshotter_windows_test.go
+++ b/pkg/ps/snapshotter_windows_test.go
@@ -355,7 +355,7 @@ func TestAddModule(t *testing.T) {
 			kparams.ProcessParentID: {Name: kparams.ProcessParentID, Type: kparams.PID, Value: uint32(os.Getppid())},
 			kparams.ProcessName:     {Name: kparams.ProcessName, Type: kparams.UnicodeString, Value: "spotify.exe"},
 			kparams.Cmdline:         {Name: kparams.Cmdline, Type: kparams.UnicodeString, Value: `C:\Users\admin\AppData\Roaming\Spotify\Spotify.exe --type=crashpad-handler /prefetch:7 --max-uploads=5 --max-db-size=20 --max-db-age=5 --monitor-self-annotation=ptype=crashpad-handler "--metrics-dir=C:\Users\admin\AppData\Local\Spotify\User Data" --url=https://crashdump.spotify.com:443/ --annotation=platform=win32 --annotation=product=spotify --annotation=version=1.1.4.197 --initial-client-data=0x5a4,0x5a0,0x5a8,0x59c,0x5ac,0x6edcbf60,0x6edcbf70,0x6edcbf7c`},
-			kparams.Exe:             {Name: kparams.Exe, Type: kparams.UnicodeString, Value: `C:\Users\admin\AppData\Roaming\Spotify\Spotify.exe --parent`},
+			kparams.Exe:             {Name: kparams.Exe, Type: kparams.UnicodeString, Value: `Spotify.exe`},
 			kparams.UserSID:         {Name: kparams.UserSID, Type: kparams.WbemSID, Value: []byte{224, 8, 226, 31, 15, 167, 255, 255, 0, 0, 0, 0, 15, 167, 255, 255, 1, 1, 0, 0, 0, 0, 0, 5, 18, 0, 0, 0}},
 			kparams.StartTime:       {Name: kparams.StartTime, Type: kparams.Time, Value: time.Now()},
 			kparams.SessionID:       {Name: kparams.SessionID, Type: kparams.Uint32, Value: uint32(1)},
@@ -373,7 +373,7 @@ func TestAddModule(t *testing.T) {
 				Type: ktypes.LoadImage,
 				Kparams: kevent.Kparams{
 					kparams.ProcessID:     {Name: kparams.ProcessID, Type: kparams.PID, Value: uint32(os.Getpid())},
-					kparams.ImageFilename: {Name: kparams.ImageFilename, Type: kparams.UnicodeString, Value: "C:\\Windows\\System32\\notepad.exe"},
+					kparams.ImageFilename: {Name: kparams.ImageFilename, Type: kparams.UnicodeString, Value: "C:\\Users\\admin\\AppData\\Roaming\\Spotify\\Spotify.exe"},
 				},
 			},
 			true,
@@ -400,6 +400,7 @@ func TestAddModule(t *testing.T) {
 			require.Equal(t, exists, ok)
 			if ok {
 				require.NotNil(t, proc.FindModule(evt.GetParamAsString(kparams.ImageFilename)))
+				assert.Equal(t, "C:\\Users\\admin\\AppData\\Roaming\\Spotify\\Spotify.exe", proc.Exe)
 			}
 		})
 	}

--- a/pkg/ps/types/types_windows.go
+++ b/pkg/ps/types/types_windows.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/util/cmdline"
 	"golang.org/x/sys/windows"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	htypes "github.com/rabbitstack/fibratus/pkg/handle/types"
@@ -218,6 +219,9 @@ type Module struct {
 func (m Module) String() string {
 	return fmt.Sprintf("Name: %s, Size: %d, Checksum: %d, Base address: %s, Default base address: %s", m.Name, m.Size, m.Checksum, m.BaseAddress, m.DefaultBaseAddress)
 }
+
+// IsExecutable determines if the loaded module is an executable.
+func (m Module) IsExecutable() bool { return strings.ToLower(filepath.Ext(m.Name)) == ".exe" }
 
 // New produces a new process state.
 func New(pid, ppid uint32, name, cmndline, exe string, sid *windows.SID, sessionID uint32) *PS {

--- a/pkg/util/cmdline/cmdline.go
+++ b/pkg/util/cmdline/cmdline.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	// splitRegexp declares the regular expression for splitting the string
-	// by white spaces if the string is not inside a double quote.
+	// by white spaces if the string is not surrounded inside double quotes.
 	splitRegexp = regexp.MustCompile(`("[^"]+?"\S*|\S+)`)
 
 	// systemRootRegexp is the regular expression for detecting path with unexpanded SystemRoot environment variable
@@ -112,7 +112,7 @@ func (c *Cmdline) Exeline() string {
 	if i > 0 {
 		return c.cmdline[0 : i+4] // dot + exe
 	}
-	return c.cmdline
+	return ""
 }
 
 // String returns the original command line string.

--- a/pkg/util/cmdline/cmdline_test.go
+++ b/pkg/util/cmdline/cmdline_test.go
@@ -42,6 +42,11 @@ func TestSplit(t *testing.T) {
 			4,
 			`svchost.exe`,
 		},
+		{
+			`"C:\Program Files\Conexant\SAII\SmartAudio.exe" /c`,
+			2,
+			`"C:\Program Files\Conexant\SAII\SmartAudio.exe"`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -84,6 +89,11 @@ func TestCmdline(t *testing.T) {
 			`"fontdrvhost.exe"`,
 			`C:\Windows\System32\fontdrvhost.exe`,
 			`"fontdrvhost.exe"`,
+		},
+		{
+			`"fontdrvhost"`,
+			``,
+			`"fontdrvhost"`,
 		},
 		{
 			`"C:\Program Files\WindowsApps\Microsoft.WindowsTerminal_1.16.10261.0_x64__8wekyb3d8bbwe\WindowsTerminal.exe" Microsoft.WindowsTerminal_1.16.10261.0_x64__8wekyb3d8bbweApp`,


### PR DESCRIPTION
If the executable image in the command line is reported without extension, the `exe` parameter is augmented from the image name parameter. Whenever the executable path lacks the FQFN, we resolve the full executable path from the image events and
mutate the process state accordingly. 

Remove spurious attribution of pid zero to be equal to the pid of the process generating the event. This should be the `System` process pid instead.

Process image rundown events in the processor. This condition was overlooked from the previous refactoring.