### PR TITLE
refactor: Revamp trace controller and consumer

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -130,13 +130,14 @@ func NewApp(config *config.Config, options ...Option) (*App, error) {
 
 	hsnap := handle.NewSnapshotter(config, opts.handleSnapshotFn)
 	psnap := ps.NewSnapshotter(hsnap, config)
+	controller := kstream.NewController(config.Kstream)
 
 	app := &App{
 		config:     config,
-		controller: kstream.NewController(config.Kstream),
+		controller: controller,
 		hsnap:      hsnap,
 		psnap:      psnap,
-		consumer:   kstream.NewConsumer(psnap, hsnap, config),
+		consumer:   kstream.NewConsumer(controller, psnap, hsnap, config),
 		signals:    sigs,
 	}
 	return app, nil

--- a/pkg/errors/errors_windows.go
+++ b/pkg/errors/errors_windows.go
@@ -35,8 +35,6 @@ var (
 	ErrTraceDiskFull = errors.New("not enough disk space for writing to log file")
 	// ErrInvalidTrace signals invalid trace handle
 	ErrInvalidTrace = errors.New("invalid trace handle")
-	// ErrStopTrace is bubbled when controller is not able to stop kernel trace session
-	ErrStopTrace = errors.New("an error occurred while stopping trace")
 	// ErrRestartTrace signals an error that is thrown when currently running kernel trace cannot be restarted
 	ErrRestartTrace = errors.New("couldn't restart an already running trace")
 	// ErrTraceAlreadyRunning identifies kernel trace already running errors

--- a/pkg/kcap/writer_windows_test.go
+++ b/pkg/kcap/writer_windows_test.go
@@ -194,7 +194,7 @@ func TestLiveKcap(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	kstreamc := kstream.NewConsumer(psnap, hsnap, cfg)
+	kstreamc := kstream.NewConsumer(ktracec, psnap, hsnap, cfg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kevent/sequencer_windows.go
+++ b/pkg/kevent/sequencer_windows.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"expvar"
 	"fmt"
+	"github.com/rabbitstack/fibratus/pkg/util/multierror"
 	"golang.org/x/sys/windows/registry"
 	"sync/atomic"
 	"syscall"
@@ -109,6 +110,11 @@ func (s *Sequencer) Reset() error {
 func (s *Sequencer) Close() error {
 	s.quit <- struct{}{}
 	return s.key.Close()
+}
+
+// Shutdown stores and closes the event sequencer.
+func (s *Sequencer) Shutdown() error {
+	return multierror.Wrap(s.Store(), s.Close())
 }
 
 // store periodically dumps the sequence number into registry value.

--- a/pkg/kevent/sequencer_windows.go
+++ b/pkg/kevent/sequencer_windows.go
@@ -112,7 +112,7 @@ func (s *Sequencer) Close() error {
 	return s.key.Close()
 }
 
-// Shutdown stores and closes the event sequencer.
+// Shutdown stores the sequence and closes the event sequencer.
 func (s *Sequencer) Shutdown() error {
 	return multierror.Wrap(s.Store(), s.Close())
 }

--- a/pkg/kstream/consumer_windows.go
+++ b/pkg/kstream/consumer_windows.go
@@ -31,14 +31,17 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/kstream/processors"
 	"github.com/rabbitstack/fibratus/pkg/ps"
 	"github.com/rabbitstack/fibratus/pkg/sys/etw"
+	"github.com/rabbitstack/fibratus/pkg/util/multierror"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/sys/windows"
 )
 
 const (
 	// callbackNext is the return callback value which designates that callback execution should progress
 	callbackNext = uintptr(1)
 )
+
+// EventCallback is the type alias for ETW event/buffer callbacks
+type EventCallback interface{}
 
 var (
 	// failedKevents counts the number of kevents that failed to process
@@ -60,7 +63,7 @@ var (
 )
 
 type consumer struct {
-	traces []etw.TraceHandle
+	controller *Controller
 
 	errs      chan error
 	q         *kevent.Queue
@@ -76,16 +79,19 @@ type consumer struct {
 
 	// capture indicates if events are dumped to capture files
 	capture bool
+
+	stop chan struct{}
 }
 
 // NewConsumer constructs a new event stream consumer.
 func NewConsumer(
+	controller *Controller,
 	psnap ps.Snapshotter,
 	hsnap handle.Snapshotter,
 	config *config.Config,
 ) Consumer {
 	kconsumer := &consumer{
-		traces:     make([]etw.TraceHandle, 0),
+		controller: controller,
 		errs:       make(chan error, 1000),
 		q:          kevent.NewQueue(500),
 		config:     config,
@@ -93,6 +99,7 @@ func NewConsumer(
 		capture:    config.KcapFile != "",
 		sequencer:  kevent.NewSequencer(),
 		processors: processors.NewChain(psnap, hsnap, config),
+		stop:       make(chan struct{}),
 	}
 	return kconsumer
 }
@@ -104,69 +111,37 @@ func (k *consumer) SetFilter(filter filter.Filter) { k.filter = filter }
 // to consume events from log buffers. This operation can fail if opening any tracing session
 // results in an error.
 func (k *consumer) Open() error {
-	traces := make([]string, 0)
-	traces = append(traces, etw.KernelLoggerSession)
-	if k.config.Kstream.EnableAuditAPIEvents {
-		traces = append(traces, etw.KernelAuditAPICallsSession)
-	}
-	if k.config.Kstream.EnableDNSEvents {
-		traces = append(traces, etw.DNSClientSession)
-	}
-
-	for _, name := range traces {
-		trace, err := k.openTrace(name)
+	for _, trace := range k.controller.Traces() {
+		if !trace.IsStarted() {
+			continue
+		}
+		err := trace.Open(k.bufferStatsCallback, k.processEventCallback)
 		if err != nil {
-			return fmt.Errorf("unable to open %s trace: %v", name, err)
+			return fmt.Errorf("unable to open %s trace: %v", trace.Name, err)
 		}
-		go k.processTrace(name, trace)
-	}
+		log.Infof("starting [%s] trace processing", trace.Name)
+		errch := make(chan error)
 
+		go trace.Process(errch)
+
+		go func(trace *Trace) {
+			select {
+			case <-k.stop:
+				return
+			case err := <-errch:
+				if err != nil && !errors.Is(err, kerrors.ErrTraceCancelled) {
+					k.errs <- fmt.Errorf("unable to process %s trace: %v", trace.Name, err)
+				}
+			}
+		}(trace)
+	}
 	return nil
-}
-
-func (k *consumer) openTrace(name string) (etw.TraceHandle, error) {
-	logfile := etw.NewEventTraceLogfile(name)
-	logfile.SetBufferCallback(windows.NewCallback(k.bufferStatsCallback))
-	logfile.SetEventCallback(windows.NewCallback(k.processEventCallback))
-	logfile.SetModes(etw.ProcessTraceModeRealtime | etw.ProcessTraceModeEventRecord)
-	trace := etw.OpenTrace(logfile)
-	if !trace.IsValid() {
-		return 0, fmt.Errorf("unable to open %s trace: %v", name, windows.GetLastError())
-	}
-	return trace, nil
-}
-
-func (k *consumer) processTrace(name string, trace etw.TraceHandle) {
-	k.traces = append(k.traces, trace)
-	log.Infof("starting [%s] trace processing", name)
-	err := trace.Process()
-	log.Infof("stopping [%s] trace processing", name)
-	if err != nil && !errors.Is(err, kerrors.ErrTraceCancelled) {
-		select {
-		case k.errs <- err:
-		default:
-			log.Warn("errors channel is full")
-		}
-	}
 }
 
 // Close shutdowns the event stream consumer by closing all running traces.
 func (k *consumer) Close() error {
-	for _, trace := range k.traces {
-		if !trace.IsValid() {
-			continue
-		}
-		if err := trace.Close(); err != nil {
-			log.Warn(err)
-		}
-	}
-	if err := k.sequencer.Store(); err != nil {
-		log.Warn(err)
-	}
-	if err := k.sequencer.Close(); err != nil {
-		log.Warn(err)
-	}
-	return k.processors.Close()
+	close(k.stop)
+	return multierror.Wrap(k.sequencer.Shutdown(), k.processors.Close())
 }
 
 // RegisterEventListener registers a new event listener that is invoked before

--- a/pkg/kstream/consumer_windows.go
+++ b/pkg/kstream/consumer_windows.go
@@ -120,8 +120,8 @@ func (k *consumer) Open() error {
 			return fmt.Errorf("unable to open %s trace: %v", trace.Name, err)
 		}
 		log.Infof("starting [%s] trace processing", trace.Name)
-		errch := make(chan error)
 
+		errch := make(chan error)
 		go trace.Process(errch)
 
 		go func(trace *Trace) {
@@ -129,6 +129,7 @@ func (k *consumer) Open() error {
 			case <-k.stop:
 				return
 			case err := <-errch:
+				log.Infof("stopping [%s] trace processing", trace.Name)
 				if err != nil && !errors.Is(err, kerrors.ErrTraceCancelled) {
 					k.errs <- fmt.Errorf("unable to process %s trace: %v", trace.Name, err)
 				}

--- a/pkg/kstream/consumer_windows_test.go
+++ b/pkg/kstream/consumer_windows_test.go
@@ -79,7 +79,7 @@ func TestRundownEvents(t *testing.T) {
 	kctrl := NewController(kstreamConfig)
 	require.NoError(t, kctrl.Start())
 	defer kctrl.Close()
-	kstreamc := NewConsumer(psnap, hsnap, &config.Config{
+	kstreamc := NewConsumer(kctrl, psnap, hsnap, &config.Config{
 		Kstream:  kstreamConfig,
 		KcapFile: "fake.kcap", // simulate capture to receive state/rundown events
 		Filters:  &config.Filters{},
@@ -496,7 +496,7 @@ func TestConsumerEvents(t *testing.T) {
 	kctrl := NewController(kstreamConfig)
 	require.NoError(t, kctrl.Start())
 	defer kctrl.Close()
-	kstreamc := NewConsumer(psnap, hsnap, &config.Config{Kstream: kstreamConfig, Filters: &config.Filters{}})
+	kstreamc := NewConsumer(kctrl, psnap, hsnap, &config.Config{Kstream: kstreamConfig, Filters: &config.Filters{}})
 	l := &MockListener{}
 	kstreamc.RegisterEventListener(l)
 	require.NoError(t, kstreamc.Open())

--- a/pkg/kstream/controller_windows.go
+++ b/pkg/kstream/controller_windows.go
@@ -218,8 +218,8 @@ func (t *Trace) Flush() error {
 // callback function that ETW calls for each event in the buffer.
 func (t *Trace) Open(bufferFn, eventFn EventCallback) error {
 	logfile := etw.NewEventTraceLogfile(t.Name)
-	logfile.SetBufferCallback(windows.NewCallback(bufferFn))
 	logfile.SetEventCallback(windows.NewCallback(eventFn))
+	logfile.SetBufferCallback(windows.NewCallback(bufferFn))
 	logfile.SetModes(etw.ProcessTraceModeRealtime | etw.ProcessTraceModeEventRecord)
 
 	t.p = etw.OpenTrace(logfile)
@@ -328,7 +328,7 @@ func (c *Controller) Start() error {
 				return err
 			}
 			time.Sleep(time.Millisecond * 100)
-			if err != trace.Start(c.config) {
+			if err := trace.Start(c.config); err != nil {
 				return multierror.Wrap(kerrors.ErrRestartTrace, err)
 			}
 		case kerrors.ErrTraceNoSysResources:

--- a/pkg/kstream/controller_windows.go
+++ b/pkg/kstream/controller_windows.go
@@ -191,6 +191,11 @@ func (t *Trace) Start(config config.KstreamConfig) error {
 // IsStarted indicates if the trace is started successfully.
 func (t *Trace) IsStarted() bool { return t.s.IsValid() }
 
+// Handle returns the trace handle returned by etw.StartTrace function.
+func (t *Trace) Handle() etw.TraceHandle {
+	return t.s
+}
+
 // Stop stops the event tracing session.
 func (t *Trace) Stop() error {
 	return etw.StopTrace(t.Name, t.GUID)

--- a/pkg/kstream/controller_windows_test.go
+++ b/pkg/kstream/controller_windows_test.go
@@ -68,10 +68,10 @@ func TestStartTraces(t *testing.T) {
 			defer ctrl.Close()
 			assert.Equal(t, tt.wantSessions, len(ctrl.traces))
 			for _, trace := range ctrl.traces {
-				require.True(t, trace.Handle.IsValid())
+				require.True(t, trace.Handle().IsValid())
 				require.NoError(t, etw.ControlTrace(0, trace.Name, trace.GUID, etw.Query))
 				if tt.wantFlags != nil && trace.IsKernelTrace() {
-					flags, err := etw.GetTraceSystemFlags(trace.Handle)
+					flags, err := etw.GetTraceSystemFlags(trace.Handle())
 					require.NoError(t, err)
 					// check enabled system event flags
 					require.Equal(t, tt.wantFlags[0], flags[0])

--- a/pkg/kstream/controller_windows_test.go
+++ b/pkg/kstream/controller_windows_test.go
@@ -70,7 +70,7 @@ func TestStartTraces(t *testing.T) {
 			for _, trace := range ctrl.traces {
 				require.True(t, trace.Handle.IsValid())
 				require.NoError(t, etw.ControlTrace(0, trace.Name, trace.GUID, etw.Query))
-				if tt.wantFlags != nil && trace.IsKernelLogger() {
+				if tt.wantFlags != nil && trace.IsKernelTrace() {
 					flags, err := etw.GetTraceSystemFlags(trace.Handle)
 					require.NoError(t, err)
 					// check enabled system event flags

--- a/pkg/sys/etw/etw.go
+++ b/pkg/sys/etw/etw.go
@@ -59,16 +59,6 @@ type TraceHandle uintptr
 // IsValid determines if the trace handle is valid
 func (trace TraceHandle) IsValid() bool { return trace != 0 && trace != 0xffffffffffffffff }
 
-// Process starts trace processing. This operation blocks the main thread.
-func (trace TraceHandle) Process() error {
-	return ProcessTrace(trace)
-}
-
-// Close stops event processing on the trace session.
-func (trace TraceHandle) Close() error {
-	return CloseTrace(trace)
-}
-
 // StartTrace registers and starts an event tracing session for the specified provider. The trace assumes there will
 // be a real-time event consumer responsible for collecting and processing events. If the function succeeds, it returns
 // the handle to the tracing session.

--- a/pkg/sys/etw/types.go
+++ b/pkg/sys/etw/types.go
@@ -224,7 +224,7 @@ type EventTraceProperties struct {
 	// For the case of a realtime logger, a value of zero (the default value) means that the flush time will be set to 1 second.
 	// A realtime logger is when LogFileMode is set to `EventTraceRealTimeMode`.
 	FlushTimer uint32
-	// EnableFlags specifies which kernel events are delievered to the consumer when NT Kernel logger session is started.
+	// EnableFlags specifies which kernel events are delivered to the consumer when NT Kernel logger session is started.
 	// For example, registry events, process, disk IO and so on.
 	EnableFlags EventTraceFlags
 	// AgeLimit is not used.


### PR DESCRIPTION
The motivation for restructuring the trace management is driven by two major areas:

1. reducing code duplication in trace controller
2. making adding future ETW providers less painful as the consumer is aware of which traces are registered and started