### PR TITLE
feat(handle): Control process handle enumeration

### DIFF
--- a/configs/fibratus.yml
+++ b/configs/fibratus.yml
@@ -112,9 +112,11 @@ filters:
 
 # =============================== Handle ===============================================
 
-# Indicates whether initial handle snapshot is built. The snapshot contains the state of system handles.
 handle:
+  # Indicates whether initial handle snapshot is built. The snapshot contains the state of system handles.
   init-snapshot: false
+  # Indicates if process handles are collected during startup or when a new process is spawn.
+  enumerate-handles: false
 
 # =============================== Kevent ===============================================
 

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -63,6 +63,7 @@ const (
 	configFile         = "config-file"
 	debugPrivilege     = "debug-privilege"
 	initHandleSnapshot = "handle.init-snapshot"
+	enumerateHandles   = "handle.enumerate-handles"
 
 	serializeThreads = "kevent.serialize-threads"
 	serializeImages  = "kevent.serialize-images"
@@ -83,8 +84,12 @@ type Config struct {
 	Output outputs.Config
 	// InitHandleSnapshot indicates whether initial handle snapshot is built
 	InitHandleSnapshot bool `json:"init-handle-snapshot" yaml:"init-handle-snapshot"`
-	DebugPrivilege     bool `json:"debug-privilege" yaml:"debug-privilege"`
-	KcapFile           string
+	// EnumerateHandles indicates if process handles are collected during startup or
+	// when a new process is spawn
+	EnumerateHandles bool `json:"enumerate-handles" yaml:"enumerate-handles"`
+
+	DebugPrivilege bool `json:"debug-privilege" yaml:"debug-privilege"`
+	KcapFile       string
 
 	// API stores global HTTP API preferences
 	API APIConfig `json:"api" yaml:"api"`
@@ -247,6 +252,7 @@ func (c *Config) Init() error {
 	c.Filters.initFromViper(c.viper)
 
 	c.InitHandleSnapshot = c.viper.GetBool(initHandleSnapshot)
+	c.EnumerateHandles = c.viper.GetBool(enumerateHandles)
 	c.DebugPrivilege = c.viper.GetBool(debugPrivilege)
 	c.KcapFile = c.viper.GetString(kcapFile)
 
@@ -345,6 +351,7 @@ func (c *Config) addFlags() {
 	}
 	if c.opts.run || c.opts.capture {
 		c.flags.Bool(initHandleSnapshot, false, "Indicates whether initial handle snapshot is built. This implies scanning the system handles table and producing an entry for each handle object")
+		c.flags.Bool(enumerateHandles, false, "Indicates if process handles are collected during startup or when a new process is spawn")
 
 		c.flags.Bool(enableThreadKevents, true, "Determines whether thread kernel events are collected by Kernel Logger provider")
 		c.flags.Bool(enableRegistryKevents, true, "Determines whether registry kernel events are collected by Kernel Logger provider")

--- a/pkg/config/schema_windows.go
+++ b/pkg/config/schema_windows.go
@@ -100,7 +100,8 @@ var schema = `
 		"handle": {
 			"type": "object",
 			"properties": {
-				"init-snapshot": 		{"type": "boolean"}
+				"init-snapshot": 		{"type": "boolean"},
+				"enumerate-handles": 	{"type": "boolean"}
 			},
 			"additionalProperties": false
 		},

--- a/pkg/handle/snapshotter.go
+++ b/pkg/handle/snapshotter.go
@@ -149,6 +149,9 @@ func (s *snapshotter) FindByObject(object uint64) (htypes.Handle, bool) {
 }
 
 func (s *snapshotter) FindHandles(pid uint32) ([]htypes.Handle, error) {
+	if !s.config.EnumerateHandles {
+		return []htypes.Handle{}, nil
+	}
 	if pid == uint32(os.Getpid()) || pid == 0 { // ignore current, idle processes
 		return []htypes.Handle{}, nil
 	}

--- a/pkg/handle/snapshotter_test.go
+++ b/pkg/handle/snapshotter_test.go
@@ -43,7 +43,7 @@ func TestInitSnapshot(t *testing.T) {
 }
 
 func TestFindHandles(t *testing.T) {
-	snap := NewSnapshotter(&config.Config{InitHandleSnapshot: true}, nil)
+	snap := NewSnapshotter(&config.Config{InitHandleSnapshot: true, EnumerateHandles: true}, nil)
 	handles, err := snap.FindHandles(uint32(os.Getppid()))
 	require.NoError(t, err)
 	require.NotEmpty(t, handles)

--- a/pkg/kstream/consumer_windows_test.go
+++ b/pkg/kstream/consumer_windows_test.go
@@ -397,7 +397,7 @@ func TestConsumerEvents(t *testing.T) {
 				}
 				time.Sleep(time.Second)
 				defer windows.TerminateProcess(pi.Process, 0)
-				hs := handle.NewSnapshotter(&config.Config{}, nil)
+				hs := handle.NewSnapshotter(&config.Config{EnumerateHandles: true}, nil)
 				handles, err := hs.FindHandles(pi.ProcessId)
 				if err != nil {
 					return err


### PR DESCRIPTION
Collecting process handles has a significant impact on memory utilization. This is why we offer the config flag `handle.enumerate-handles` for controlling handle enumeration. It is off by default.