### PR TITLE
perf: More efficient event dropping

### DIFF
--- a/pkg/config/kstream.go
+++ b/pkg/config/kstream.go
@@ -25,7 +25,6 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/rabbitstack/fibratus/pkg/kevent"
 	"github.com/rabbitstack/fibratus/pkg/kevent/ktypes"
 	pstypes "github.com/rabbitstack/fibratus/pkg/ps/types"
 	"github.com/spf13/viper"
@@ -143,10 +142,10 @@ func (c *KstreamConfig) Init() {
 	}
 }
 
-// ExcludeKevent determines whether the supplied event is present in the list of
+// ExcludeKevent determines whether the supplied event type is present in the list of
 // excluded event types.
-func (c *KstreamConfig) ExcludeKevent(kevt *kevent.Kevent) bool {
-	return c.excludedKtypes[kevt.Type]
+func (c *KstreamConfig) ExcludeKevent(ktype ktypes.Ktype) bool {
+	return c.excludedKtypes[ktype]
 }
 
 // ExcludeImage determines whether the process generating event is present in the

--- a/pkg/config/kstream_test.go
+++ b/pkg/config/kstream_test.go
@@ -26,7 +26,6 @@ import (
 
 	pstypes "github.com/rabbitstack/fibratus/pkg/ps/types"
 
-	"github.com/rabbitstack/fibratus/pkg/kevent"
 	"github.com/rabbitstack/fibratus/pkg/kevent/ktypes"
 
 	"github.com/stretchr/testify/assert"
@@ -57,8 +56,8 @@ func TestKstreamConfig(t *testing.T) {
 	assert.False(t, c.Kstream.EnableImageKevents)
 	assert.False(t, c.Kstream.EnableFileIOKevents)
 
-	assert.True(t, c.Kstream.ExcludeKevent(&kevent.Kevent{Type: ktypes.CloseHandle}))
-	assert.False(t, c.Kstream.ExcludeKevent(&kevent.Kevent{Type: ktypes.CreateProcess}))
+	assert.True(t, c.Kstream.ExcludeKevent(ktypes.CloseHandle))
+	assert.False(t, c.Kstream.ExcludeKevent(ktypes.CreateProcess))
 
 	assert.True(t, c.Kstream.ExcludeImage(&pstypes.PS{Name: "svchost.exe"}))
 	assert.False(t, c.Kstream.ExcludeImage(&pstypes.PS{Name: "explorer.exe"}))

--- a/pkg/config/schema_windows.go
+++ b/pkg/config/schema_windows.go
@@ -172,7 +172,7 @@ var schema = `
 				"blacklist":		{
 					"type": "object",
 					"properties":	{
-						"events":	{"type": "array", "items": {"type": "string", "enum": ["CreateThread", "TerminateThread", "OpenProcess", "OpenThread", "SetThreadContext", "LoadImage", "UnloadImage", "CreateFile", "CloseFile", "ReadFile", "WriteFile", "DeleteFile", "RenameFile", "SetFileInformation", "EnumDirectory", "MapViewFile", "RegCreateKey", "RegOpenKey", "RegSetValue", "RegQueryValue", "RegQueryKey", "RegDeleteKey", "RegDeleteValue", "RegCloseKey", "Accept", "Send", "Recv", "Connect", "Disconnect", "Reconnect", "Retransmit", "CreateHandle", "CloseHandle", "DuplicateHandle", "QueryDns", "ReplyDns"]}},
+						"events":	{"type": "array", "items": {"type": "string", "enum": ["CreateThread", "TerminateThread", "OpenProcess", "OpenThread", "SetThreadContext", "LoadImage", "UnloadImage", "CreateFile", "CloseFile", "ReadFile", "WriteFile", "DeleteFile", "RenameFile", "SetFileInformation", "EnumDirectory", "MapViewFile", "UnmapViewFile", "RegCreateKey", "RegOpenKey", "RegSetValue", "RegQueryValue", "RegQueryKey", "RegDeleteKey", "RegDeleteValue", "RegCloseKey", "Accept", "Send", "Recv", "Connect", "Disconnect", "Reconnect", "Retransmit", "CreateHandle", "CloseHandle", "DuplicateHandle", "QueryDns", "ReplyDns"]}},
 						"images":	{"type": "array", "items": {"type": "string", "minLength": 1}}
 					},
 					"additionalProperties": false

--- a/pkg/config/schema_windows.go
+++ b/pkg/config/schema_windows.go
@@ -172,8 +172,8 @@ var schema = `
 				"blacklist":		{
 					"type": "object",
 					"properties":	{
-						"events":	{"type": "array", "items": [{"type": "string", "enum": ["CreateProcess", "CreateThread", "TerminateProcess", "TerminateThread", "OpenProcess", "OpenThread", "SetThreadContext", "LoadImage", "UnloadImage", "CreateFile", "CloseFile", "ReadFile", "WriteFile", "DeleteFile", "RenameFile", "SetFileInformation", "EnumDirectory", "RegCreateKey", "RegOpenKey", "RegSetValue", "RegQueryValue", "RegQueryKey", "RegDeleteKey", "RegDeleteValue", "Accept", "Send", "Recv", "Connect", "Disconnect", "Reconnect", "Retransmit", "CreateHandle", "CloseHandle"]}]},
-						"images":	{"type": "array", "items": [{"type": "string", "minLength": 1}]}
+						"events":	{"type": "array", "items": {"type": "string", "enum": ["CreateThread", "TerminateThread", "OpenProcess", "OpenThread", "SetThreadContext", "LoadImage", "UnloadImage", "CreateFile", "CloseFile", "ReadFile", "WriteFile", "DeleteFile", "RenameFile", "SetFileInformation", "EnumDirectory", "MapViewFile", "RegCreateKey", "RegOpenKey", "RegSetValue", "RegQueryValue", "RegQueryKey", "RegDeleteKey", "RegDeleteValue", "RegCloseKey", "Accept", "Send", "Recv", "Connect", "Disconnect", "Reconnect", "Retransmit", "CreateHandle", "CloseHandle", "DuplicateHandle", "QueryDns", "ReplyDns"]}},
+						"images":	{"type": "array", "items": {"type": "string", "minLength": 1}}
 					},
 					"additionalProperties": false
 				}

--- a/pkg/kevent/kevent_windows.go
+++ b/pkg/kevent/kevent_windows.go
@@ -135,8 +135,12 @@ func (e Kevent) IsDropped(capture bool) bool {
 	if e.IsRundown() && e.IsRundownProcessed() {
 		return true
 	}
-	return DropCurrentProc && e.CurrentPid()
+	return IsCurrentProcDropped(e.PID)
 }
+
+// IsCurrentProcDropped determines if the event originated from the
+// current process is dropped.
+func IsCurrentProcDropped(pid uint32) bool { return DropCurrentProc && pid == currentPid }
 
 // DelayKey returns the value that is used to
 // store and reference delayed events in the event

--- a/pkg/kevent/ktypes/metainfo_windows.go
+++ b/pkg/kevent/ktypes/metainfo_windows.go
@@ -113,6 +113,7 @@ var ktypes = map[string]Ktype{
 	"RegQueryKey":        RegQueryKey,
 	"RegDeleteKey":       RegDeleteKey,
 	"RegDeleteValue":     RegDeleteValue,
+	"RegCloseKey":        RegCloseKey,
 	"AcceptTCP4":         AcceptTCPv4,
 	"AcceptTCP6":         AcceptTCPv6,
 	"SendTCP4":           SendTCPv4,


### PR DESCRIPTION
To avoid processing uninterested events at later stages of the event consumer, such as event parsing or processor traversing, drop events coming from the current process as soon as possible. Additionally, excluded event types are dropped after the event type descriptor is constructed.