### PR TITLE
chore(rules): Improve rules

### DIFF
--- a/rules/credential_access_modify_authentication_process.yml
+++ b/rules/credential_access_modify_authentication_process.yml
@@ -47,9 +47,9 @@
       description: |
         Detects possible credentials dumping or exfiltration via malicious password filter DLL.
         Adversaries can leverage the password filter DLL to intercept passwords in clear-text
-        and dump them to the file system or exfiltrate via network.
+        and exfiltrate them via C2 channels.
       condition: >
-        (write_file or send_socket)
+        (outbound_network)
             and
         ps.name ~= 'lsass.exe'
             and

--- a/rules/credential_access_os_credential_dumping.yml
+++ b/rules/credential_access_os_credential_dumping.yml
@@ -42,27 +42,39 @@
       description:
         Identifies access to the Security Account Manager registry hives.
       condition: >
-        (query_registry or open_registry)
-            and
-        registry.key.name imatches
-            (
-              'HKEY_LOCAL_MACHINE\\SAM\\SAM\\Domains\\Account\\*',
-              'HKEY_LOCAL_MACHINE\\SAM\\*',
-              'HKEY_LOCAL_MACHINE\\SAM'
-            )
-            and
-            not
-        ps.exe imatches
-            (
-              '?:\\Windows\\System32\\lsass.exe',
-              '?:\\Windows\\explorer.exe',
-              '?:\\Windows\\System32\\Taskmgr.exe',
-              '?:\\Windows\\System32\\sihost.exe',
-              '?:\\Windows\\System32\\SearchIndexer.exe',
-              '?:\\Windows\\System32\\svchost.exe',
-              '?:\\Windows\\System32\\services.exe',
-              '?:\\ProgramData\\Microsoft\\Windows Defender\\*\\MsMpEng.exe'
-            )
+        sequence
+        maxspan 10m
+          |spawn_process
+              and
+              not
+           ps.exe imatches
+             (
+               '?:\\Program Files\\*.exe',
+               '?:\\Program Files (x86)\\*.exe'
+             )
+          | by ps.child.uuid
+          |(query_registry or open_registry)
+              and
+            registry.key.name imatches
+              (
+                'HKEY_LOCAL_MACHINE\\SAM\\SAM\\Domains\\Account\\*',
+                'HKEY_LOCAL_MACHINE\\SAM\\*',
+                'HKEY_LOCAL_MACHINE\\SAM'
+              )
+              and
+              not
+            ps.exe imatches
+              (
+                '?:\\Windows\\System32\\lsass.exe',
+                '?:\\Windows\\explorer.exe',
+                '?:\\Windows\\System32\\Taskmgr.exe',
+                '?:\\Windows\\System32\\sihost.exe',
+                '?:\\Windows\\System32\\SearchIndexer.exe',
+                '?:\\Windows\\System32\\svchost.exe',
+                '?:\\Windows\\System32\\services.exe',
+                '?:\\ProgramData\\Microsoft\\Windows Defender\\*\\MsMpEng.exe'
+              )
+            | by ps.uuid
       action: >
         {{
             emit . "Potential SAM database dump through registry" ""
@@ -97,7 +109,7 @@
         by ps.uuid
           |open_process
               and
-           ps.access.mask.names in ('ALL_ACCESS', 'CREATE_PROCESS')
+           ps.access.mask.names in ('ALL_ACCESS', 'CREATE_PROCESS', 'VM_READ')
               and
            kevt.arg[exe] imatches '?:\\Windows\\System32\\lsass.exe'
               and
@@ -153,11 +165,7 @@
         maxspan 2m
           |spawn_process
               and
-            ps.child.name in
-              (
-                'WerFault.exe',
-                'WerFaultSecure.exe'
-              )
+           ps.child.name in ('WerFault.exe', 'WerFaultSecure.exe')
           | by ps.child.uuid
           |write_minidump_file
               and

--- a/rules/initial_access_phishing.yml
+++ b/rules/initial_access_phishing.yml
@@ -19,9 +19,9 @@
       condition: >
         sequence
         maxspan 1h
-          |write_file
+          |create_file
               and
-           file.extension iin executable_extensions
+           (file.extension iin executable_extensions or file.is_exec)
               and
            ps.name iin msoffice_binaries
           | by file.name
@@ -37,9 +37,9 @@
       condition: >
         sequence
         maxspan 1h
-          |write_file
+          |create_file
               and
-           file.extension iin module_extensions
+           (file.extension iin module_extensions or file.is_dll)
               and
            ps.name iin msoffice_binaries
           | by file.name

--- a/rules/macros/macros.yml
+++ b/rules/macros/macros.yml
@@ -3,15 +3,6 @@
 
 - macro: open_process
   expr: kevt.name = 'OpenProcess' and ps.access.status = 'Success'
-  description: Acquires the local process object
-
-- macro: open_process_all_access
-  expr: open_process and ps.access.mask.names in ('ALL_ACCESS')
-  description: Acquires the local process object with all possible access rights
-
-- macro: spawn_msoffice_process
-  expr: spawn_process and ps.child.name iin msoffice_binaries
-  description: Identifies the execution of the MS Office process
 
 - macro: write_file
   expr: kevt.name = 'WriteFile'
@@ -58,20 +49,6 @@
 - macro: set_thread_context
   expr: kevt.name = 'SetThreadContext' and kevt.arg[status] = 'Success'
 
-- macro: inbound_network
-  expr: (recv_socket or accept_socket) and ((net.sip != 0.0.0.0 or net.dip != 0.0.0.0) and (net.sip not in ('0:0:0:0:0:0:0:1', '::1') or net.dip not in ('0:0:0:0:0:0:0:1', '::1')) and not (cidr_contains(net.sip, '127.0.0.0/8') or cidr_contains(net.dip, '127.0.0.0/8')))
-  description: |
-    Detects inbound network traffic excluding source/destination loopback addresses/address spaces.
-
-- macro: outbound_network
-  expr: >
-    (send_socket or connect_socket)
-        and
-    (net.dip != 0.0.0.0 and net.dip not in ('0:0:0:0:0:0:0:1', '::1') and not cidr_contains(net.dip, '127.0.0.0/8', '10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16'))
-  description: |
-    Detects outbound network traffic excluding unspecified destination IP addresses,
-    loopback addresses, and IP addresses pertaining to the RFC1918 address space.
-
 - macro: virtual_alloc
   expr: kevt.name = 'VirtualAlloc'
 
@@ -101,6 +78,23 @@
 
 - macro: reply_dns
   expr: kevt.name = 'ReplyDns'
+
+- macro: inbound_network
+  expr: >
+    (recv_socket or accept_socket)
+        and
+    ((net.sip != 0.0.0.0 or net.dip != 0.0.0.0) and (net.sip not in ('0:0:0:0:0:0:0:1', '::1') or net.dip not in ('0:0:0:0:0:0:0:1', '::1')) and not (cidr_contains(net.sip, '127.0.0.0/8') or cidr_contains(net.dip, '127.0.0.0/8')))
+  description: |
+    Detects inbound network traffic excluding source/destination loopback addresses/address spaces.
+
+- macro: outbound_network
+  expr: >
+    (send_socket or connect_socket)
+        and
+    (net.dip != 0.0.0.0 and net.dip not in ('0:0:0:0:0:0:0:1', '::1') and not cidr_contains(net.dip, '127.0.0.0/8', '10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16'))
+  description: |
+    Detects outbound network traffic excluding unspecified destination IP addresses,
+    loopback addresses, and IP addresses pertaining to the RFC1918 address space.
 
 - macro: load_driver
   expr: >
@@ -154,7 +148,7 @@
 
 - macro: write_minidump_file
   expr: >
-    write_file
+    create_file
       and
     (
       file.extension iin


### PR DESCRIPTION
Several changes are introduced to address the following points:

- reduce false positives in `SAM dump through registry rule` by converting into sequence
- use `CreateFile` event type in `write_minidump_file` macro
- use `outbound_network` macro in `Potential credentials dumping or exfiltration via malicious password filter DLL` to reduce alert fatigue
- `LSASS memory dumping via legitimate or offensive tools` rule checks for `VM_READ` access right
- initial access rules are both using `create_file` macros instead of `write_file` and have an additional check for image characteristics
- unused macros are removed