### PR TITLE
fix(ci): Download artifact from workflow

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -12,10 +12,13 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - uses: actions/download-artifact@v3
+    - name: Download binary
+      uses: dawidd6/action-download-artifact@v2
       with:
+        run_id: ${{ github.event.workflow_run.id }}
         name: fibratus-amd64.exe
         path: .
+        search_artifacts: true
     - name: Validate rules
       run: |
         ./fibratus-amd64.exe rules validate --filters.rules.from-paths=rules\* --filters.macros.from-paths=rules\macros\*


### PR DESCRIPTION
Fibratus binary needs to be downloaded from the artifacts tied to the specific workflow.