### PR TITLE
fix(ci): Wait for MSI install

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -71,6 +71,9 @@ jobs:
           export PATH=/c/msys64/mingw64/bin:$PATH
           export PKG_CONFIG_PATH=$(pwd)/pkg-config
           export COMMIT=$(echo $GITHUB_SHA | cut -c1-8)
+          export VERSION=0.0.0
+          ./make.bat rsrc
+          ./make.bat mc
           ./make.bat
         env:
           TAGS: kcap,filament,yara,yara_static
@@ -78,6 +81,24 @@ jobs:
         with:
           name: "fibratus-amd64.exe"
           path: "./cmd/fibratus/fibratus.exe"
+      - name: "Install Wix"
+        shell: bash
+        run: |
+          mkdir -p /c/wix
+          cd /c/wix
+          curl -sSfL https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip > wix-binaries.zip
+          unzip wix-binaries.zip
+          rm wix-binaries.zip
+      - name: Package
+        shell: bash
+        run: |
+          export PATH="/c/wix:$PATH"
+          export VERSION=0.0.0
+          ./make.bat pkg
+      - uses: actions/upload-artifact@v3
+        with:
+          name: "fibratus-amd64.msi"
+          path: "./build/msi/fibratus-0.0.0-amd64.msi"
 
   test:
     runs-on: windows-latest

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -21,8 +21,10 @@ jobs:
         search_artifacts: true
     - name: Install Fibratus
       run: |
-        msiexec /i fibratus-0.0.0-amd64.msi /qn /l*v install.log || cat install.log
+        $exec = Start-Process "msiexec" "/i fibratus-0.0.0-amd64.msi /qn /l*! install.log" -NoNewWindow -PassThru;
+        $tail = Start-Process "powershell" "Get-Content -Path install.log -Wait" -NoNewWindow -PassThru;
+        $exec.WaitForExit();
+        $tail.Kill()
     - name: Validate rules
       run: |
-        $env:PATH += ";$env:ProgramFiles\Fibratus\Bin"
         fibratus rules validate


### PR DESCRIPTION
`msiexec `launches the installation of Fibratus in the background and returns immediately. The side effect is that the next step will never find the Fibratus binary ready to run the rules validation. The solution consists of waiting for the `msiexec `process to complete before executing the next step