### PR TITLE
feat(rules): Introduce min-engine-version attribute

### DIFF
--- a/pkg/config/_fixtures/filters/default-new-attributes.yml
+++ b/pkg/config/_fixtures/filters/default-new-attributes.yml
@@ -5,8 +5,10 @@
   rules:
     - name: only network category
       condition: kevt.category = 'net'
+      min-engine-version: 2.0.0
 
 - group: rouge processes
   rules:
     - name: suspicious network {{ upper "activity" }}
       condition: kevt.category = 'net' and ps.name in ('at.exe', 'java.exe')
+      min-engine-version: 2.0.0

--- a/pkg/config/_fixtures/filters/default.yml
+++ b/pkg/config/_fixtures/filters/default.yml
@@ -5,9 +5,11 @@
   rules:
     - name: only network category
       condition: kevt.category = 'net'
+      min-engine-version: 2.0.0
 
 - group: rouge processes
   enabled: true
   rules:
     - name: suspicious network {{ upper "activity" }}
       condition: kevt.category = 'net' and ps.name in ('at.exe', 'java.exe')
+      min-engine-version: 2.0.0

--- a/pkg/config/_fixtures/filters/invalid_filter_action.yml
+++ b/pkg/config/_fixtures/filters/invalid_filter_action.yml
@@ -3,5 +3,6 @@
   rules:
     - name: suspicious network activity
       condition: kevt.category = 'net' and ps.name in ('at.exe', 'java.exe')
+      min-engine-version: 2.0.0
       action: |
         {{ kil .Kevt.PID }}

--- a/pkg/config/_fixtures/filters/invalid_filter_action_values.yml
+++ b/pkg/config/_fixtures/filters/invalid_filter_action_values.yml
@@ -3,5 +3,6 @@
   rules:
     - name: suspicious network activity
       condition: kevt.category = 'net' and ps.name in ('at.exe', 'java.exe')
+      min-engine-version: 2.0.0
       action: |
         {{ kill .Kevt.Pid }}

--- a/pkg/config/filters.go
+++ b/pkg/config/filters.go
@@ -40,11 +40,12 @@ import (
 
 // FilterConfig is the descriptor of a single filter.
 type FilterConfig struct {
-	Name        string            `json:"name" yaml:"name"`
-	Description string            `json:"description" yaml:"description"`
-	Condition   string            `json:"condition" yaml:"condition"`
-	Action      string            `json:"action" yaml:"action"`
-	Labels      map[string]string `json:"labels" yaml:"labels"`
+	Name             string            `json:"name" yaml:"name"`
+	Description      string            `json:"description" yaml:"description"`
+	Condition        string            `json:"condition" yaml:"condition"`
+	Action           string            `json:"action" yaml:"action"`
+	Labels           map[string]string `json:"labels" yaml:"labels"`
+	MinEngineVersion string            `json:"min-engine-version" yaml:"min-engine-version"`
 }
 
 // parseTmpl ensures the correctness of the rule

--- a/pkg/config/filters_test.go
+++ b/pkg/config/filters_test.go
@@ -61,6 +61,7 @@ func TestLoadGroupsFromPaths(t *testing.T) {
 	assert.Len(t, g1.Rules, 1)
 	assert.Equal(t, "only network category", g1.Rules[0].Name)
 	assert.Equal(t, "kevt.category = 'net'", g1.Rules[0].Condition)
+	assert.Equal(t, "2.0.0", g1.Rules[0].MinEngineVersion)
 
 	g2 := filters.groups[1]
 	assert.Equal(t, "rouge processes", g2.Name)

--- a/pkg/config/schema_windows.go
+++ b/pkg/config/schema_windows.go
@@ -489,12 +489,13 @@ var rulesSchema = `
 				{
 					"type": "object",
 					"properties": {
-						"name": 		{"type": "string", "minLength": 3},
-                        "description":  {"type": "string"},
-						"condition": 	{"type": "string", "minLength": 3},
-						"action": 		{"type": "string"}
+						"name": 				{"type": "string", "minLength": 3},
+                        "description":  		{"type": "string"},
+ 						"min-engine-version":  	{"type": "string", "minLength": 5, "pattern": "^([0-9]+.)([0-9]+.)([0-9]+)$"},
+						"condition": 			{"type": "string", "minLength": 3},
+						"action": 				{"type": "string"}
 					},
-					"required": ["name", "condition"],
+					"required": ["name", "condition", "min-engine-version"],
 					"minItems": 1,
 					"additionalProperties": false
 				}}},

--- a/pkg/filter/_fixtures/default/default.yml
+++ b/pkg/filter/_fixtures/default/default.yml
@@ -26,6 +26,7 @@
             'C:\\Windows\\system32\\wbem\\wmiprvse.exe -Embedding',
             'C:\\Windows\\system32\\wbem\\wmiprvse.exe -secured -Embedding'
           )
+      min-engine-version: 2.0.0
     - name: Windows error reporting/telemetry, Search Indexer, Session Manager, Auto check utility
       condition: kevt.name = 'CreateProcess' and ps.comm in
           (
@@ -36,6 +37,7 @@
             '\\SystemRoot\\System32\\smss.exe',
             'C:\\Windows\\System32\\RuntimeBroker.exe -Embedding'
           )
+      min-engine-version: 2.0.0
     - name: Various Windows processes
       condition: kevt.name = 'CreateProcess' and ps.exe in
           (
@@ -62,10 +64,13 @@
             'C:\\WINDOWS\\system32\\devicecensus.exe UserCxt',
             'C:\\Windows\\System32\\usocoreworker.exe -Embedding'
           )
+      min-engine-version: 2.0.0
     - name: svchost
       condition: kevt.name = 'CreateProcess' and ps.comm in ('svchost.exe')
+      min-engine-version: 2.0.0
     - name: Microsoft edge
       condition: kevt.name = 'CreateProcess' and ps.comm startswith '\"C:\\Program Files (x86)\\Microsoft\\Edge Dev\\Application\\msedge.exe\" --type='
+      min-engine-version: 2.0.0
     - name: Microsoft dotNet
       condition: kevt.name = 'CreateProcess' and ps.comm startswith
           (
@@ -79,6 +84,7 @@
             'C:\\Windows\\Microsoft.NET\\Framework\\v4.0.30319\\mscorsvw.exe',
             'C:\\Windows\\Microsoft.Net\\Framework64\\v3.0\\WPF\\PresentationFontCache.exe'
           )
+      min-engine-version: 2.0.0
     - name: Microsoft Office
       condition: kevt.name = 'CreateProcess' and ps.exe in
           (
@@ -89,16 +95,19 @@
             'C:\\Program Files (x86)\\Microsoft Office\\root\\Office16\\officebackgroundtaskhandler.exe',
             'C:\\Program Files\\Common Files\\Microsoft Shared\\ClickToRun\\OfficeC2RClient.exe'
           )
+      min-engine-version: 2.0.0
     - name: Media Player
       condition: kevt.name = 'CreateProcess' and ps.exe = 'C:\\Program Files\\Windows Media Player\\wmpnscfg.exe'
+      min-engine-version: 2.0.0
     - name: Google
       condition: kevt.name = 'CreateProcess' and ps.comm in
           (
             '\"C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe\\\" --type='
           )
+      min-engine-version: 2.0.0
     - name: Loaded suspicious module
       condition: kevt.name = 'LoadImage' and image.name = 'svchost.dll'
-
+      min-engine-version: 2.0.0
 
 # ======================= Network connection initiated ================================
 #
@@ -121,6 +130,7 @@
             'C:\\Windows\\fonts',
             'C:\\Windows\\system32\\config'
           )
+      min-engine-version: 2.0.0
     - name: Suspicious Windows tools network-connecting binaries
       condition: kevt.name = 'Connect' and ps.name in
           (
@@ -160,6 +170,7 @@
             'wmic.exe',
             'wscript.exe'
           )
+      min-engine-version: 2.0.0
     - name: Relevant 3rd Party Tools
       condition: kevt.name = 'Connect' and ps.name in
           (
@@ -175,6 +186,7 @@
             'nmap.exe',
             'psinfo.exe'
           )
+      min-engine-version: 2.0.0
     - name: Suspicious ports
       condition: kevt.name = 'Connect' and net.dport in
           (
@@ -193,6 +205,7 @@
             9001,
             9030
           )
+      min-engine-version: 2.0.0
 
 - group: Suspicious network-connecting binaries
   enabled: true
@@ -208,7 +221,10 @@
               'microsoft.com.akadns.net',
               'microsoft.com.nsatc.net'
            )
+      min-engine-version: 2.0.0
     - name: OCSP protocol known addresses
       condition: kevt.name = 'Connect' and net.dip in (23.4.43.27, 72.21.91.29)
+      min-engine-version: 2.0.0
     - name: Loopback addresses
       condition: kevt.name = 'Connect' and net.dip = 127.0.0.1 or net.dip startswith 'fe80:0:0:0'
+      min-engine-version: 2.0.0

--- a/pkg/filter/_fixtures/merged_groups.yml
+++ b/pkg/filter/_fixtures/merged_groups.yml
@@ -3,17 +3,21 @@
   rules:
     - name: match https connections
       condition: kevt.name = 'Recv' and net.dport = 443
+      min-engine-version: 2.0.0
     - name: match http connections
       condition: kevt.name = 'Recv' and net.dport = 80
+      min-engine-version: 2.0.0
 
 - group: network events 2
   enabled: true
   rules:
     - name: match http connections
       condition: kevt.category = 'net' and net.dport = 80
+      min-engine-version: 2.0.0
 
 - group: network events 3
   enabled: true
   rules:
     - name: match ssh connections
       condition: kevt.name = 'Recv' and net.dport = 22
+      min-engine-version: 2.0.0

--- a/pkg/filter/_fixtures/min-engine-ver-fail.yml
+++ b/pkg/filter/_fixtures/min-engine-ver-fail.yml
@@ -3,17 +3,10 @@
   rules:
     - name: match https connections
       condition: kevt.name = 'Recv' and net.dport = 443
-      min-engine-version: 2.0.0
+      min-engine-version: 1.0.0
     - name: accept events where source port = 44123
       condition: kevt.name = 'Recv' and net.sport = 44123
-      min-engine-version: 2.0.0
+      min-engine-version: 2.2.0
     - name: src ip address is not a loopback address
       condition:  kevt.name = 'Recv' and net.sip != 127.0.0.1
-      min-engine-version: 2.0.0
-
-- group: network events 2
-  enabled: true
-  rules:
-    - name: src ip address is
-      condition: kevt.name = 'Recv' and net.sip = 172.0.0.1
-      min-engine-version: 2.0.0
+      min-engine-version: 1.5.0

--- a/pkg/filter/_fixtures/min-engine-ver-ok.yml
+++ b/pkg/filter/_fixtures/min-engine-ver-ok.yml
@@ -6,14 +6,7 @@
       min-engine-version: 2.0.0
     - name: accept events where source port = 44123
       condition: kevt.name = 'Recv' and net.sport = 44123
-      min-engine-version: 2.0.0
+      min-engine-version: 1.8.0
     - name: src ip address is not a loopback address
       condition:  kevt.name = 'Recv' and net.sip != 127.0.0.1
-      min-engine-version: 2.0.0
-
-- group: network events 2
-  enabled: true
-  rules:
-    - name: src ip address is
-      condition: kevt.name = 'Recv' and net.sip = 172.0.0.1
-      min-engine-version: 2.0.0
+      min-engine-version: 1.5.0

--- a/pkg/filter/_fixtures/sequence_and_simple_rule_mix.yml
+++ b/pkg/filter/_fixtures/sequence_and_simple_rule_mix.yml
@@ -4,6 +4,7 @@
     - name: Process spawned by powershell
       condition: >
         kevt.name = 'CreateProcess' and ps.name = 'powershell.exe'
+      min-engine-version: 2.0.0
     - name: Powershell created a temp file
       condition: >
         sequence
@@ -13,11 +14,14 @@
             and
          file.name icontains 'temp'
         | by ps.pid
+      min-engine-version: 2.0.0
     - name: Spawn Chrome browser
       condition: >
         kevt.name = 'CreateProcess' and ps.sibling.name = 'chrome.exe'
+      min-engine-version: 2.0.0
     - name: Command shell spawned Chrome browser
       condition: >
         sequence maxspan 1s
         |kevt.name = 'CreateProcess' and ps.name = 'powershell.exe'| by ps.pid
         |kevt.name = 'CreateProcess' and ps.sibling.name = 'chrome.exe'| by ps.pid
+      min-engine-version: 2.0.0

--- a/pkg/filter/_fixtures/sequence_rule_bound_fields.yml
+++ b/pkg/filter/_fixtures/sequence_rule_bound_fields.yml
@@ -13,3 +13,4 @@
          $e1.ps.sid = ps.sid
         | as e2
         |kevt.name = 'Connect' and ps.sid != $e2.ps.sid and ps.sid = $e1.ps.sid|
+      min-engine-version: 2.0.0

--- a/pkg/filter/_fixtures/sequence_rule_bound_fields_with_functions.yml
+++ b/pkg/filter/_fixtures/sequence_rule_bound_fields_with_functions.yml
@@ -43,3 +43,4 @@
              registered the password filter DLL under %2.registry.key.name registry key
             `
         }}
+      min-engine-version: 2.0.0

--- a/pkg/filter/_fixtures/sequence_rule_complex.yml
+++ b/pkg/filter/_fixtures/sequence_rule_complex.yml
@@ -25,3 +25,4 @@
             "Phishing dropper outbound communication"
             (printf "%s process initiated outbound communication to %s" .Kevts.k2.PS.Name .Kevts.k3.Kparams.dip)
         }}
+      min-engine-version: 2.0.0

--- a/pkg/filter/_fixtures/sequence_rule_ps_uuid.yml
+++ b/pkg/filter/_fixtures/sequence_rule_ps_uuid.yml
@@ -14,3 +14,4 @@
             and
         file.extension = '.exe'
         |
+      min-engine-version: 2.0.0

--- a/pkg/filter/_fixtures/sequence_rule_simple.yml
+++ b/pkg/filter/_fixtures/sequence_rule_simple.yml
@@ -10,4 +10,5 @@
             and
          file.name icontains 'temp'
         | by file.name
+      min-engine-version: 2.0.0
 

--- a/pkg/filter/_fixtures/sequence_rule_simple_max_span.yml
+++ b/pkg/filter/_fixtures/sequence_rule_simple_max_span.yml
@@ -11,3 +11,4 @@
             and
          file.name icontains 'temp'
         |
+      min-engine-version: 2.0.0

--- a/pkg/filter/_fixtures/simple_emit_alert.yml
+++ b/pkg/filter/_fixtures/simple_emit_alert.yml
@@ -6,9 +6,11 @@
       action: |
         {{ $text := cat .Kevt.PS.Name "process received data on port" .Kevt.Kparams.dport }}
         {{ emit . "Test alert" $text "critical" "tag1" "tag2" }}
+      min-engine-version: 2.0.0
     - name: Windows error reporting/telemetry, WMI provider host
       condition:  kevt.name = 'Recv' and ps.comm startswith
         (
           ' \"C:\\Windows\\system32\\wermgr.exe\\" \"-queuereporting_svc\" ',
           'C:\\Windows\\system32\\DllHost.exe /Processid'
         )
+      min-engine-version: 2.0.0

--- a/pkg/filter/_fixtures/simple_matches.yml
+++ b/pkg/filter/_fixtures/simple_matches.yml
@@ -3,3 +3,4 @@
   rules:
     - name: match https connections
       condition:  kevt.name = 'Recv' and net.dport = 443
+      min-engine-version: 2.0.0

--- a/pkg/filter/_fixtures/simple_not_matches.yml
+++ b/pkg/filter/_fixtures/simple_not_matches.yml
@@ -3,3 +3,4 @@
   rules:
     - name: match https connections
       condition:  kevt.name = 'Recv' and net.sip = 172.17.0.1
+      min-engine-version: 2.0.0

--- a/pkg/filter/rules_test.go
+++ b/pkg/filter/rules_test.go
@@ -274,7 +274,6 @@ func TestMinEngineVersion(t *testing.T) {
 	require.Error(t, rules.Compile())
 	rules = NewRules(psnap, newConfig("_fixtures/min-engine-ver-ok.yml"))
 	require.NoError(t, rules.Compile())
-
 }
 
 func TestSimpleSequenceRule(t *testing.T) {

--- a/pkg/filter/rules_test.go
+++ b/pkg/filter/rules_test.go
@@ -21,6 +21,7 @@ package filter
 import (
 	"github.com/rabbitstack/fibratus/pkg/fs"
 	"github.com/rabbitstack/fibratus/pkg/ps"
+	"github.com/rabbitstack/fibratus/pkg/util/version"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows/registry"
 	"net"
@@ -264,6 +265,16 @@ func TestSequenceState(t *testing.T) {
 	require.False(t, ss.inExpired)
 
 	assert.Equal(t, "kevt.name = CreateFile AND file.name ICONTAINS temp", ss.currentState())
+}
+
+func TestMinEngineVersion(t *testing.T) {
+	psnap := new(ps.SnapshotterMock)
+	rules := NewRules(psnap, newConfig("_fixtures/min-engine-ver-fail.yml"))
+	version.Set("2.0.0")
+	require.Error(t, rules.Compile())
+	rules = NewRules(psnap, newConfig("_fixtures/min-engine-ver-ok.yml"))
+	require.NoError(t, rules.Compile())
+
 }
 
 func TestSimpleSequenceRule(t *testing.T) {

--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -20,11 +20,13 @@ package version
 
 import (
 	"fmt"
+	semver "github.com/hashicorp/go-version"
 	"os"
 	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 )
@@ -43,11 +45,29 @@ var versionRegexp = regexp.MustCompile(`(\d+\.\d+\.\d+)`)
 
 var version string
 
+var once sync.Once
+var sem *semver.Version
+
 // Set initializes the version string as global variable.
 func Set(v string) { version = v }
 
 // Get returns the version string.
 func Get() string { return version }
+
+// IsDev determines if this is a dev version.
+func IsDev() bool { return version == "dev" || version == "" }
+
+// Sem returns a semver spec.
+func Sem() *semver.Version {
+	once.Do(func() {
+		var err error
+		sem, err = semver.NewSemver(version)
+		if err != nil {
+			panic(err)
+		}
+	})
+	return sem
+}
 
 // ProductToken returns a tag to be poked in User Agent headers.
 func ProductToken() string { return fmt.Sprintf("fibratus/%s", version) }

--- a/rules/credential_access_credentials_from_password_stores.yml
+++ b/rules/credential_access_credentials_from_password_stores.yml
@@ -38,6 +38,7 @@
         {{
             emit . "Unusual access to Windows Credential history files" ""
         }}
+      min-engine-version: 2.0.0
     - name: Suspicious access to Windows Credential Manager files
       description: |
         Identifies suspicious processes trying to acquire credentials from the Windows Credential Manager.
@@ -60,6 +61,7 @@
         {{
             emit . "Suspicious access to Windows Credential Manager files" ""
         }}
+      min-engine-version: 2.0.0
     - name: Suspicious access to Windows Vault files
       description: |
         Identifies attempts from adversaries to acquire credentials from Vault files.
@@ -86,6 +88,7 @@
         {{
             emit . "Suspicious access to Windows Vault files" ""
         }}
+      min-engine-version: 2.0.0
     - name: Suspicious access to Windows DPAPI Master Keys
       description: |
         Detects suspicious processes accessing the Windows Data Protection API Master keys
@@ -120,6 +123,7 @@
             "Suspicious access to Windows DPAPI Master Keys"
             "`%ps.exe` attempted to access DPAPI keys in `%file.name` location"
         }}
+      min-engine-version: 2.0.0
     - name: Enumerate credentials from Windows Credentials Manager via VaultCmd.exe
       description: |
         Detects the usage of the VaultCmd tool to list Windows Credentials.
@@ -142,6 +146,7 @@
             "Credential discovery via VaultCmd.exe"
             "`%ps.exe` executed the `VaultCmd` tool to enumerate Windows Credentials"
         }}
+      min-engine-version: 2.0.0
     - name: Credentials access from credential backups
       description: |
         Detects an attempt to obtain credentials from credential backups.
@@ -158,6 +163,7 @@
             "Credential access from credential backups"
             "`%ps.exe` executed the `rundll32.exe` binary to obtain credentials from credentials backups"
         }}
+      min-engine-version: 2.0.0
 
 - group: Credentials access from Web Browsers stores
   description: |
@@ -202,3 +208,4 @@
             "Unusual access to Web Browser Credentials stores"
             "`%ps.exe` process accessed the Web Browser Credentials store in `%file.name`"
         }}
+      min-engine-version: 2.0.0

--- a/rules/credential_access_modify_authentication_process.yml
+++ b/rules/credential_access_modify_authentication_process.yml
@@ -43,6 +43,7 @@
              registered the password filter DLL under %2.registry.key.name registry key
             `
         }}
+      min-engine-version: 2.0.0
     - name: Potential credentials dumping or exfiltration via malicious password filter DLL
       description: |
         Detects possible credentials dumping or exfiltration via malicious password filter DLL.
@@ -63,3 +64,4 @@
             "Potential credentials dumping via malicious password filter"
             "Suspicious password filter DLL detected in `LSASS` domain controller process"
         }}
+      min-engine-version: 2.0.0

--- a/rules/credential_access_os_credential_dumping.yml
+++ b/rules/credential_access_os_credential_dumping.yml
@@ -38,6 +38,7 @@
         {{
             emit . "File access to SAM database" ""
         }}
+      min-engine-version: 2.0.0
     - name: Potential SAM database dump through registry
       description:
         Identifies access to the Security Account Manager registry hives.
@@ -79,6 +80,7 @@
         {{
             emit . "Potential SAM database dump through registry" ""
         }}
+      min-engine-version: 2.0.0
 
 - group: LSASS memory
   description: |
@@ -132,6 +134,7 @@
             `
             "critical"
         }}
+      min-engine-version: 2.0.0
     - name: LSASS memory dump preparation via SilentProcessExit
       description: |
         Adversaries may exploit the SilentProcessExit debugging technique to conduct
@@ -156,6 +159,7 @@
             "LSASS memory dump preparation via SilentProcessExit"
             "`%ps.exe` process created `%registry.key.name` key to enable LSASS memory dump via WER service"
         }}
+      min-engine-version: 2.0.0
     - name: LSASS memory dump via Windows Error Reporting
       description: |
         Adversaries may abuse Windows Error Reporting service to dump LSASS memory. The ALPC protocol can send
@@ -178,6 +182,7 @@
             "LSASS memory dump via Windows Error Reporting"
             "`%1.ps.name` wrote LSASS memory dump into `%2.file.name` file"
         }}
+      min-engine-version: 2.0.0
 
 - group: Access to NTDS Active Directory domain database
   description: |
@@ -222,3 +227,4 @@
             "Suspicious access to Active Directory domain database"
             "`%ps.exe` process accessed the `%file.name` Active Directory domain database"
         }}
+      min-engine-version: 2.0.0

--- a/rules/credential_access_unsecured_credentials.yml
+++ b/rules/credential_access_unsecured_credentials.yml
@@ -46,6 +46,7 @@
             "Unusual access to SSH keys"
             "`%ps.exe` process accessed SSH keys in `%file.name`"
         }}
+      min-engine-version: 2.0.0
     - name: Sensitive access to Unattended Panther files
       description: |
         Identifies suspicious to access to unattend.xml files where credentials
@@ -76,3 +77,4 @@
             "Suspicious access to Windows Panther Unattended files"
             ""
         }}
+      min-engine-version: 2.0.0

--- a/rules/defense_evasion_system_binary_proxy_execution.yml
+++ b/rules/defense_evasion_system_binary_proxy_execution.yml
@@ -42,6 +42,7 @@
         {{
             emit . "System Binary Proxy Execution via Rundll32" ""
         }}
+      min-engine-version: 2.0.0
 
 - group: System Binary Proxy Execution via Regsvr32
   description: |
@@ -86,3 +87,4 @@
        {{
             emit . "Regsvr32 scriptlet execution" ""
        }}
+      min-engine-version: 2.0.0

--- a/rules/initial_access_phishing.yml
+++ b/rules/initial_access_phishing.yml
@@ -33,6 +33,7 @@
         {{
             emit . "File execution via Microsoft Office process" ""
         }}
+      min-engine-version: 2.0.0
     - name: Potentially malicious module loaded by Microsoft Office process
       condition: >
         sequence
@@ -51,3 +52,4 @@
         {{
             emit . "Potentially malicious module loaded by Microsoft Office process" ""
         }}
+      min-engine-version: 2.0.0

--- a/rules/persistence_boot_or_logon_autostart_execution.yml
+++ b/rules/persistence_boot_or_logon_autostart_execution.yml
@@ -45,6 +45,7 @@
         {{
             emit . "Unusual file written or modified in Startup folder" ""
         }}
+      min-engine-version: 2.0.0
     - name: Unusual process modified the registry run key
       description: |
         Identifies an attempt by unusual Windows native processes to modify
@@ -82,6 +83,7 @@
         {{
             emit . "Unusual process modified the registry run key" ""
         }}
+      min-engine-version: 2.0.0
     - name: Network connection via startup folder executable or script
       description: |
         Identifies the execution of unsigned binary or script from the
@@ -110,6 +112,7 @@
         {{
             emit . "Network connection via startup folder executable or script" ""
         }}
+      min-engine-version: 2.0.0
     - name: Suspicious persistence via registry modification
       description: |
         Adversaries may abuse the registry to achieve persistence
@@ -131,6 +134,7 @@
         {{
             emit . "Suspicious persistence via registry modification" ""
         }}
+      min-engine-version: 2.0.0
     - name: Suspicious Startup shell folder modification
       description: |
         Detects when adversaries attempt to modify the default Startup
@@ -151,6 +155,7 @@
         {{
             emit . "Suspicious Startup shell folder modification" ""
         }}
+      min-engine-version: 2.0.0
     - name: Script interpreter host or untrusted process persistence
       description: |
         Identifies the script interpreter or untrusted process writing
@@ -175,3 +180,4 @@
         {{
             emit . "Script interpreter host or untrusted process persistence" ""
         }}
+      min-engine-version: 2.0.0


### PR DESCRIPTION
Rules may utilize rule engine features that are only available in specific Fibratus versions. Let's imagine a rule referencing non-existing filter fields because it's running on an incompatible engine version. This would lead to confusing syntax errors. By pinning a rule to a specific rule engine version, we can guarantee it will compile successfully. On the contrary, the error message will clearly communicate the rule needs a newer engine to compile and run accordingly.