### PR TITLE
feat(cli): Implement list rules command

### DIFF
--- a/cmd/fibratus/app/rules/list.go
+++ b/cmd/fibratus/app/rules/list.go
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2021-2022 by Nedim Sabic Sabic
+ * https://www.fibratus.io
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rules
+
+import (
+	"fmt"
+	"github.com/enescakir/emoji"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/rabbitstack/fibratus/internal/bootstrap"
+	"os"
+	"strings"
+)
+
+func listRules() error {
+	if err := bootstrap.InitConfigAndLogger(cfg); err != nil {
+		return err
+	}
+	if err := cfg.Filters.LoadGroups(); err != nil {
+		return fmt.Errorf("%v %v", emoji.DisappointedFace, err)
+	}
+	groups := cfg.GetRuleGroups()
+	if len(groups) == 0 {
+		return fmt.Errorf("%v no rules found in %s", emoji.DisappointedFace, strings.Join(cfg.Filters.Rules.FromPaths, ","))
+	}
+
+	t := table.NewWriter()
+	t.SetOutputMirror(os.Stdout)
+	t.SetStyle(table.StyleLight)
+
+	// render summary
+	if summarized {
+		t.AppendHeader(table.Row{"Tactic", "# Rules"})
+		t.SetColumnConfigs([]table.ColumnConfig{
+			{Name: "Tactic", WidthMin: 50, WidthMax: 50},
+			{Name: "#", WidthMin: 50, WidthMax: 50},
+		})
+		tactics := make(map[string]int)
+		techniques := make(map[string]int)
+		for _, group := range groups {
+			tactics[group.Labels["tactic.name"]] += len(group.Rules)
+			techniques[group.Labels["technique.name"]] += len(group.Rules)
+		}
+		tot := 0
+		for tac, n := range tactics {
+			t.AppendRow(table.Row{tac, n})
+			tot += n
+		}
+
+		t.AppendSeparator()
+		t.AppendRow(table.Row{"TECHNIQUE", "# RULES"})
+		t.AppendSeparator()
+
+		for tec, n := range techniques {
+			t.AppendRow(table.Row{tec, n})
+		}
+
+		t.AppendFooter(table.Row{"TOTAL", tot})
+	} else {
+		// show all rules
+		t.AppendHeader(table.Row{"#", "Rule", "Technique", "Tactic"})
+		t.SetColumnConfigs([]table.ColumnConfig{
+			{Name: "#", WidthMax: 5},
+			{Name: "Rule"},
+			{Name: "Technique"},
+			{Name: "Tactic", WidthMax: 50},
+		})
+
+		n := 0
+		tactics := make(map[string]int)
+		techniques := make(map[string]int)
+
+		for _, group := range groups {
+			tac := group.Labels["tactic.name"]
+			tec := group.Labels["technique.name"]
+			if _, ok := tactics[tac]; !ok {
+				tactics[tac] = 1
+			}
+			if _, ok := tactics[tec]; !ok {
+				techniques[tec] = 1
+			}
+			for _, rule := range group.Rules {
+				t.AppendRow(table.Row{n + 1, rule.Name, group.Name, group.Labels["tactic.name"]})
+				n++
+			}
+		}
+
+		var (
+			totTat int
+			totTec int
+		)
+
+		for _, n := range tactics {
+			totTat += n
+		}
+		for _, n := range techniques {
+			totTec += n
+		}
+
+		t.AppendFooter(table.Row{"TOTAL", n, totTec, totTat})
+	}
+
+	t.Render()
+
+	return nil
+}

--- a/cmd/fibratus/app/rules/rules.go
+++ b/cmd/fibratus/app/rules/rules.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021-2022 by Nedim Sabic Sabic
+ * https://www.fibratus.io
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rules
+
+import (
+	"fmt"
+	"github.com/rabbitstack/fibratus/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+var Command = &cobra.Command{
+	Use:   "rules",
+	Short: "Validate, list, or search detection rules",
+}
+
+var validateCmd = &cobra.Command{
+	Use:   "validate",
+	Short: "Validate rules for structural and syntactic correctness",
+	RunE:  validate,
+}
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List rules",
+	RunE:  list,
+}
+
+var cfg = config.NewWithOpts(config.WithValidate(), config.WithList())
+
+var (
+	summarized bool
+)
+
+func init() {
+	cfg.MustViperize(Command)
+
+	Command.AddCommand(validateCmd)
+
+	listCmd.PersistentFlags().BoolVarP(&summarized, "summary", "s", false, "Show rules summary by MITRE tactics and techniques")
+	Command.AddCommand(listCmd)
+}
+
+func validate(cmd *cobra.Command, args []string) error {
+	return validateRules()
+}
+
+func list(cmd *cobra.Command, args []string) error {
+	return listRules()
+}
+
+func emo(s string, args ...any) { fmt.Printf(s, args...) }


### PR DESCRIPTION
The new subcommand is able to list all rules contained in the local detection rules catalog. It can also receive the `-s` option to show the summary of rules per MITRE tactic/technique. Example:

```
┌────────────────────────────────────────────────────┬─────────┐
│ TACTIC                                             │ # RULES │
├────────────────────────────────────────────────────┼─────────┤
│ Persistence                                        │ 6       │
│ Credential Access                                  │ 17      │
│ Defense Evasion                                    │ 2       │
│ Initial Access                                     │ 2       │
├────────────────────────────────────────────────────┼─────────┤
│ TECHNIQUE                                          │ # RULES │
├────────────────────────────────────────────────────┼─────────┤
│ System Binary Proxy Execution                      │ 2       │
│ Phishing                                           │ 2       │
│ Boot or Logon Autostart Execution                  │ 6       │
│ Credentials from Password Stores                   │ 7       │
│ Modify Authentication Process                      │ 2       │
│ OS Credential Dumping                              │ 6       │
│ Unsecured credentials                              │ 2       │
├────────────────────────────────────────────────────┼─────────┤
│ TOTAL                                              │ 27      │
└────────────────────────────────────────────────────┴─────────┘
```