### PR TITLE
fix(ci): Rules workflow fixes

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -26,4 +26,6 @@ jobs:
     - name: Validate rules
       shell: bash
       run: |
-        ./make.bat validate-rules
+        export PATH="/c/Program Files/Fibratus/Bin:$PATH"
+        fibratus rules list
+        fibratus rules validate

--- a/make.bat
+++ b/make.bat
@@ -191,12 +191,6 @@ timeout 2 > NUL
 type install.log
 goto :EOF
 
-:validate-rules
-set PATH="%PATH%;%ProgramFiles%\Fibratus\Bin"
-fibratus rules list
-fibratus rules validate
-goto :EOF
-
 :fail
 echo Failed with error #%errorlevel%.
 exit /b %errorlevel%


### PR DESCRIPTION
If the rules validate target fails, also mark the workflow as failed. Export the `PATH` directly in the workflow manifest.