### PR TITLE
feat(config): Permit disabling rule engine

### DIFF
--- a/configs/fibratus.yml
+++ b/configs/fibratus.yml
@@ -106,10 +106,12 @@ filters:
     # Indicates if the rule engine is enabled and rules loaded
     enabled: true
 
+    # The list of file system paths were rule files are located. Supports glob expressions in path names.
     from-paths:
      # - C:\Program Files\Fibratus\Rules\*.yml
     #from-urls:
   macros:
+    # The list of file system paths were macro library files are located. Supports glob expressions in path names.
     from-paths:
       #- C:\Program Files\Fibratus\Rules\Macros\*.yml
 

--- a/configs/fibratus.yml
+++ b/configs/fibratus.yml
@@ -103,6 +103,9 @@ filament:
 # rules from different directory locations.
 filters:
   rules:
+    # Indicates if the rule engine is enabled and rules loaded
+    enabled: true
+
     from-paths:
      # - C:\Program Files\Fibratus\Rules\*.yml
     #from-urls:

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -178,6 +178,8 @@ func (f *App) Run(args []string) error {
 		if err != nil {
 			return err
 		}
+	} else {
+		log.Info("rule engine is disabled")
 	}
 	// build the filter from the CLI argument. If we got
 	// a valid expression the filter is attached to the

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -171,10 +171,13 @@ func (f *App) Run(args []string) error {
 		return err
 	}
 	// initialize rules engine
-	rules := filter.NewRules(f.psnap, cfg)
-	err = rules.Compile()
-	if err != nil {
-		return err
+	var rules *filter.Rules
+	if f.config.Filters.Rules.Enabled {
+		rules = filter.NewRules(f.psnap, cfg)
+		err = rules.Compile()
+		if err != nil {
+			return err
+		}
 	}
 	// build the filter from the CLI argument. If we got
 	// a valid expression the filter is attached to the
@@ -228,7 +231,9 @@ func (f *App) Run(args []string) error {
 			f.consumer.RegisterEventListener(f.symbolizer)
 		}
 		// register rule engine
-		f.consumer.RegisterEventListener(rules)
+		if rules != nil {
+			f.consumer.RegisterEventListener(rules)
+		}
 		// register YARA scanner
 		if cfg.Yara.Enabled {
 			scanner, err := yara.NewScanner(f.psnap, cfg.Yara)

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -361,6 +361,7 @@ func (c *Config) addFlags() {
 		}
 		dir := filepath.Join(filepath.Dir(exe), "..", "Rules")
 
+		c.flags.Bool(rulesEnabled, true, "Indicates if the rule engine is enabled and rules loaded")
 		c.flags.StringSlice(rulesFromPaths, []string{filepath.Join(dir, "*")}, "Comma-separated list of rules files")
 		c.flags.StringSlice(macrosFromPaths, []string{filepath.Join(dir, "Macros", "*")}, "Comma-separated list of macro files")
 		c.flags.StringSlice(rulesFromURLs, []string{}, "Comma-separated list of rules URL resources")

--- a/pkg/config/filters.go
+++ b/pkg/config/filters.go
@@ -136,6 +136,7 @@ func FiltersWithMacros(macros map[string]*Macro) *Filters {
 // Rules contains attributes that describe the location of
 // rule resources.
 type Rules struct {
+	Enabled   bool     `json:"enabled" yaml:"enabled"`
 	FromPaths []string `json:"from-paths" yaml:"from-paths"`
 	FromURLs  []string `json:"from-urls" yaml:"from-urls"`
 }
@@ -171,12 +172,14 @@ type ActionContext struct {
 }
 
 const (
+	rulesEnabled    = "filters.rules.enabled"
 	rulesFromPaths  = "filters.rules.from-paths"
 	rulesFromURLs   = "filters.rules.from-urls"
 	macrosFromPaths = "filters.macros.from-paths"
 )
 
 func (f *Filters) initFromViper(v *viper.Viper) {
+	f.Rules.Enabled = v.GetBool(rulesEnabled)
 	f.Rules.FromPaths = v.GetStringSlice(rulesFromPaths)
 	f.Rules.FromURLs = v.GetStringSlice(rulesFromURLs)
 	f.Macros.FromPaths = v.GetStringSlice(macrosFromPaths)

--- a/pkg/config/filters.go
+++ b/pkg/config/filters.go
@@ -310,6 +310,10 @@ func (f *Filters) LoadGroups() error {
 		f.groups = append(f.groups, groups...)
 	}
 
+	if len(f.groups) == 0 {
+		log.Warnf("no rules were loaded from [%s] path(s)", strings.Join(f.Rules.FromPaths, ","))
+	}
+
 	// check for duplicate rule groups
 	groupNames := make(map[string]bool)
 	for _, group := range f.groups {

--- a/pkg/config/schema_windows.go
+++ b/pkg/config/schema_windows.go
@@ -129,6 +129,7 @@ var schema = `
 				"rules": {
 					"type": "object",
 					"properties": {
+						"enabled": 		{"type": "boolean"},
 						"from-paths": 	{"type": ["array", "null"], "items": [{"type": "string", "minLength": 4}]},
 						"from-urls":	{"type": ["array", "null"], "items": [{"type": "string", "minLength": 8}]}
 					},


### PR DESCRIPTION
If the user wants to completely disable the rule engine, it can do this by setting the `filters.rules.enabled` flag to false. When the rule engine is disabled, all events matching the CLI filters are routed to output sinks.