### PR TITLE
fix(capture): Empty capture file and replay crashes

### DIFF
--- a/pkg/kcap/writer_windows.go
+++ b/pkg/kcap/writer_windows.go
@@ -226,7 +226,7 @@ func (w *writer) write(b []byte) error {
 		overflowKevents.Add(1)
 		return fmt.Errorf("event size overflow by %d bytes", l-maxKevtSize)
 	}
-	if err := w.ws(section.Kevt, kcapver.KevtSecV1, 0, uint32(l)); err != nil {
+	if err := w.ws(section.Kevt, kcapver.KevtSecV2, 0, uint32(l)); err != nil {
 		kevtWriteErrors.Add(1)
 		return err
 	}

--- a/pkg/kevent/marshaller_windows.go
+++ b/pkg/kevent/marshaller_windows.go
@@ -148,6 +148,13 @@ func (e *Kevent) MarshalRaw() []byte {
 					b = append(b, bytes.WriteUint16(uint16(len(s)))...)
 					b = append(b, s...)
 				}
+			case []va.Address:
+				// 8 byte integers
+				b = append(b, uint8('8'))
+				b = append(b, bytes.WriteUint16(uint16(len(slice)))...)
+				for _, v := range slice {
+					b = append(b, bytes.WriteUint64(v.Uint64())...)
+				}
 			}
 		case kparams.Binary, kparams.SID, kparams.WbemSID:
 			b = append(b, bytes.WriteUint32(uint32(len(kpar.Value.([]byte))))...)
@@ -354,6 +361,13 @@ func (e *Kevent) UnmarshalRaw(b []byte, ver kcapver.Version) error {
 					off += 2 + uint32(size)
 				}
 				kval = s
+			case '8':
+				v := make([]uint64, l)
+				for i := 0; i < int(l); i++ {
+					bytes.ReadUint64(b[inc(idx, 22)+offset+kparamNameLength+poffset+off:])
+					off += 8
+				}
+				kval = v
 			}
 			poffset += kparamNameLength + 4 + 1 + 2 + off
 		case kparams.Binary, kparams.SID, kparams.WbemSID:

--- a/pkg/kevent/queue.go
+++ b/pkg/kevent/queue.go
@@ -143,7 +143,7 @@ func (q *Queue) push(e *Kevent) error {
 			enqueue = true
 		}
 	}
-	if enqueue {
+	if enqueue || len(q.listeners) == 0 {
 		q.q <- e
 		keventsEnqueued.Add(1)
 	} else {


### PR DESCRIPTION
When there are no listeners registered on the event queue, the event is not pushed to the channel, and so, neither is written to the capture.
The callstack parameters are slices of uint64 values. The marshaling logic didn't contemplate those, leading to slice out-of-bounds crashes. 
This changeset takes care of both defects.