### PR TITLE
feat(rules): Dynamic event flags enablement

### DIFF
--- a/configs/fibratus.yml
+++ b/configs/fibratus.yml
@@ -195,6 +195,9 @@ kstream:
   # Determines whether file kernel events are collected by Kernel Logger provider
   #enable-fileio: true
 
+  # Determines whether VA map/unmap events are collected by Kernel Logger provider
+  #enable-vamap: true
+
   # Determines whether image kernel events are collected by Kernel Logger provider
   #enable-image: true
 

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -391,6 +391,7 @@ func (c *Config) addFlags() {
 		c.flags.Bool(enableRegistryKevents, true, "Determines whether registry kernel events are collected by Kernel Logger provider")
 		c.flags.Bool(enableNetKevents, true, "Determines whether network (TCP/UDP) kernel events are collected by Kernel Logger provider")
 		c.flags.Bool(enableFileIOKevents, true, "Determines whether disk I/O kernel events are collected by Kernel Logger provider")
+		c.flags.Bool(enableVAMapKevents, true, "Determines whether VA map/unmap events are collected by Kernel Logger provider")
 		c.flags.Bool(enableImageKevents, true, "Determines whether file I/O kernel events are collected by Kernel Logger provider")
 		c.flags.Bool(enableHandleKevents, false, "Determines whether object manager kernel events (handle creation/destruction) are collected by Kernel Logger provider")
 		c.flags.Bool(enableMemKevents, true, "Determines whether memory manager kernel events are collected by Kernel Logger provider")

--- a/pkg/config/schema_windows.go
+++ b/pkg/config/schema_windows.go
@@ -172,6 +172,7 @@ var schema = `
 				"enable-image": 	{"type": "boolean"},
 				"enable-registry": 	{"type": "boolean"},
 				"enable-fileio": 	{"type": "boolean"},
+				"enable-vamap":		{"type": "boolean"},
 				"enable-handle": 	{"type": "boolean"},
 				"enable-net": 		{"type": "boolean"},
 				"enable-mem": 		{"type": "boolean"},
@@ -185,7 +186,7 @@ var schema = `
 				"blacklist":		{
 					"type": "object",
 					"properties":	{
-						"events":	{"type": "array", "items": {"type": "string", "enum": ["CreateThread", "TerminateThread", "OpenProcess", "OpenThread", "SetThreadContext", "LoadImage", "UnloadImage", "CreateFile", "CloseFile", "ReadFile", "WriteFile", "DeleteFile", "RenameFile", "SetFileInformation", "EnumDirectory", "MapViewFile", "UnmapViewFile", "RegCreateKey", "RegOpenKey", "RegSetValue", "RegQueryValue", "RegQueryKey", "RegDeleteKey", "RegDeleteValue", "RegCloseKey", "Accept", "Send", "Recv", "Connect", "Disconnect", "Reconnect", "Retransmit", "CreateHandle", "CloseHandle", "DuplicateHandle", "QueryDns", "ReplyDns"]}},
+						"events":	{"type": "array", "items": {"type": "string", "enum": ["CreateThread", "TerminateThread", "OpenProcess", "OpenThread", "SetThreadContext", "LoadImage", "UnloadImage", "CreateFile", "CloseFile", "ReadFile", "WriteFile", "DeleteFile", "RenameFile", "SetFileInformation", "EnumDirectory", "MapViewFile", "UnmapViewFile", "RegCreateKey", "RegOpenKey", "RegSetValue", "RegQueryValue", "RegQueryKey", "RegDeleteKey", "RegDeleteValue", "RegCloseKey", "Accept", "Send", "Recv", "Connect", "Disconnect", "Reconnect", "Retransmit", "CreateHandle", "CloseHandle", "DuplicateHandle", "QueryDns", "ReplyDns", "VirtualAlloc", "VirtualFree"]}},
 						"images":	{"type": "array", "items": {"type": "string", "minLength": 1}}
 					},
 					"additionalProperties": false

--- a/pkg/filter/_fixtures/default/default.yml
+++ b/pkg/filter/_fixtures/default/default.yml
@@ -206,8 +206,11 @@
             9030
           )
       min-engine-version: 2.0.0
+    - name: Suspicious domains
+      condition: kevt.name = 'QueryDns' and dns.name = 'fishy.domain.dot'
+      min-engine-version: 2.0.0
 
-- group: Suspicious network-connecting binaries
+- group: Legitimate network-connecting binaries
   enabled: true
   rules:
     - name: Microsoft binaries

--- a/pkg/kcap/writer_windows_test.go
+++ b/pkg/kcap/writer_windows_test.go
@@ -188,7 +188,7 @@ func TestLiveKcap(t *testing.T) {
 	<-wait
 
 	// initiate the kernel trace and start consuming from the event stream
-	ktracec := kstream.NewController(cfg.Kstream)
+	ktracec := kstream.NewController(cfg, nil)
 	err := ktracec.Start()
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/kevent/ktypes/eventset.go
+++ b/pkg/kevent/ktypes/eventset.go
@@ -19,6 +19,7 @@
 package ktypes
 
 import (
+	"fmt"
 	"github.com/bits-and-blooms/bitset"
 	"golang.org/x/sys/windows"
 )
@@ -34,11 +35,12 @@ type EventsetMasks struct {
 
 // Set puts a new event type into the bitset.
 func (e *EventsetMasks) Set(ktype Ktype) {
-	i := e.bitsetIndex(ktype.GUID())
+	g := ktype.GUID()
+	i := e.bitsetIndex(g)
 	if i < 0 {
-		panic("invalid bitset index")
+		panic(fmt.Sprintf("invalid event bitset index: %s", g.String()))
 	}
-	e.masks[i].Set(uint(ktype.HookID()))
+	e.masks[e.bitsetIndex(ktype.GUID())].Set(uint(ktype.HookID()))
 }
 
 // Test checks if the given provider GUID and
@@ -48,16 +50,16 @@ func (e *EventsetMasks) Test(guid windows.GUID, hookID uint16) bool {
 	if i < 0 {
 		return false
 	}
-	return e.masks[i].Test(uint(hookID))
+	return e.masks[e.bitsetIndex(guid)].Test(uint(hookID))
 }
 
 // Clear clears the bitset for a given provider GUID.
 func (e *EventsetMasks) Clear(guid windows.GUID) {
 	i := e.bitsetIndex(guid)
 	if i < 0 {
-		panic("invalid bitset index")
+		panic(fmt.Sprintf("invalid event bitset index: %s", guid.String()))
 	}
-	e.masks[i].ClearAll()
+	e.masks[e.bitsetIndex(guid)].ClearAll()
 }
 
 func (e *EventsetMasks) bitsetIndex(guid windows.GUID) int {
@@ -72,16 +74,19 @@ func (e *EventsetMasks) bitsetIndex(guid windows.GUID) int {
 		return 3
 	case RegistryEventGUID:
 		return 4
-	case NetworkEventGUID:
+	case NetworkTCPEventGUID:
 		return 5
-	case HandleEventGUID:
+	case NetworkUDPEventGUID:
 		return 6
-	case MemEventGUID:
+	case HandleEventGUID:
 		return 7
-	case AuditAPIEventGUID:
+	case MemEventGUID:
 		return 8
-	case DNSEventGUID:
+	case AuditAPIEventGUID:
 		return 9
+	case DNSEventGUID:
+		return 10
+	default:
+		return -1
 	}
-	return -1
 }

--- a/pkg/kstream/consumer_windows_test.go
+++ b/pkg/kstream/consumer_windows_test.go
@@ -86,7 +86,7 @@ func TestRundownEvents(t *testing.T) {
 		EnableRegistryKevents: true,
 	}
 
-	kctrl := NewController(kstreamConfig)
+	kctrl := NewController(&config.Config{Kstream: kstreamConfig}, nil)
 	require.NoError(t, kctrl.Start())
 	defer kctrl.Close()
 	kstreamc := NewConsumer(kctrl, psnap, hsnap, &config.Config{
@@ -497,6 +497,7 @@ func TestConsumerEvents(t *testing.T) {
 		EnableThreadKevents:   true,
 		EnableImageKevents:    true,
 		EnableFileIOKevents:   true,
+		EnableVAMapKevents:    true,
 		EnableNetKevents:      true,
 		EnableRegistryKevents: true,
 		EnableMemKevents:      true,
@@ -506,7 +507,7 @@ func TestConsumerEvents(t *testing.T) {
 		StackEnrichment:       false,
 	}
 
-	kctrl := NewController(kstreamConfig)
+	kctrl := NewController(&config.Config{Kstream: kstreamConfig}, nil)
 	require.NoError(t, kctrl.Start())
 	defer kctrl.Close()
 	kstreamc := NewConsumer(kctrl, psnap, hsnap, &config.Config{Kstream: kstreamConfig, Filters: &config.Filters{}})
@@ -918,7 +919,7 @@ func TestCallstackEnrichment(t *testing.T) {
 		SymbolizeKernelAddresses: true,
 	}
 
-	kctrl := NewController(kstreamConfig)
+	kctrl := NewController(&config.Config{Kstream: kstreamConfig}, nil)
 	require.NoError(t, kctrl.Start())
 	defer kctrl.Close()
 	kstreamc := NewConsumer(kctrl, psnap, hsnap, cfg)

--- a/rules/credential_access_os_credential_dumping.yml
+++ b/rules/credential_access_os_credential_dumping.yml
@@ -50,7 +50,7 @@
                '?:\\Program Files (x86)\\*.exe'
              )
           | by ps.child.uuid
-          |(query_registry or open_registry)
+          |open_registry
               and
             registry.key.name imatches
               (


### PR DESCRIPTION
To optimize resource consumption and avoid processing events that are not used in the ruleset, this new mechanism
permits to dynamically enable event categories or providers depending on what event types are present in the loaded
ruleset.