### PR TITLE
feat: Introduce system providers support

### DIFF
--- a/cmd/fibratus/app/stats/stats.go
+++ b/cmd/fibratus/app/stats/stats.go
@@ -88,7 +88,6 @@ type Stats struct {
 	KstreamUnknownKevents               int            `json:"kstream.kevents.unknown"`
 	KstreamKeventsProcessed             int            `json:"kstream.kevents.processed"`
 	KstreamExcludedKevents              int            `json:"kstream.excluded.kevents"`
-	KstreamExcludedProcs                int            `json:"kstream.excluded.procs"`
 	KstreamKeventsFailures              map[string]int `json:"kstream.kevents.failures"`
 	LoggerErrors                        map[string]int `json:"logger.errors"`
 	OutputAMQPChannelFailures           int            `json:"output.amqp.channel.failures"`

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -300,6 +300,10 @@ func (c *Config) Init() error {
 	return nil
 }
 
+// IsCaptureSet determines if the events are stored
+// in the capture file.
+func (c *Config) IsCaptureSet() bool { return c.KcapFile != "" }
+
 // TryLoadFile attempts to load the configuration file from specified path on the file system.
 func (c *Config) TryLoadFile(file string) error {
 	c.viper.SetConfigFile(file)

--- a/pkg/config/kstream.go
+++ b/pkg/config/kstream.go
@@ -51,7 +51,7 @@ const (
 	excludedEvents = "kstream.blacklist.events"
 	excludedImages = "kstream.blacklist.images"
 
-	maxBufferSize = uint32(1024)
+	maxBufferSize = uint32(512)
 )
 
 var (

--- a/pkg/kevent/callstack_test.go
+++ b/pkg/kevent/callstack_test.go
@@ -64,7 +64,7 @@ func TestCallstack(t *testing.T) {
 }
 
 func TestCallstackDecorator(t *testing.T) {
-	q := NewQueue(50, false)
+	q := NewQueue(50, false, true)
 	cd := NewCallstackDecorator(q)
 
 	e := &Kevent{
@@ -131,7 +131,7 @@ func init() {
 }
 
 func TestCallstackDecoratorFlush(t *testing.T) {
-	q := NewQueue(50, false)
+	q := NewQueue(50, false, true)
 	q.RegisterListener(&DummyListener{})
 	cd := NewCallstackDecorator(q)
 

--- a/pkg/kevent/ktypes/eventset.go
+++ b/pkg/kevent/ktypes/eventset.go
@@ -27,7 +27,7 @@ import (
 // EventsetMasks allows efficient testing
 // of a group of bitsets containing event
 // hook identifiers. For each provider
-// is represented by a GUID, a dedicated
+// represented by a GUID, a dedicated
 // bitset is defined.
 type EventsetMasks struct {
 	masks [ProvidersCount]bitset.BitSet

--- a/pkg/kevent/ktypes/ktypes_windows.go
+++ b/pkg/kevent/ktypes/ktypes_windows.go
@@ -549,6 +549,9 @@ func (k Ktype) Source() EventSource {
 	}
 }
 
+// FromParts builds ktype from provider GUID and hook ID.
+func FromParts(g windows.GUID, id uint16) Ktype { return pack(g, id) }
+
 // pack merges event provider GUID and the hook ID into `Ktype` array.
 // The type provides a convenient way for comparing event types.
 func pack(g windows.GUID, id uint16) Ktype {

--- a/pkg/kevent/queue_test.go
+++ b/pkg/kevent/queue_test.go
@@ -173,7 +173,7 @@ func TestQueuePush(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			q := NewQueue(100, false)
+			q := NewQueue(100, false, true)
 			for _, lis := range tt.listeners() {
 				q.RegisterListener(lis)
 			}
@@ -202,7 +202,7 @@ func TestPushBacklog(t *testing.T) {
 		Metadata: make(Metadata),
 	}
 
-	q := NewQueue(100, false)
+	q := NewQueue(100, false, true)
 	q.RegisterListener(&DummyListener{})
 
 	require.NoError(t, q.Push(e))

--- a/pkg/kstream/consumer_windows_test.go
+++ b/pkg/kstream/consumer_windows_test.go
@@ -85,15 +85,16 @@ func TestRundownEvents(t *testing.T) {
 		EnableNetKevents:      true,
 		EnableRegistryKevents: true,
 	}
-
-	kctrl := NewController(&config.Config{Kstream: kstreamConfig}, nil)
-	require.NoError(t, kctrl.Start())
-	defer kctrl.Close()
-	kstreamc := NewConsumer(kctrl, psnap, hsnap, &config.Config{
+	cfg := &config.Config{
 		Kstream:  kstreamConfig,
 		KcapFile: "fake.kcap", // simulate capture to receive state/rundown events
 		Filters:  &config.Filters{},
-	})
+	}
+
+	kctrl := NewController(cfg, nil)
+	require.NoError(t, kctrl.Start())
+	defer kctrl.Close()
+	kstreamc := NewConsumer(kctrl, psnap, hsnap, cfg)
 	l := &MockListener{}
 	kstreamc.RegisterEventListener(l)
 	require.NoError(t, kstreamc.Open())

--- a/pkg/kstream/stackext.go
+++ b/pkg/kstream/stackext.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021-2022 by Nedim Sabic Sabic
+ * https://www.fibratus.io
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kstream
+
+import (
+	"github.com/rabbitstack/fibratus/pkg/config"
+	"github.com/rabbitstack/fibratus/pkg/kevent/ktypes"
+	"github.com/rabbitstack/fibratus/pkg/sys/etw"
+	"golang.org/x/sys/windows"
+)
+
+// StackExtensions manages stack tracing enablement
+// for particular event or event categories.
+type StackExtensions struct {
+	ids    []etw.ClassicEventID
+	config config.KstreamConfig
+}
+
+// NewStackExtensions creates an empty stack extensions.
+func NewStackExtensions(config config.KstreamConfig) *StackExtensions {
+	return &StackExtensions{ids: make([]etw.ClassicEventID, 0), config: config}
+}
+
+// AddStackTracing enables stack tracing for the specified event type.
+func (s *StackExtensions) AddStackTracing(ktype ktypes.Ktype) {
+	if !s.config.TestDropMask(ktype) {
+		s.ids = append(s.ids, etw.NewClassicEventID(ktype.GUID(), ktype.HookID()))
+	}
+}
+
+// AddStackTracingWith enables stack tracing for the specified provider GUID and event hook id.
+func (s *StackExtensions) AddStackTracingWith(guid windows.GUID, hookID uint16) {
+	if !s.config.TestDropMask(ktypes.FromParts(guid, hookID)) {
+		s.ids = append(s.ids, etw.NewClassicEventID(guid, hookID))
+	}
+}
+
+// EventIds returns all event types eligible for stack tracing.
+func (s *StackExtensions) EventIds() []etw.ClassicEventID { return s.ids }
+
+// EnableProcessStackTracing populates the stack identifiers
+// with event types eligible for emitting stack walk events
+// related to process telemetry, such as creating a process,
+// creating/terminating a thread or loading an image into
+// process address space.
+func (s *StackExtensions) EnableProcessStackTracing() {
+	s.AddStackTracing(ktypes.CreateProcess)
+	if s.config.EnableThreadKevents {
+		s.AddStackTracing(ktypes.CreateThread)
+		s.AddStackTracing(ktypes.TerminateThread)
+	}
+	if s.config.EnableImageKevents {
+		s.AddStackTracingWith(ktypes.ProcessEventGUID, ktypes.LoadImage.HookID())
+	}
+}
+
+// EnableFileStackTracing populates the stack identifiers
+// with event types eligible for publishing call stack
+// return addresses for file system activity.
+func (s *StackExtensions) EnableFileStackTracing() {
+	if s.config.EnableFileIOKevents {
+		s.AddStackTracing(ktypes.CreateFile)
+		s.AddStackTracing(ktypes.DeleteFile)
+		s.AddStackTracing(ktypes.RenameFile)
+	}
+}
+
+// EnableRegistryStackTracing populates the stack identifiers
+// with event types eligible for publishing call stack
+// return addresses for registry operations.
+func (s *StackExtensions) EnableRegistryStackTracing() {
+	if s.config.EnableRegistryKevents {
+		s.AddStackTracing(ktypes.RegCreateKey)
+		s.AddStackTracing(ktypes.RegDeleteKey)
+		s.AddStackTracing(ktypes.RegSetValue)
+		s.AddStackTracing(ktypes.RegDeleteValue)
+	}
+}

--- a/pkg/kstream/stackext_test.go
+++ b/pkg/kstream/stackext_test.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021-2022 by Nedim Sabic Sabic
+ * https://www.fibratus.io
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kstream
+
+import (
+	"github.com/rabbitstack/fibratus/pkg/config"
+	"github.com/rabbitstack/fibratus/pkg/kevent/ktypes"
+	"github.com/rabbitstack/fibratus/pkg/sys/etw"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestStackExtensions(t *testing.T) {
+	cfg := &config.Config{
+		Kstream: config.KstreamConfig{
+			EnableThreadKevents: true,
+			EnableNetKevents:    true,
+			EnableFileIOKevents: true,
+			BufferSize:          1024,
+			FlushTimer:          time.Millisecond * 2300,
+		},
+	}
+	exts := NewStackExtensions(cfg.Kstream)
+	assert.Len(t, exts.EventIds(), 0)
+
+	exts.EnableProcessStackTracing()
+	exts.EnableRegistryStackTracing()
+	exts.EnableFileStackTracing()
+
+	assert.Len(t, exts.EventIds(), 6)
+	assert.Contains(t, exts.EventIds(), etw.ClassicEventID{GUID: ktypes.ProcessEventGUID, Type: uint8(ktypes.CreateProcess.HookID())})
+	assert.Contains(t, exts.EventIds(), etw.ClassicEventID{GUID: ktypes.ThreadEventGUID, Type: uint8(ktypes.CreateThread.HookID())})
+	assert.Contains(t, exts.EventIds(), etw.ClassicEventID{GUID: ktypes.ThreadEventGUID, Type: uint8(ktypes.TerminateThread.HookID())})
+	assert.Contains(t, exts.EventIds(), etw.ClassicEventID{GUID: ktypes.FileEventGUID, Type: uint8(ktypes.CreateFile.HookID())})
+	assert.Contains(t, exts.EventIds(), etw.ClassicEventID{GUID: ktypes.FileEventGUID, Type: uint8(ktypes.RenameFile.HookID())})
+	assert.Contains(t, exts.EventIds(), etw.ClassicEventID{GUID: ktypes.FileEventGUID, Type: uint8(ktypes.DeleteFile.HookID())})
+}

--- a/pkg/pe/types.go
+++ b/pkg/pe/types.go
@@ -118,9 +118,9 @@ func (pe *PE) VerifySignature() {
 	pe.once.Do(func() {
 		if sys.IsWintrustFound() {
 			runtime.LockOSThread()
-			defer runtime.UnlockOSThread()
 			trust := sys.NewWintrustData(sys.WtdChoiceFile)
 			defer trust.Close()
+			defer runtime.UnlockOSThread()
 			pe.IsTrusted = trust.VerifyFile(pe.filename)
 			// maybe the PE is catalog signed?
 			if !pe.IsSigned {

--- a/pkg/sys/etw/types.go
+++ b/pkg/sys/etw/types.go
@@ -60,12 +60,55 @@ const (
 	KernelAuditAPICallsSession = "Kernel Audit API Calls Logger"
 	// DNSClientSession represents the session name for the DNS client logger
 	DNSClientSession = "DNS Client Logger"
+
+	// SystemProcessSession represents system process provider logger
+	SystemProcessSession = "System Process Logger"
+	// SystemIOSession represents system I/O provider logger
+	SystemIOSession = "System I/O Logger"
+	// SystemRegistrySession represents system registry logger
+	SystemRegistrySession = "System Registry Logger"
+	// SystemMemorySession represents system memory logger
+	SystemMemorySession = "System Memory Logger"
+
 	// WnodeTraceFlagGUID indicates that the structure contains event tracing information
 	WnodeTraceFlagGUID = 0x00020000
 	// ProcessTraceModeRealtime denotes that there will be a real-time consumers for events forwarded from the providers
 	ProcessTraceModeRealtime = 0x00000100
 	// ProcessTraceModeEventRecord is the mode that enables the "event record" format for kernel events
 	ProcessTraceModeEventRecord = 0x10000000
+	// EventTraceSystemLoggerMode enables events from system loggers
+	EventTraceSystemLoggerMode = 0x02000000
+)
+
+var (
+	// SystemProcessProviderID provides events related to the process, including lifetime information, image load events, and thread related events.
+	SystemProcessProviderID = windows.GUID{Data1: 0x151f55dc, Data2: 0x467d, Data3: 0x471f, Data4: [8]byte{0x83, 0xb5, 0x5f, 0x88, 0x9d, 0x46, 0xff, 0x66}}
+	// SystemIOProviderID provides events related to multiple kinds of IO including disk, cache, and network.
+	SystemIOProviderID = windows.GUID{Data1: 0x3d5c43e3, Data2: 0x0f1c, Data3: 0x4202, Data4: [8]byte{0xb8, 0x17, 0x17, 0x4c, 0x00, 0x70, 0xdc, 0x79}}
+	// SystemRegistryProviderID provides events related to the registry.
+	SystemRegistryProviderID = windows.GUID{Data1: 0x16156bd9, Data2: 0xfab4, Data3: 0x4cfa, Data4: [8]byte{0xa2, 0x32, 0x89, 0xd1, 0x09, 0x90, 0x58, 0xe3}}
+	// SystemMemoryProviderID provides events related to the memory manager.
+	SystemMemoryProviderID = windows.GUID{Data1: 0x82958ca9, Data2: 0xb6cd, Data3: 0x47f8, Data4: [8]byte{0xa3, 0xa8, 0x03, 0xae, 0x85, 0xa4, 0xbc, 0x24}}
+)
+
+const (
+	// ProcessKeywordGeneral enables process events
+	ProcessKeywordGeneral = 0x1
+	// ProcessKeywordThread enables thread events
+	ProcessKeywordThread = 0x800
+	// ProcessKeywordLoader enables image load/unload events
+	ProcessKeywordLoader = 0x1000
+
+	// RegistryKeywordGeneral enables registry events
+	RegistryKeywordGeneral = 0x1
+
+	// IOKeywordNetwork enables network events
+	IOKeywordNetwork = 0x200
+
+	// MemoryVirtualAlloc enables memory alloc events
+	MemoryVirtualAlloc = 0x400
+	// MemoryVAMap enables section mapping/unmapping events
+	MemoryVAMap = 0x4000
 )
 
 const (

--- a/pkg/util/key/key.go
+++ b/pkg/util/key/key.go
@@ -30,8 +30,8 @@ import (
 )
 
 var (
-	hklmPrefixes = []string{"\\REGISTRY\\MACHINE", "\\Registry\\Machine", "\\Registry\\MACHINE"}
-	hkcrPrefixes = []string{"\\REGISTRY\\MACHINE\\SOFTWARE\\CLASSES", "\\Registry\\Machine\\Software\\Classes"}
+	hklmPrefixes = []string{"\\REGISTRY\\MACHINE", "\\Registry\\Machine", "\\Registry\\MACHINE", "\\registry\\machine"}
+	hkcrPrefixes = []string{"\\REGISTRY\\MACHINE\\SOFTWARE\\CLASSES", "\\Registry\\Machine\\Software\\Classes", "\\REGISTRY\\COMROOT\\CLASSES"}
 	hkuPrefixes  = []string{"\\REGISTRY\\USER", "\\Registry\\User"}
 )
 


### PR DESCRIPTION
When granular system provider support is detected, the kernel trace session only emits file I/O
events. The remaining events are published by their respective system providers. This speeds up delivering events from the session buffers which is integral to achieving near real-time detections.