### PR TITLE
perf(stack-enrichment): Boost stack enrichment performance

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -240,7 +240,7 @@ func (f *App) Run(args []string) error {
 	} else {
 		// register stack symbolizer
 		if cfg.Kstream.StackEnrichment {
-			f.symbolizer = symbolize.NewSymbolizer(symbolize.NewDebugHelpResolver(cfg), cfg, false)
+			f.symbolizer = symbolize.NewSymbolizer(symbolize.NewDebugHelpResolver(cfg), f.psnap, cfg, false)
 			f.consumer.RegisterEventListener(f.symbolizer)
 		}
 		// register rule engine

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -401,7 +401,7 @@ func (c *Config) addFlags() {
 		c.flags.Bool(enableMemKevents, true, "Determines whether memory manager kernel events are collected by Kernel Logger provider")
 		c.flags.Bool(enableAuditAPIEvents, true, "Determines whether kernel audit API calls events are published")
 		c.flags.Bool(enableDNSEvents, true, "Determines whether DNS client events are enabled")
-		c.flags.Bool(stackEnrichment, true, "Indicates if stack enrichment is enabled for eligible events")
+		c.flags.Bool(stackEnrichment, c.boolFromFlagSet(rulesEnabled), "Indicates if stack enrichment is enabled for eligible events")
 		c.flags.Int(bufferSize, int(maxBufferSize), "Represents the amount of memory allocated for each event tracing session buffer, in kilobytes. The buffer size affects the rate at which buffers fill and must be flushed (small buffer size requires less memory but it increases the rate at which buffers must be flushed)")
 		c.flags.Int(minBuffers, int(defaultMinBuffers), "Determines the minimum number of buffers allocated for the event tracing session's buffer pool")
 		c.flags.Int(maxBuffers, int(defaultMaxBuffers), "Determines the maximum number of buffers allocated for the event tracing session's buffer pool")
@@ -416,4 +416,9 @@ func (c *Config) addFlags() {
 		c.flags.Bool(serializeEnvs, true, "Indicates if environment variables are serialized as part of the process state")
 	}
 	c.Log.AddFlags(c.flags)
+}
+
+func (c *Config) boolFromFlagSet(f string) bool {
+	b, _ := c.flags.GetBool(f)
+	return b
 }

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -419,6 +419,9 @@ func (c *Config) addFlags() {
 }
 
 func (c *Config) boolFromFlagSet(f string) bool {
-	b, _ := c.flags.GetBool(f)
+	b, err := c.flags.GetBool(f)
+	if err != nil {
+		return false
+	}
 	return b
 }

--- a/pkg/kevent/callstack.go
+++ b/pkg/kevent/callstack.go
@@ -123,6 +123,9 @@ func (s *Callstack) Init(n int) {
 
 // PushFrame pushes a new from to the call stack.
 func (s *Callstack) PushFrame(f Frame) {
+	if f.Module == "" {
+		f.Module = unbacked
+	}
 	*s = append(*s, f)
 }
 

--- a/pkg/kevent/callstack.go
+++ b/pkg/kevent/callstack.go
@@ -34,7 +34,7 @@ import (
 
 // maxDequeFlushPeriod specifies the maximum period
 // for the events to reside in the deque.
-var maxDequeFlushPeriod = 2 * time.Minute
+var maxDequeFlushPeriod = time.Minute
 
 // callstackFlushes computes overall callstack dequeue flushes
 var callstackFlushes = expvar.NewInt("callstack.flushes")

--- a/pkg/ps/snapshotter.go
+++ b/pkg/ps/snapshotter.go
@@ -52,6 +52,9 @@ type Snapshotter interface {
 	// if the process was find in the state. Otherwise, returns false and constructs a fresh process
 	// state by querying the OS via API functions.
 	Find(pid uint32) (bool, *pstypes.PS)
+	// FindModule traverses loaded modules of all processes in the snapshot and
+	// if there is module with the specified base address, it returns its metadata.
+	FindModule(addr va.Address) (bool, *pstypes.Module)
 	// FindAndPut attempts to retrieve process' state for the specified process identifier.
 	// If the process is found, the snapshotter state is updated with the new process.
 	FindAndPut(pid uint32) *pstypes.PS

--- a/pkg/ps/snapshotter_mock.go
+++ b/pkg/ps/snapshotter_mock.go
@@ -48,6 +48,15 @@ func (s *SnapshotterMock) Find(pid uint32) (bool, *pstypes.PS) {
 	return args.Bool(0), args.Get(1).(*pstypes.PS)
 }
 
+func (s *SnapshotterMock) FindModule(addr va.Address) (bool, *pstypes.Module) {
+	args := s.Called(addr)
+	mod := args.Get(1)
+	if mod != nil {
+		return args.Bool(0), mod.(*pstypes.Module)
+	}
+	return args.Bool(0), nil
+}
+
 // FindAndPut method
 func (s *SnapshotterMock) FindAndPut(pid uint32) *pstypes.PS {
 	args := s.Called(pid)

--- a/pkg/ps/snapshotter_windows.go
+++ b/pkg/ps/snapshotter_windows.go
@@ -249,6 +249,19 @@ func (s *snapshotter) RemoveModule(pid uint32, module string) error {
 	return nil
 }
 
+func (s *snapshotter) FindModule(addr va.Address) (bool, *pstypes.Module) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, proc := range s.procs {
+		for _, mod := range proc.Modules {
+			if mod.BaseAddress == addr {
+				return true, &mod
+			}
+		}
+	}
+	return false, nil
+}
+
 func (s *snapshotter) AddFileMapping(e *kevent.Kevent) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/symbolize/symbolizer_test.go
+++ b/pkg/symbolize/symbolizer_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/kevent"
 	"github.com/rabbitstack/fibratus/pkg/kevent/kparams"
 	"github.com/rabbitstack/fibratus/pkg/kevent/ktypes"
+	"github.com/rabbitstack/fibratus/pkg/pe"
+	"github.com/rabbitstack/fibratus/pkg/ps"
 	pstypes "github.com/rabbitstack/fibratus/pkg/ps/types"
 	"github.com/rabbitstack/fibratus/pkg/sys"
 	"github.com/rabbitstack/fibratus/pkg/util/va"
@@ -34,6 +36,7 @@ import (
 	"golang.org/x/sys/windows"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -81,12 +84,14 @@ func TestLoadKernelModuleSymbolTables(t *testing.T) {
 	r := new(MockResolver)
 	c := &config.Config{SymbolizeKernelAddresses: true}
 
+	psnap := new(ps.SnapshotterMock)
+
 	opts := uint32(sys.SymUndname | sys.SymCaseInsensitive | sys.SymAutoPublics)
 	r.On("Initialize", windows.CurrentProcess(), opts).Return(nil)
 	r.On("LoadModule", windows.CurrentProcess(), mock.Anything, mock.Anything).Return(nil)
 	r.On("UnloadModule", mock.Anything, mock.Anything)
 
-	s := NewSymbolizer(r, c, false)
+	s := NewSymbolizer(r, psnap, c, false)
 	require.NotNil(t, s)
 	defer s.Close()
 
@@ -98,9 +103,11 @@ func TestProcessCallstackFastMode(t *testing.T) {
 	r := new(MockResolver)
 	c := &config.Config{}
 
+	psnap := new(ps.SnapshotterMock)
+
 	r.On("UnloadModule", mock.Anything, mock.Anything)
 
-	s := NewSymbolizer(r, c, false)
+	s := NewSymbolizer(r, psnap, c, false)
 	require.NotNil(t, s)
 	defer s.Close()
 
@@ -154,27 +161,27 @@ func TestProcessCallstackFastMode(t *testing.T) {
 	assert.True(t, e.Callstack.ContainsUnbacked())
 }
 
-func TestProcessCallstackFullMode(t *testing.T) {
+func TestProcessCallstackPeExports(t *testing.T) {
 	r := new(MockResolver)
 	c := &config.Config{}
+	log.SetLevel(log.DebugLevel)
 
+	psnap := new(ps.SnapshotterMock)
+
+	r.On("UnloadModule", mock.Anything, mock.Anything)
 	opts := uint32(sys.SymUndname | sys.SymCaseInsensitive | sys.SymAutoPublics | sys.SymOmapFindNearest | sys.SymDeferredLoads)
 	r.On("Initialize", mock.Anything, opts).Return(nil)
-	r.On("LoadModule", windows.CurrentProcess(), mock.Anything).Return(nil)
-
-	r.On("GetModuleName", mock.Anything, mock.Anything).Return("C:\\WINDOWS\\System32\\KERNEL32.DLL").Once()
-	r.On("GetModuleName", mock.Anything, mock.Anything).Return("C:\\WINDOWS\\System32\\KERNELBASE.dll").Once()
-	r.On("GetModuleName", mock.Anything, mock.Anything).Return("C:\\WINDOWS\\System32\\ntdll.dll").Times(3)
-
-	r.On("GetSymbolNameAndOffset", mock.Anything, mock.Anything).Return("CreateProcessW", 0x54).Once()
-	r.On("GetSymbolNameAndOffset", mock.Anything, mock.Anything).Return("CreateProcessW", 0x66).Once()
-	r.On("GetSymbolNameAndOffset", mock.Anything, mock.Anything).Return("NtCreateProcess", 0x3a2).Once()
-	r.On("GetSymbolNameAndOffset", mock.Anything, mock.Anything).Return("NtCreateProcessEx", 0x3a2).Times(2)
-
 	r.On("Cleanup", mock.Anything)
 
-	s := NewSymbolizer(r, c, false)
+	r.On("GetModuleName", mock.Anything, mock.Anything).Return("?").Once()
+	r.On("GetSymbolNameAndOffset", mock.Anything, mock.Anything).Return("?", 0).Once()
+	r.On("GetSymbolNameAndOffset", mock.Anything, mock.Anything).Return("CreateProcessW", 0x54).Once()
+
+	psnap.On("FindModule", mock.Anything).Return(false, nil).Once()
+
+	s := NewSymbolizer(r, psnap, c, false)
 	require.NotNil(t, s)
+	defer s.Close()
 
 	proc := &pstypes.PS{
 		Name:      "notepad.exe",
@@ -191,10 +198,149 @@ func TestProcessCallstackFullMode(t *testing.T) {
 		},
 		Envs: map[string]string{"ProgramData": "C:\\ProgramData", "COMPUTRENAME": "archrabbit"},
 		Modules: []pstypes.Module{
-			{Name: "ntdll.dll", Size: 32358, Checksum: 23123343, BaseAddress: va.Address(0x7ffb313833a3), DefaultBaseAddress: va.Address(0x7ffb313833a3)},
-			{Name: "kernel32.dll", Size: 12354, Checksum: 23123343, BaseAddress: va.Address(0x7ffb5c1d0126), DefaultBaseAddress: va.Address(0x7ffb5c1d0126)},
-			{Name: "user32.dll", Size: 212354, Checksum: 33123343, BaseAddress: va.Address(0x7ffb5d8e11c4), DefaultBaseAddress: va.Address(0x7ffb5d8e11c4)},
+			{Name: "C:\\Windows\\System32\\ntdll.dll", Size: 32358, Checksum: 23123343, BaseAddress: va.Address(0x7ffb313833a3), DefaultBaseAddress: va.Address(0x7ffb313833a3)},
+			{Name: "C:\\Windows\\System32\\kernel32.dll", Size: 12354, Checksum: 23123343, BaseAddress: va.Address(0x7ffb5c1d0126), DefaultBaseAddress: va.Address(0x7ffb5c1d0126)},
+			{Name: "C:\\Windows\\System32\\user32.dll", Size: 212354, Checksum: 33123343, BaseAddress: va.Address(0x7ffb5d8e11c4), DefaultBaseAddress: va.Address(0x7ffb5d8e11c4)},
 		},
+	}
+
+	e := &kevent.Kevent{
+		Type:        ktypes.CreateFile,
+		Tid:         2484,
+		PID:         uint32(os.Getpid()),
+		CPU:         1,
+		Seq:         2,
+		Name:        "CreateFile",
+		Timestamp:   time.Now(),
+		Category:    ktypes.File,
+		Host:        "archrabbit",
+		Description: "Creates or opens a new file, directory, I/O device, pipe, console",
+		Kparams: kevent.Kparams{
+			kparams.FileObject:    {Name: kparams.FileObject, Type: kparams.Uint64, Value: uint64(12456738026482168384)},
+			kparams.FileName:      {Name: kparams.FileName, Type: kparams.UnicodeString, Value: "C:\\Windows\\system32\\mimi.dll"},
+			kparams.FileType:      {Name: kparams.FileType, Type: kparams.AnsiString, Value: "file"},
+			kparams.FileOperation: {Name: kparams.FileOperation, Type: kparams.Enum, Value: uint32(2), Enum: fs.FileCreateDispositions},
+			kparams.Callstack:     {Name: kparams.Callstack, Type: kparams.Slice, Value: []va.Address{0x7ffb5c1d0396, 0x7ffb5d8e61f4, 0x7ffb3138592e, 0x7ffb313853b2, 0x2638e59e0a5}},
+		},
+		PS: proc,
+	}
+
+	parsePeFile = func(name string, option ...pe.Option) (*pe.PE, error) {
+		exports := map[uint32]string{
+			8192:  "RtlSetSearchPathMode",
+			9344:  "RtlCreateQueryDebugBuffer",
+			20352: "LoadKeyboardLayoutW",
+		}
+		px := &pe.PE{
+			Exports: exports,
+		}
+		return px, nil
+	}
+
+	_, err := s.ProcessEvent(e)
+	require.NoError(t, err)
+
+	assert.Len(t, e.Callstack, 5)
+	assert.Len(t, e.Callstack.Symbols(), 5)
+	assert.Len(t, e.Callstack.Modules(), 5)
+
+	assert.Equal(t, "unbacked!?", e.Callstack.Symbols()[0])
+	assert.Equal(t, "ntdll.dll!RtlSetSearchPathMode", e.Callstack.Symbols()[1])
+	assert.Equal(t, "ntdll.dll!RtlCreateQueryDebugBuffer", e.Callstack.Symbols()[2])
+	assert.Equal(t, "user32.dll!LoadKeyboardLayoutW", e.Callstack.Symbols()[3])
+	assert.Equal(t, "kernel32.dll!CreateProcessW", e.Callstack.Symbols()[4])
+
+	assert.Equal(t, "kernel32.dll|user32.dll|ntdll.dll|unbacked", e.Callstack.Summary())
+	assert.True(t, e.Callstack.ContainsUnbacked())
+
+	// check internal state
+	assert.Len(t, s.mods, 3)
+
+	// should have populated the symbols cache
+	assert.Len(t, s.symbols, 1)
+	assert.Equal(t, "C:\\Windows\\System32\\kernel32.dll!CreateProcessW", s.symbols[e.PID][0x7ffb5c1d0396])
+
+	// image load event should add module exports
+	// and when the image is unloaded and there are
+	// no processes with the image section mapped
+	// inside their VAS, we can remove the module
+	e2 := &kevent.Kevent{
+		Type:      ktypes.LoadImage,
+		Tid:       2484,
+		PID:       uint32(12328),
+		CPU:       1,
+		Seq:       2,
+		Name:      "LoadImage",
+		Timestamp: time.Now(),
+		Category:  ktypes.Image,
+		Kparams: kevent.Kparams{
+			kparams.ImageBase: {Name: kparams.ImageBase, Type: kparams.Address, Value: uint64(0x12345f)},
+			kparams.FileName:  {Name: kparams.FileName, Type: kparams.UnicodeString, Value: "C:\\Windows\\System32\\bcrypt32.dll"},
+		},
+		PS: proc,
+	}
+	_, err = s.ProcessEvent(e2)
+	require.NoError(t, err)
+	assert.Len(t, s.mods, 4)
+
+	e3 := &kevent.Kevent{
+		Type:      ktypes.UnloadImage,
+		Tid:       2484,
+		PID:       uint32(12328),
+		CPU:       1,
+		Seq:       2,
+		Name:      "UnloadImage",
+		Timestamp: time.Now(),
+		Category:  ktypes.Image,
+		Kparams: kevent.Kparams{
+			kparams.ImageBase: {Name: kparams.ImageBase, Type: kparams.Address, Value: uint64(0x12345f)},
+			kparams.FileName:  {Name: kparams.FileName, Type: kparams.UnicodeString, Value: filepath.Join(os.Getenv("SystemRoot"), "System32", "bcrypt32.dll")},
+		},
+		PS: proc,
+	}
+	_, err = s.ProcessEvent(e3)
+	require.NoError(t, err)
+	assert.Len(t, s.mods, 3)
+}
+
+func TestProcessCallstackFullMode(t *testing.T) {
+	r := new(MockResolver)
+	c := &config.Config{}
+
+	psnap := new(ps.SnapshotterMock)
+
+	opts := uint32(sys.SymUndname | sys.SymCaseInsensitive | sys.SymAutoPublics | sys.SymOmapFindNearest | sys.SymDeferredLoads)
+	r.On("Initialize", mock.Anything, opts).Return(nil)
+	r.On("LoadModule", windows.CurrentProcess(), mock.Anything).Return(nil)
+
+	r.On("GetModuleName", mock.Anything, mock.Anything).Return("C:\\WINDOWS\\System32\\KERNEL32.DLL").Once()
+	r.On("GetModuleName", mock.Anything, mock.Anything).Return("C:\\WINDOWS\\System32\\KERNELBASE.dll").Once()
+	r.On("GetModuleName", mock.Anything, mock.Anything).Return("C:\\WINDOWS\\System32\\ntdll.dll").Times(3)
+
+	r.On("GetSymbolNameAndOffset", mock.Anything, mock.Anything).Return("CreateProcessW", 0x54).Once()
+	r.On("GetSymbolNameAndOffset", mock.Anything, mock.Anything).Return("CreateProcessW", 0x66).Once()
+	r.On("GetSymbolNameAndOffset", mock.Anything, mock.Anything).Return("NtCreateProcess", 0x3a2).Once()
+	r.On("GetSymbolNameAndOffset", mock.Anything, mock.Anything).Return("NtCreateProcessEx", 0x3a2).Times(2)
+
+	r.On("Cleanup", mock.Anything)
+
+	s := NewSymbolizer(r, psnap, c, false)
+	require.NotNil(t, s)
+
+	proc := &pstypes.PS{
+		Name:      "notepad.exe",
+		PID:       23234,
+		Ppid:      2434,
+		Exe:       `C:\Windows\notepad.exe`,
+		Cmdline:   `C:\Windows\notepad.exe`,
+		SID:       "S-1-1-18",
+		Cwd:       `C:\Windows\`,
+		SessionID: 1,
+		Threads: map[uint32]pstypes.Thread{
+			3453: {Tid: 3453, Entrypoint: va.Address(140729524944768), IOPrio: 2, PagePrio: 5, KstackBase: va.Address(18446677035730165760), KstackLimit: va.Address(18446677035730137088), UstackLimit: va.Address(86376448), UstackBase: va.Address(86372352)},
+			3455: {Tid: 3455, Entrypoint: va.Address(140729524944768), IOPrio: 3, PagePrio: 5, KstackBase: va.Address(18446677035730165760), KstackLimit: va.Address(18446677035730137088), UstackLimit: va.Address(86376448), UstackBase: va.Address(86372352)},
+		},
+		Envs: map[string]string{"ProgramData": "C:\\ProgramData", "COMPUTRENAME": "archrabbit"},
 	}
 	e := &kevent.Kevent{
 		Type:      ktypes.CreateProcess,
@@ -248,6 +394,8 @@ func TestProcessCallstackProcsTTL(t *testing.T) {
 	r := new(MockResolver)
 	c := &config.Config{}
 
+	psnap := new(ps.SnapshotterMock)
+
 	opts := uint32(sys.SymUndname | sys.SymCaseInsensitive | sys.SymAutoPublics | sys.SymOmapFindNearest | sys.SymDeferredLoads)
 	r.On("Initialize", mock.Anything, opts).Return(nil)
 	r.On("LoadModule", windows.CurrentProcess(), mock.Anything).Return(nil)
@@ -255,7 +403,7 @@ func TestProcessCallstackProcsTTL(t *testing.T) {
 	r.On("GetSymbolNameAndOffset", mock.Anything, mock.Anything).Return("CreateProcessW", 0x54)
 	r.On("Cleanup", mock.Anything)
 
-	s := NewSymbolizer(r, c, false)
+	s := NewSymbolizer(r, psnap, c, false)
 	require.NotNil(t, s)
 	defer s.Close()
 


### PR DESCRIPTION
Stack return address symbolization is performed from process modules and symbol data obtained from the PE export directory. Debug Help API is used when either the module is not found or symbol information can't be resolved.