### PR TITLE
refactor(rule-engine): Remove kill action `pid` field

### DIFF
--- a/pkg/config/_fixtures/filters/default.yml
+++ b/pkg/config/_fixtures/filters/default.yml
@@ -11,7 +11,6 @@
         `%ps.exe` attempted to reach out to `%net.sip` IP address
       action:
       - name: kill
-        pid: ps.pid
       min-engine-version: 2.0.0
 
 - group: rouge processes

--- a/pkg/config/filters_test.go
+++ b/pkg/config/filters_test.go
@@ -59,7 +59,6 @@ func TestLoadGroupsFromPaths(t *testing.T) {
 	require.NoError(t, err)
 	require.IsType(t, KillAction{}, acts[0])
 
-	assert.Equal(t, "ps.pid", acts[0].(KillAction).Pid)
 	assert.Equal(t, "2.0.0", g1.Rules[0].MinEngineVersion)
 
 	g2 := filters.groups[1]

--- a/pkg/config/schema_windows.go
+++ b/pkg/config/schema_windows.go
@@ -518,8 +518,7 @@ var rulesSchema = `
 									"items": {
 										"type": "object",
 										"properties": {
-											"name": 	{"type": "string", "enum": ["kill"]},
-											"pid": 		{"type": "string", "minLength": 5}
+											"name": 	{"type": "string", "enum": ["kill"]}
 										},
 										"required": ["name"],
 										"additionalProperties": false

--- a/pkg/filter/_fixtures/kill_action.yml
+++ b/pkg/filter/_fixtures/kill_action.yml
@@ -6,5 +6,4 @@
       severity: critical
       action:
       - name: kill
-        pid: ps.child.pid
       min-engine-version: 2.0.0

--- a/pkg/filter/rules.go
+++ b/pkg/filter/rules.go
@@ -1024,15 +1024,10 @@ func (r *Rules) processActions() error {
 			return err
 		}
 		for _, act := range actions {
-			switch act := act.(type) {
+			switch act.(type) {
 			case config.KillAction:
-				field := act.Pid
-				if field == "" {
-					field = "ps.pid"
-				}
-				pid := act.PidToInt(InterpolateFields("%"+field, evts))
-				log.Infof("executing kill action: pid=%d rule=%s", pid, f.Name)
-				if err := action.Kill(pid); err != nil {
+				log.Infof("executing kill action: pids=%v rule=%s", m.ctx.UniquePids(), f.Name)
+				if err := action.Kill(m.ctx.UniquePids()); err != nil {
 					return ErrRuleAction(f.Name, err)
 				}
 			}

--- a/pkg/util/convert/convert_test.go
+++ b/pkg/util/convert/convert_test.go
@@ -18,24 +18,15 @@
 
 package convert
 
-// Btoi converts the provided bool value to uint8 integer.
-func Btoi(b bool) uint8 {
-	if b {
-		return 1
-	}
-	return 0
-}
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
 
-// Itob converts the provided uint8 integer to a bool value.
-func Itob(i uint8) bool {
-	return i > 0
-}
-
-// MapKeysToSlice given the map, it converts the map keys to a slice.
-func MapKeysToSlice[K comparable, V any](m map[K]V) []K {
-	s := make([]K, 0, len(m))
-	for k := range m {
-		s = append(s, k)
-	}
-	return s
+func TestMapKeysToSlice(t *testing.T) {
+	m := map[uint32]bool{1245: true, 2233: false, 341234: true}
+	s := MapKeysToSlice(m)
+	assert.Len(t, s, 3)
+	assert.Contains(t, s, uint32(1245))
+	assert.Contains(t, s, uint32(341234))
 }


### PR DESCRIPTION
Introducing a field to specify which process id is used to terminate the process may be convoluted and at the same time superfluous to handle. For this reason, the pid field is removed from the action definition, and the action automatically collects pids to be killed by walking event matches.