### PR TITLE
perf(rule-engine): Determine sequence ordering

### DIFF
--- a/pkg/filter/action/kill_windows.go
+++ b/pkg/filter/action/kill_windows.go
@@ -42,7 +42,7 @@ func terminate(pid uint32) error {
 	proc, err := windows.OpenProcess(syscall.PROCESS_TERMINATE, false, pid)
 	if err != nil {
 		errno, ok := err.(windows.Errno)
-		if ok && errno.Is(os.ErrNotExist) {
+		if ok && (errno.Is(os.ErrNotExist) || err == windows.ERROR_INVALID_PARAMETER) {
 			return nil
 		}
 		return fmt.Errorf("couldn't open pid %d for termination: %v", pid, err)

--- a/pkg/filter/ql/parser.go
+++ b/pkg/filter/ql/parser.go
@@ -97,6 +97,9 @@ func (p *Parser) ParseSequence() (*Sequence, error) {
 			if seq.impairBy() {
 				return nil, fmt.Errorf("%s: all expressions require the 'by' statement", p.expr)
 			}
+			if seq.incompatibleConstraints() {
+				return nil, fmt.Errorf("%s: sequence mixes global and per-expression 'by' statements", p.expr)
+			}
 			return seq, nil
 		}
 		p.unscan()

--- a/pkg/filter/ql/parser.go
+++ b/pkg/filter/ql/parser.go
@@ -100,6 +100,7 @@ func (p *Parser) ParseSequence() (*Sequence, error) {
 			if seq.incompatibleConstraints() {
 				return nil, fmt.Errorf("%s: sequence mixes global and per-expression 'by' statements", p.expr)
 			}
+			seq.init()
 			return seq, nil
 		}
 		p.unscan()

--- a/pkg/filter/ql/parser_test.go
+++ b/pkg/filter/ql/parser_test.go
@@ -243,7 +243,6 @@ func TestParseSequence(t *testing.T) {
 		{
 
 			`maxspan 20s
-             by ps.pid
 			 |kevt.name = 'CreateProcess'| by ps.pid
 			 |kevt.name = 'CreateFile'| by ps.pid
 			`,
@@ -290,6 +289,17 @@ func TestParseSequence(t *testing.T) {
 			errors.New("maximum span 40h0m0s cannot be greater than 4h"),
 			time.Hour * 40,
 			false,
+		},
+		{
+
+			`by ps.uuid
+			 maxspan 2m
+			 |kevt.name = 'CreateProcess'| by ps.child.uuid
+			 |kevt.name = 'CreateFile'| by ps.uuid
+			`,
+			errors.New("sequence mixes global and per-expression 'by' statements"),
+			time.Minute * 2,
+			true,
 		},
 	}
 

--- a/pkg/filter/ql/parser_test.go
+++ b/pkg/filter/ql/parser_test.go
@@ -342,9 +342,40 @@ func TestIsSequenceUnordered(t *testing.T) {
 		},
 		{
 			`|kevt.name = 'CreateProcess'|
+			 |kevt.name = 'UnmapViewFile'|
+ 			 |kevt.name = 'LoadImage'|
+			`,
+			false,
+		},
+		{
+			`|kevt.name = 'CreateProcess'|
 			 |kevt.name = 'SetThreadContext'|
 			`,
 			true,
+		},
+		{
+			`|kevt.name = 'OpenThread'| by ps.uuid
+			 |kevt.name = 'OpenProcess'| by ps.uuid
+			`,
+			false,
+		},
+		{
+			`|kevt.name = 'OpenThread' or kevt.name = 'OpenProcess'| by ps.uuid
+			 |kevt.name = 'SetThreadContext'| by ps.uuid
+			`,
+			false,
+		},
+		{
+			`|kevt.name = 'RegSetValue'| by ps.uuid
+			 |kevt.name = 'SetThreadContext'| by ps.uuid
+			`,
+			true,
+		},
+		{
+			`|kevt.name = 'RegSetValue'| by ps.uuid
+			 |kevt.name = 'RegDeleteValue'| by ps.uuid
+			`,
+			false,
 		},
 	}
 
@@ -353,8 +384,8 @@ func TestIsSequenceUnordered(t *testing.T) {
 		seq, err := p.ParseSequence()
 		require.NoError(t, err)
 
-		if seq.IsUnordered() != tt.isUnordered {
-			t.Errorf("%d. exp=%s isUnordered=%t got isUnordered=%t", i, tt.expr, tt.isUnordered, seq.IsUnordered())
+		if seq.IsUnordered != tt.isUnordered {
+			t.Errorf("%d. exp=%s isUnordered=%t got isUnordered=%t", i, tt.expr, tt.isUnordered, seq.IsUnordered)
 		}
 	}
 }

--- a/pkg/filter/rules.go
+++ b/pkg/filter/rules.go
@@ -848,6 +848,9 @@ func (r *Rules) runSequence(kevt *kevent.Kevent, f *compiledFilter) bool {
 		// only try to evaluate the expression
 		// if upstream expressions have matched
 		if !f.ss.next(i) {
+			if !seq.IsUnordered() {
+				continue
+			}
 			// it could be the event arrived out
 			// of order because certain provider
 			// flushed its buffers first. When this

--- a/pkg/filter/rules.go
+++ b/pkg/filter/rules.go
@@ -848,7 +848,7 @@ func (r *Rules) runSequence(kevt *kevent.Kevent, f *compiledFilter) bool {
 		// only try to evaluate the expression
 		// if upstream expressions have matched
 		if !f.ss.next(i) {
-			if !seq.IsUnordered() {
+			if !seq.IsUnordered {
 				continue
 			}
 			// it could be the event arrived out

--- a/pkg/kevent/ktypes/ktypes_windows.go
+++ b/pkg/kevent/ktypes/ktypes_windows.go
@@ -549,6 +549,15 @@ func (k Ktype) Source() EventSource {
 	}
 }
 
+// CanArriveOutOfOrder indicates if the event can be
+// emitted by the provider in out-of-order fashion, i.e.
+// its timestamp is perfectly aligned in relation to other
+// events, but it appears first on the consumer callback
+// before other events published before it.
+func (k Ktype) CanArriveOutOfOrder() bool {
+	return k.Category() == Registry || k.Subcategory() == DNS || k == OpenProcess || k == OpenThread || k == SetThreadContext
+}
+
 // FromParts builds ktype from provider GUID and hook ID.
 func FromParts(g windows.GUID, id uint16) Ktype { return pack(g, id) }
 

--- a/pkg/kevent/ktypes/ktypes_windows_test.go
+++ b/pkg/kevent/ktypes/ktypes_windows_test.go
@@ -128,3 +128,9 @@ func TestGUIDAndHookIDFromKtype(t *testing.T) {
 		})
 	}
 }
+
+func TestCanArriveOutOfOrder(t *testing.T) {
+	assert.True(t, RegSetValue.CanArriveOutOfOrder())
+	assert.False(t, VirtualAlloc.CanArriveOutOfOrder())
+	assert.True(t, OpenProcess.CanArriveOutOfOrder())
+}


### PR DESCRIPTION
Some sequence expressions contain events that may arrive out of order. Only for such expressions the sequence evaluation should honor out-of-order partials. If the sequence references out-of-order events but all pertain to the same provider, then the sequence can be denoted as ordered.