### PR TITLE
feat(rules): New `Potential Process Hollowing` rule

### DIFF
--- a/rules/defense_evasion_process_injection.yml
+++ b/rules/defense_evasion_process_injection.yml
@@ -66,3 +66,41 @@
       - name: kill
       min-engine-version: 2.2.0
 
+- group: Process Hollowing
+  description: |
+    Adversaries may inject malicious code into suspended and hollowed processes in order to
+    evade process-based defenses. Process hollowing is a method of executing arbitrary code
+    in the address space of a separate live process.
+
+    Process hollowing is commonly performed by creating a process in a suspended state then
+    unmapping/hollowing its memory, which can then be replaced with malicious code. A victim
+    process can be created with native Windows API calls such as CreateProcess, which includes
+    a flag to suspend the processes primary thread. At this point the process can be unmapped
+    using APIs calls such as ZwUnmapViewOfSection or NtUnmapViewOfSection before being written
+    to, realigned to the injected code, and resumed via VirtualAllocEx, WriteProcessMemory,
+    SetThreadContext, then ResumeThread/ResumeProcess respectively.
+  labels:
+    tactic.id: TA0005
+    tactic.name: Defense Evasion
+    tactic.ref: https://attack.mitre.org/tactics/TA0005/
+    technique.id: T1055
+    technique.name: Process Injection
+    technique.ref: https://attack.mitre.org/techniques/T1055/
+    subtechnique.id: T1055.012
+    subtechnique.name: Process Hollowing
+    subtechnique.ref: https://attack.mitre.org/techniques/T1055/012/
+  rules:
+    - name: Potential Process Hollowing
+      description: |
+        Identifies process hollowing injection attempts by spawning a legitimate process
+        in a suspended state. The code section of the process' executable in-memory image
+        is unmapped and replaced enabling the veiled execution of malicious code.
+      condition: >
+        sequence
+        maxspan 2m
+        |spawn_process| by ps.child.uuid
+        |unmap_view_of_section and (length(file.name) = 0 or not ext(file.name) = '.dll')| by ps.uuid
+        |load_executable and pe.is_modified| by ps.uuid
+      action:
+      - name: kill
+      min-engine-version: 2.0.0

--- a/rules/macros/macros.yml
+++ b/rules/macros/macros.yml
@@ -62,10 +62,10 @@
   expr: kevt.name = 'UnmapViewFile'
 
 - macro: map_view_of_section
-  expr: map_view_file and file.view.type in ('IMAGE', 'IMAGE_NO_EXECUTE`)
+  expr: map_view_file and file.view.type in ('IMAGE', 'IMAGE_NO_EXECUTE')
 
 - macro: unmap_view_of_section
-  expr: unmap_view_file and file.view.type in ('IMAGE', 'IMAGE_NO_EXECUTE`)
+  expr: unmap_view_file and file.view.type in ('IMAGE', 'IMAGE_NO_EXECUTE')
 
 - macro: duplicate_handle
   expr: kevt.name = 'DuplicateHandle'


### PR DESCRIPTION
This rule identifies process hollowing injection attempts by spawning a legitimate process in a suspended state. The code section of the process' executable in-memory image is unmapped and replaced enabling the veiled execution of malicious code.