### PR TITLE
refactor(rule): Suspicious DLL loaded by LSASS

### DIFF
--- a/rules/credential_access_modify_authentication_process.yml
+++ b/rules/credential_access_modify_authentication_process.yml
@@ -19,7 +19,8 @@
         Detects attempts to register malicious password filters to harvest credentials
         from local computers and/or entire domains. To perform proper validation,
         filters must receive plain-text credentials from the LSA. A malicious password
-        filter would receive these plain-text credentials every time a password request is made.
+        filter would receive these plain-text credentials every time a password request
+        is made.
       condition: >
         sequence
         maxspan 5m
@@ -34,23 +35,19 @@
            registry.value iin (base($e1.file.name, false))
           |
       output: >
-        Detected `%1.ps.exe` process dropping a potentially malicious
-        `%1.file.name` password filter DLL and subsequently `%2.ps.name`
-        process registering the password filter DLL in the Notification
+        Detected `%1.ps.name` process dropping a potentially malicious
+        `%1.file.name` password filter DLL and subsequently process
+        `%2.ps.name` registering the password filter DLL in the Notification
         Packages registry key. This may be indicative of potential abuse
         of password filters to steal credentials material.
       min-engine-version: 2.0.0
-    - name: Potential credentials dumping or exfiltration via malicious password filter DLL
+    - name: Suspicious DLL loaded by LSASS
       description: |
-        Detects possible credentials dumping or exfiltration via malicious password filter DLL.
-        Adversaries can leverage the password filter DLL to intercept passwords in clear-text
-        and exfiltrate them via C2 channels.
+        Attackers can abuse Windows Security Support Provider and Authentication Packages to
+        dynamically inject a Security Package into the Local Security Authority Subsystem Service
+        process to intercept all logon passwords.
       condition: >
-        (outbound_network)
+        (load_unsigned_or_untrusted_module)
             and
         ps.name ~= 'lsass.exe'
-            and
-        base(ps.modules, false)
-            iin
-        (get_reg_value('HKLM\\SYSTEM\\CurrentControlSet\\Control\\Lsa\\Notification Packages'))
       min-engine-version: 2.0.0


### PR DESCRIPTION
Attackers can abuse Windows Security Support Provider and Authentication Packages to dynamically inject a Security Package into the Local Security Authority Subsystem Service process to intercept all logon passwords. This rule supersedes the `Potential credentials dumping or exfiltration via malicious password filter DLL` rule.