### PR TITLE
perf: Move enrichment to accessors

### DIFF
--- a/pkg/filter/fields/fields_windows.go
+++ b/pkg/filter/fields/fields_windows.go
@@ -485,7 +485,8 @@ func (f Field) IsPeSignature() bool {
 func (f Field) IsPeIsTrusted() bool { return f == PeIsTrusted }
 func (f Field) IsPeIsSigned() bool  { return f == PeIsSigned }
 
-func (f Field) IsPeCert() bool { return strings.HasPrefix(string(f), "pe.cert.") }
+func (f Field) IsPeCert() bool    { return strings.HasPrefix(string(f), "pe.cert.") }
+func (f Field) IsImageCert() bool { return strings.HasPrefix(string(f), "image.cert.") }
 
 func (f Field) IsPeModified() bool { return f == PeIsModified }
 

--- a/pkg/filter/filter_windows.go
+++ b/pkg/filter/filter_windows.go
@@ -49,7 +49,7 @@ func New(expr string, config *config.Config, options ...Option) Filter {
 	for _, opt := range options {
 		opt(&opts)
 	}
-	accessors := []accessor{
+	accessors := []Accessor{
 		// general event parameters
 		newKevtAccessor(),
 		// process state and parameters
@@ -122,7 +122,7 @@ func NewFromCLIWithAllAccessors(args []string) (Filter, error) {
 	}
 	filter := &filter{
 		parser:       ql.NewParser(expr),
-		accessors:    getAccessors(),
+		accessors:    GetAccessors(),
 		fields:       make([]fields.Field, 0),
 		stringFields: make(map[fields.Field][]string),
 		boundFields:  make([]*ql.BoundFieldLiteral, 0),

--- a/pkg/kevent/callstack.go
+++ b/pkg/kevent/callstack.go
@@ -22,7 +22,9 @@ import (
 	"expvar"
 	"github.com/gammazero/deque"
 	"github.com/rabbitstack/fibratus/pkg/kevent/kparams"
+	"github.com/rabbitstack/fibratus/pkg/util/multierror"
 	"github.com/rabbitstack/fibratus/pkg/util/va"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/arch/x86/x86asm"
 	"golang.org/x/sys/windows"
 	"path/filepath"
@@ -34,7 +36,7 @@ import (
 
 // maxDequeFlushPeriod specifies the maximum period
 // for the events to reside in the deque.
-var maxDequeFlushPeriod = time.Minute
+var maxDequeFlushPeriod = time.Second * 30
 
 // callstackFlushes computes overall callstack dequeue flushes
 var callstackFlushes = expvar.NewInt("callstack.flushes")
@@ -283,13 +285,17 @@ type CallstackDecorator struct {
 	deq *deque.Deque[*Kevent]
 	q   *Queue
 	mux sync.Mutex
+
+	flusher *time.Ticker
 }
 
 // NewCallstackDecorator creates a new callstack decorator
 // which receives the event queue for long-standing event
 // flushing.
 func NewCallstackDecorator(q *Queue) *CallstackDecorator {
-	return &CallstackDecorator{q: q, deq: deque.New[*Kevent](100)}
+	c := &CallstackDecorator{q: q, deq: deque.New[*Kevent](100), flusher: time.NewTicker(time.Second * 5)}
+	go c.doFlush()
+	return c
 }
 
 // Push pushes a new event to the queue.
@@ -316,10 +322,20 @@ func (cd *CallstackDecorator) Pop(e *Kevent) *Kevent {
 	return evt
 }
 
-// Flush pushes events to the event queue if they have
+func (cd *CallstackDecorator) doFlush() {
+	for {
+		<-cd.flusher.C
+		errs := cd.flush()
+		if len(errs) > 0 {
+			log.Warnf("callstack: unable to flush queued events: %v", multierror.Wrap(errs...))
+		}
+	}
+}
+
+// flush pushes events to the event queue if they have
 // been living in the deque more than the maximum allowed
 // flush period.
-func (cd *CallstackDecorator) Flush() []error {
+func (cd *CallstackDecorator) flush() []error {
 	cd.mux.Lock()
 	defer cd.mux.Unlock()
 	if cd.deq.Len() == 0 {

--- a/pkg/kevent/callstack_test.go
+++ b/pkg/kevent/callstack_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/kevent/ktypes"
 	"github.com/rabbitstack/fibratus/pkg/util/va"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 )
@@ -128,12 +127,14 @@ func TestCallstackDecorator(t *testing.T) {
 
 func init() {
 	maxDequeFlushPeriod = time.Second * 2
+	flusherInterval = time.Second
 }
 
 func TestCallstackDecoratorFlush(t *testing.T) {
 	q := NewQueue(50, false, true)
 	q.RegisterListener(&DummyListener{})
 	cd := NewCallstackDecorator(q)
+	defer cd.Stop()
 
 	e := &Kevent{
 		Type:      ktypes.CreateFile,
@@ -154,9 +155,7 @@ func TestCallstackDecoratorFlush(t *testing.T) {
 
 	cd.Push(e)
 	assert.True(t, cd.deq.Len() == 1)
-	time.Sleep(time.Millisecond * 4100)
-
-	require.Len(t, cd.Flush(), 0)
+	time.Sleep(time.Millisecond * 3100)
 
 	evt := <-q.Events()
 	assert.True(t, cd.deq.Len() == 0)

--- a/pkg/kevent/kparam.go
+++ b/pkg/kevent/kparam.go
@@ -353,7 +353,7 @@ func (kpars Kparams) GetBool(name string) (bool, error) {
 }
 
 // TryGetBool tries to retrieve the boolean value from the parameter.
-// Returns the underyling value on success, or false otherwise.
+// Returns the underlying value on success, or false otherwise.
 func (kpars Kparams) TryGetBool(name string) bool {
 	val, err := kpars.GetBool(name)
 	if err != nil {
@@ -396,6 +396,16 @@ func (kpars Kparams) MustGetUint16(name string) uint16 {
 		panic(err)
 	}
 	return v
+}
+
+// TryGetUint16 tries to retrieve the uint16 value from the parameter.
+// Returns the underlying value on success, or zero otherwise.
+func (kpars Kparams) TryGetUint16(name string) uint16 {
+	val, err := kpars.GetUint16(name)
+	if err != nil {
+		return 0
+	}
+	return val
 }
 
 // GetInt16 returns the underlying int16 value from the parameter.
@@ -568,6 +578,15 @@ func (kpars Kparams) GetIP(name string) (net.IP, error) {
 		return net.IP{}, fmt.Errorf("unable to type cast %q parameter to net.IP value", name)
 	}
 	return v, nil
+}
+
+// MustGetIP returns the IP address parameter or panics if an error occurs.
+func (kpars Kparams) MustGetIP(name string) net.IP {
+	ip, err := kpars.GetIP(name)
+	if err != nil {
+		panic(err)
+	}
+	return ip
 }
 
 // GetTime returns the underlying time structure from the parameter.

--- a/pkg/kevent/queue.go
+++ b/pkg/kevent/queue.go
@@ -111,13 +111,6 @@ func (q *Queue) Push(e *Kevent) error {
 		if e.IsStackWalk() {
 			e = q.cd.Pop(e)
 		}
-		if !e.IsStackWalk() {
-			// flush long-standing events
-			errs := q.cd.Flush()
-			if len(errs) > 0 {
-				return multierror.Wrap(errs...)
-			}
-		}
 	}
 	if isEventDelayed(e) {
 		q.backlog.put(e)

--- a/pkg/kevent/queue.go
+++ b/pkg/kevent/queue.go
@@ -80,6 +80,9 @@ func (q *Queue) RegisterListener(listener Listener) {
 // Events returns the channel with all queued events.
 func (q *Queue) Events() <-chan *Kevent { return q.q }
 
+// Close closes the queue disposing allocated resources.
+func (q *Queue) Close() { q.cd.Stop() }
+
 // Push pushes a new event to the channel. Prior to
 // sending the event to the channel, all registered
 // listeners are invoked. The event is sent to the

--- a/pkg/kstream/consumer_windows.go
+++ b/pkg/kstream/consumer_windows.go
@@ -215,6 +215,7 @@ func (s *sink) run(evts chan *kevent.Kevent) {
 		case evt := <-s.q.Events():
 			evts <- evt
 		case <-s.quit:
+			s.q.Close()
 			return
 		}
 	}

--- a/pkg/kstream/consumer_windows_test.go
+++ b/pkg/kstream/consumer_windows_test.go
@@ -195,10 +195,7 @@ func TestConsumerEvents(t *testing.T) {
 			nil,
 			func(e *kevent.Kevent) bool {
 				img := filepath.Join(os.Getenv("windir"), "System32", "notepad.exe")
-				// should get a catalog-signed binary
-				signatureType := e.GetParamAsString(kparams.ImageSignatureType)
-				return e.IsLoadImage() && strings.EqualFold(img, e.GetParamAsString(kparams.ImageFilename)) &&
-					signatureType == "CATALOG_CACHED"
+				return e.IsLoadImage() && strings.EqualFold(img, e.GetParamAsString(kparams.ImageFilename))
 			},
 			false,
 		},

--- a/pkg/kstream/processors/net_windows_test.go
+++ b/pkg/kstream/processors/net_windows_test.go
@@ -54,10 +54,6 @@ func TestNetworkProcessor(t *testing.T) {
 				assert.Equal(t, "8.8.8.8", e.GetParamAsString(kparams.NetDIP))
 				assert.Equal(t, "443", e.GetParamAsString(kparams.NetDport))
 				assert.Equal(t, "43123", e.GetParamAsString(kparams.NetSport))
-
-				names, err := e.Kparams.GetStringSlice(kparams.NetDIPNames)
-				require.NoError(t, err)
-				assert.Contains(t, names, "dns.google.")
 			},
 		},
 		{

--- a/pkg/network/dns.go
+++ b/pkg/network/dns.go
@@ -64,9 +64,15 @@ type dnsNames struct {
 	expiration int64
 }
 
-// NewReverseDNS creates a new DNS reverser with the specified size and TTL period.
-func NewReverseDNS(size int, ttl, exp time.Duration) *ReverseDNS {
-	reverseDNS := &ReverseDNS{
+var r *ReverseDNS
+
+// GetReverseDNS creates a new singleton instance of DNS reverser with the specified size and TTL period.
+func GetReverseDNS(size int, ttl, exp time.Duration) *ReverseDNS {
+	if r != nil {
+		return r
+	}
+
+	r = &ReverseDNS{
 		domains:   make(map[Address]*dnsNames),
 		blacklist: make(map[Address]int),
 		size:      size,
@@ -79,14 +85,15 @@ func NewReverseDNS(size int, ttl, exp time.Duration) *ReverseDNS {
 		for {
 			select {
 			case <-tick.C:
-				reverseDNS.Expire()
-			case <-reverseDNS.close:
+				r.Expire()
+			case <-r.close:
 				tick.Stop()
 				return
 			}
 		}
 	}()
-	return reverseDNS
+
+	return r
 }
 
 // Add performs a reverse lookup for the given address, returning a list

--- a/pkg/network/dns_test.go
+++ b/pkg/network/dns_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestLookupAddr(t *testing.T) {
-	reverseDNS := NewReverseDNS(100, time.Minute, time.Minute)
+	reverseDNS := GetReverseDNS(100, time.Minute, time.Minute)
 	names, err := reverseDNS.Add(AddressFromIP(net.ParseIP("8.8.8.8")))
 
 	require.NoError(t, err)
@@ -40,7 +40,7 @@ func TestLookupAddr(t *testing.T) {
 }
 
 func TestLookupAddrBlacklisted(t *testing.T) {
-	reverseDNS := NewReverseDNS(100, time.Minute, time.Minute)
+	reverseDNS := GetReverseDNS(100, time.Minute, time.Minute)
 	for i := 0; i < maxFailedDNSLookups+1; i++ {
 		_, err := reverseDNS.Add(AddressFromIP(net.ParseIP("1.2.3.1")))
 		require.Error(t, err)
@@ -50,7 +50,7 @@ func TestLookupAddrBlacklisted(t *testing.T) {
 }
 
 func TestLookupAddrExpiration(t *testing.T) {
-	reverseDNS := NewReverseDNS(100, time.Millisecond*5, time.Minute)
+	reverseDNS := GetReverseDNS(100, time.Millisecond*5, time.Minute)
 
 	names, err := reverseDNS.Add(AddressFromIP(net.ParseIP("8.8.8.8")))
 
@@ -68,7 +68,7 @@ func TestLookupAddrExpiration(t *testing.T) {
 }
 
 func TestLookupAddrTickerExpiration(t *testing.T) {
-	reverseDNS := NewReverseDNS(100, time.Millisecond*50, time.Millisecond*80)
+	reverseDNS := GetReverseDNS(100, time.Millisecond*50, time.Millisecond*80)
 
 	names, err := reverseDNS.Add(AddressFromIP(net.ParseIP("8.8.8.8")))
 	require.NoError(t, err)

--- a/pkg/network/dns_test.go
+++ b/pkg/network/dns_test.go
@@ -50,6 +50,8 @@ func TestLookupAddrBlacklisted(t *testing.T) {
 }
 
 func TestLookupAddrExpiration(t *testing.T) {
+	r = nil // request a fresh reverse DNS
+
 	reverseDNS := GetReverseDNS(100, time.Millisecond*5, time.Minute)
 
 	names, err := reverseDNS.Add(AddressFromIP(net.ParseIP("8.8.8.8")))
@@ -68,6 +70,8 @@ func TestLookupAddrExpiration(t *testing.T) {
 }
 
 func TestLookupAddrTickerExpiration(t *testing.T) {
+	r = nil // request a fresh reverse DNS
+
 	reverseDNS := GetReverseDNS(100, time.Millisecond*50, time.Millisecond*80)
 
 	names, err := reverseDNS.Add(AddressFromIP(net.ParseIP("8.8.8.8")))

--- a/pkg/util/cmdline/cmdline.go
+++ b/pkg/util/cmdline/cmdline.go
@@ -89,6 +89,11 @@ func (c *Cmdline) CleanExe() *Cmdline {
 			c.cmdline = strings.Join(append([]string{exe[4:]}, args[1:]...), " ")
 			return c
 		}
+		// remove \\?\ prefix from executable path
+		if len(exe) > 4 && exe[2] == '?' && exe[3] == '\\' {
+			c.cmdline = strings.Join(append([]string{exe[4:]}, args[1:]...), " ")
+			return c
+		}
 	}
 	return c
 }

--- a/pkg/util/cmdline/cmdline_test.go
+++ b/pkg/util/cmdline/cmdline_test.go
@@ -106,10 +106,11 @@ func TestCmdline(t *testing.T) {
 			`C:\WINDOWS\system32\svchost.exe -k RPCSS -p`,
 		},
 		{
-			`"C:\Program Files\Conexant\SAII\CxUtilSvc.exe"`,
-			`C:\Program Files\Conexant\SAII\CxUtilSvc.exe`,
-			`"C:\Program Files\Conexant\SAII\CxUtilSvc.exe"`,
+			`\\?\C:\Windows\System32\SecurityHealth\1.0.2402.27001-0\SecurityHealthHost.exe {E041C90B-68BA-42C9-991E-477B73A75C90} -Embedding`,
+			`C:\Windows\System32\SecurityHealth\1.0.2402.27001-0\SecurityHealthHost.exe`,
+			`\\?\C:\Windows\System32\SecurityHealth\1.0.2402.27001-0\SecurityHealthHost.exe {E041C90B-68BA-42C9-991E-477B73A75C90} -Embedding`,
 		},
+		{},
 	}
 
 	for _, tt := range tests {

--- a/pkg/util/signature/signature_test.go
+++ b/pkg/util/signature/signature_test.go
@@ -63,13 +63,12 @@ func TestSignature(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sig, err := Check(tt.filename)
+			sign := &Signature{Filename: tt.filename}
+			typ, _, err := sign.Check()
 			assert.True(t, err == tt.err)
-			if sig != nil {
-				assert.Equal(t, tt.sigType, sig.Type)
-				sig.Verify()
-				assert.Equal(t, tt.sigLevel, sig.Level)
-			}
+			sign.Verify()
+			assert.Equal(t, tt.sigType, typ)
+			assert.Equal(t, tt.sigLevel, sign.Level)
 		})
 	}
 }

--- a/rules/credential_access_os_credential_dumping.yml
+++ b/rules/credential_access_os_credential_dumping.yml
@@ -81,7 +81,8 @@
                 '?:\\Windows\\System32\\MoUsoCoreWorker.exe',
                 '?:\\Windows\\System32\\lpremove.exe',
                 '?:\\Windows\\System32\\LogonUI.exe',
-                '?:\\ProgramData\\Microsoft\\Windows Defender\\*\\MsMpEng.exe'
+                '?:\\ProgramData\\Microsoft\\Windows Defender\\*\\MsMpEng.exe',
+                '?:\\Windows\\System32\\ApplicationFrameHost.exe'
               )
             | by ps.uuid
       min-engine-version: 2.0.0

--- a/rules/defense_evasion_process_injection.yml
+++ b/rules/defense_evasion_process_injection.yml
@@ -53,15 +53,15 @@
         sequence
         maxspan 2m
         by ps.uuid
-        |create_file
-            and
-         thread.callstack.symbols imatches
-            (
-              'kernel32.dll!CreateFileTransacted*',
-              'ntdll.dll!RtlSetCurrentTransaction'
-            )
-        |
-        |spawn_process|
+          |create_file
+              and
+           thread.callstack.symbols imatches
+              (
+                'kernel32.dll!CreateFileTransacted*',
+                'ntdll.dll!RtlSetCurrentTransaction'
+              )
+          |
+          |spawn_process|
       action:
       - name: kill
       min-engine-version: 2.2.0
@@ -98,9 +98,9 @@
       condition: >
         sequence
         maxspan 2m
-        |spawn_process| by ps.child.uuid
-        |unmap_view_of_section and (length(file.name) = 0 or not ext(file.name) = '.dll')| by ps.uuid
-        |load_executable and pe.is_modified| by ps.uuid
+          |spawn_process| by ps.child.uuid
+          |unmap_view_of_section and (length(file.name) = 0 or not ext(file.name) = '.dll')| by ps.uuid
+          |load_executable and pe.is_modified| by ps.uuid
       action:
       - name: kill
       min-engine-version: 2.0.0

--- a/rules/persistence_boot_or_logon_autostart_execution.yml
+++ b/rules/persistence_boot_or_logon_autostart_execution.yml
@@ -73,7 +73,8 @@
               '?:\\Windows\\System32\\sihost.exe',
               '?:\\Windows\\SysWOW64\\prevhost.exe',
               '?:\\Windows\\System32\\conhost.exe',
-              '?:\\Windows\\System32\\taskhostw.exe'
+              '?:\\Windows\\System32\\taskhostw.exe',
+              '?:\\Windows\\System32\\backgroundTaskHost.exe'
             )
       min-engine-version: 2.0.0
     - name: Network connection via startup folder executable or script


### PR DESCRIPTION
Reverse DNS enrichment and image signature checking are both moved to accessors. The accessor interface is refactored and a new `IsFieldAccessible` method will only evaluate an event against the accessor if the condition is met. As part of this refactoring, instead of trying to flush the queue on each event, a periodical timer will traverse the queue and flush any events that remained in deque more time than allowed.