### PR TITLE
feat(rules): New `Process injection via section mapping` rules

### DIFF
--- a/pkg/filter/accessor_windows.go
+++ b/pkg/filter/accessor_windows.go
@@ -731,6 +731,8 @@ func (l *fileAccessor) Get(f fields.Field, kevt *kevent.Kevent) (kparams.Value, 
 		return kevt.Kparams.GetUint64(kparams.FileViewSize)
 	case fields.FileViewType:
 		return kevt.GetParamAsString(kparams.FileViewSectionType), nil
+	case fields.FileViewProtection:
+		return kevt.GetParamAsString(kparams.MemProtect), nil
 	case fields.FileIsDriverVulnerable, fields.FileIsDriverMalicious:
 		if kevt.IsCreateDisposition() && kevt.IsSuccess() {
 			return isLOLDriver(f, kevt)
@@ -742,6 +744,10 @@ func (l *fileAccessor) Get(f fields.Field, kevt *kevent.Kevent) (kparams.Value, 
 		return kevt.Kparams.GetBool(kparams.FileIsDriver)
 	case fields.FileIsExecutable:
 		return kevt.Kparams.GetBool(kparams.FileIsExecutable)
+	case fields.FilePID:
+		return kevt.Kparams.GetPid()
+	case fields.FileKey:
+		return kevt.Kparams.GetUint64(kparams.FileKey)
 	}
 	return nil, nil
 }

--- a/pkg/filter/fields/fields_windows.go
+++ b/pkg/filter/fields/fields_windows.go
@@ -364,6 +364,8 @@ const (
 	FileViewSize Field = "file.view.size"
 	// FileViewType represents the type of the mapped view section
 	FileViewType Field = "file.view.type"
+	// FileViewProtection represents the protection attributes of the section view
+	FileViewProtection Field = "file.view.protection"
 	// FileIsDriverVulnerable represents the field that denotes whether the created file is a vulnerable driver
 	FileIsDriverVulnerable Field = "file.is_driver_vulnerable"
 	// FileIsDriverMalicious represents the field that denotes whether the created file is a malicious driver
@@ -374,6 +376,10 @@ const (
 	FileIsDriver Field = "file.is_driver"
 	// FileIsExecutable indicates if the created file is an executable
 	FileIsExecutable Field = "file.is_exec"
+	// FilePID represents the field that denotes the process id performing file operations
+	FilePID Field = "file.pid"
+	// FileKey represents the field that uniquely identifies the file object.
+	FileKey Field = "file.key"
 
 	// RegistryKeyName represents the registry key name
 	RegistryKeyName Field = "registry.key.name"
@@ -705,11 +711,14 @@ var fields = map[Field]FieldInfo{
 	FileViewBase:           {FileViewBase, "view base address", kparams.Address, []string{"file.view.base = '25d42170000'"}, nil},
 	FileViewSize:           {FileViewSize, "size of the mapped view", kparams.Uint64, []string{"file.view.size > 1024"}, nil},
 	FileViewType:           {FileViewType, "type of the mapped view section", kparams.Enum, []string{"file.view.type = 'IMAGE'"}, nil},
+	FileViewProtection:     {FileViewProtection, "protection rights of the section view", kparams.AnsiString, []string{"file.view.protection = 'READONLY'"}, nil},
 	FileIsDriverMalicious:  {FileIsDriverMalicious, "indicates if the dropped driver is malicious", kparams.Bool, []string{"file.is_driver_malicious"}, nil},
 	FileIsDriverVulnerable: {FileIsDriverVulnerable, "indicates if the dropped driver is vulnerable", kparams.Bool, []string{"file.is_driver_vulnerable"}, nil},
 	FileIsDLL:              {FileIsDLL, "indicates if the created file is a DLL", kparams.Bool, []string{"file.is_dll'"}, nil},
 	FileIsDriver:           {FileIsDriver, "indicates if the created file is a driver", kparams.Bool, []string{"file.is_driver'"}, nil},
 	FileIsExecutable:       {FileIsExecutable, "indicates if the created file is an executable", kparams.Bool, []string{"file.is_exec'"}, nil},
+	FilePID:                {FilePID, "denotes the process id performing file operation", kparams.PID, []string{"file.pid = 4"}, nil},
+	FileKey:                {FileKey, "uniquely identifies the file object", kparams.Uint64, []string{"file.key = 12446738026482168384"}, nil},
 
 	RegistryKeyName:   {RegistryKeyName, "fully qualified key name", kparams.UnicodeString, []string{"registry.key.name contains 'HKEY_LOCAL_MACHINE'"}, nil},
 	RegistryKeyHandle: {RegistryKeyHandle, "registry key object address", kparams.Address, []string{"registry.key.handle = 'FFFFB905D60C2268'"}, nil},

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -205,6 +205,9 @@ func (f *filter) RunSequence(kevt *kevent.Kevent, seqID uint16, partials map[uin
 					evt = evts[n]
 				}
 				for _, accessor := range f.accessors {
+					if !accessor.IsFieldAccessible(evt) {
+						continue
+					}
 					v, err := accessor.Get(field.Field(), evt)
 					if err != nil && !kerrors.IsKparamNotFound(err) {
 						accessorErrors.Add(err.Error(), 1)

--- a/rules/defense_evasion_process_injection.yml
+++ b/rules/defense_evasion_process_injection.yml
@@ -148,3 +148,53 @@
       action:
       - name: kill
       min-engine-version: 2.2.0
+    - name: Potential process injection via tainted memory section
+      description: |
+        Identifies potential process injection when the adversary creates and maps a memory
+        section with RW protection rights followed by mapping of the same memory section in
+        the remote process with RX protection.
+        By definition, the mapped view in the target process mirrors the content of the local
+        process' address space. The attacker can poison the local section memory with shellcode
+        and execute it in the context of the remote process.
+      condition: >
+        sequence
+        maxspan 1m
+          |map_view_of_section and file.view.protection = 'READWRITE' and kevt.pid != 4 and file.view.size >= 4096| as e1
+          |map_view_of_section and file.view.protection = 'READONLY|EXECUTE' and file.key = $e1.file.key and kevt.pid != $e1.kevt.pid|
+      action:
+      - name: kill
+      min-engine-version: 2.2.0
+
+- group: Dynamic-link Library Injection
+  description: |
+    Adversaries may inject dynamic-link libraries (DLLs) into processes in order to evade process-based defenses
+    as well as possibly elevate privileges. DLL injection is a method of executing arbitrary code in the address
+    space of a separate live process.
+
+    DLL injection is commonly performed by writing the path to a DLL in the virtual address space of the target
+    process before loading the DLL by invoking a new thread. The write can be performed with native Windows API
+    calls such as VirtualAllocEx and WriteProcessMemory, then invoked with CreateRemoteThread, which calls the
+    LoadLibrary API responsible for loading the DLL.
+  labels:
+    tactic.id: TA0005
+    tactic.name: Defense Evasion
+    tactic.ref: https://attack.mitre.org/tactics/TA0005/
+    technique.id: T1055
+    technique.name: Process Injection
+    technique.ref: https://attack.mitre.org/techniques/T1055/
+    subtechnique.id: T1055.001
+    subtechnique.name: Dynamic-link Library Injection
+    subtechnique.ref: https://attack.mitre.org/techniques/T1055/001/
+  rules:
+    - name: Suspicious DLL loaded via memory section mapping
+      description: |
+        Identifies the mapping of a memory section with RX protection followed by unsigned DLL loading.
+      condition: >
+        sequence
+        maxspan 2m
+        by ps.uuid
+          |map_view_of_section and file.view.protection = 'READONLY|EXECUTE' and kevt.pid != 4 and file.view.size >= 4096|
+          |(load_unsigned_or_untrusted_dll)|
+      action:
+      - name: kill
+      min-engine-version: 2.2.0

--- a/rules/macros/macros.yml
+++ b/rules/macros/macros.yml
@@ -62,7 +62,7 @@
   expr: kevt.name = 'UnmapViewFile'
 
 - macro: map_view_of_section
-  expr: map_view_file and file.view.type in ('IMAGE', 'IMAGE_NO_EXECUTE')
+  expr: map_view_file and file.view.type in ('IMAGE', 'IMAGE_NO_EXECUTE', 'PAGEFILE')
 
 - macro: unmap_view_of_section
   expr: unmap_view_file and file.view.type in ('IMAGE', 'IMAGE_NO_EXECUTE')
@@ -110,17 +110,13 @@
 - macro: unload_driver
   expr: unload_image and (image.name iendswith '.sys' or image.is_driver)
 
-- macro: load_unsigned_module
-  expr: >
-    load_module and image.signature.type = 'NONE'
-  description: |
-    Detects when unsigned executable or DLL is loaded into process address space.
-    The module is considered as unsigned if it lacks the cert in the PE security
-    directory or the Authenticode hash is not present in any of the catalogs.
-
 - macro: load_executable
   expr: >
     load_module and (image.name iendswith '.exe' or image.is_exec)
+
+- macro: load_dll
+  expr: >
+    load_module and (image.name iendswith '.dll' or image.is_dll)
 
 - macro: load_untrusted_executable
   expr: >
@@ -129,6 +125,28 @@
     (image.signature.level = 'UNCHECKED' or image.signature.level = 'UNSIGNED')
   description:
     Detects when untrusted executable is loaded into process address space.
+
+- macro: load_untrusted_dll
+  expr: >
+    load_dll
+      and
+    (image.signature.level = 'UNCHECKED' or image.signature.level = 'UNSIGNED')
+  description:
+    Detects when untrusted DLL is loaded into process address space.
+
+- macro: load_unsigned_module
+  expr: >
+    load_module and image.signature.type = 'NONE'
+  description: |
+    Detects when unsigned executable or DLL is loaded into process address space.
+    The module is considered as unsigned if it lacks the cert in the PE security
+    directory or the Authenticode hash is not present in any of the catalogs.
+
+- macro: load_unsigned_dll
+  expr: >
+    load_dll and image.signature.type = 'NONE'
+  description: |
+    Detects when unsigned executable DLL is loaded into process address space.
 
 - macro: load_untrusted_module
   expr: >
@@ -145,6 +163,11 @@
   expr: (load_unsigned_module) or (load_untrusted_module)
   description: >
     Detects when either unsigned or untrusted module is loaded into process address space.
+
+- macro: load_unsigned_or_untrusted_dll
+  expr: (load_unsigned_dll) or (load_untrusted_dll)
+  description: >
+    Detects when either unsigned or untrusted DLL is loaded into process address space.
 
 - macro: write_minidump_file
   expr: >


### PR DESCRIPTION
This changeset introduces potential process injection via tainted memory section and suspicious DLL loaded via memory section mapping rules along with the file fields to extract the file key and the protection rights of the section view.