### PR TITLE
feat(rules): New `Macro execution via script interpreters` rule

### DIFF
--- a/rules/initial_access_phishing.yml
+++ b/rules/initial_access_phishing.yml
@@ -100,3 +100,42 @@
           (file.is_exec or file.is_dll)
         )
       min-engine-version: 2.2.0
+    - name: Macro execution via script interpreters
+      description: |
+        Identifies the execution of the Windows scripting interpreter spawning
+        a Microsoft Office process to execute suspicious Visual Basic macro.
+      condition: >
+        sequence
+        maxspan 5m
+          |spawn_process
+              and
+           ps.parent.name iin script_interpreters
+              and
+           ps.child.name iin msoffice_binaries
+          | by ps.child.uuid
+          |ps.name iin msoffice_binaries
+              and
+           thread.callstack.modules imatches '*vbe?.dll'
+              and
+           (
+              spawn_process
+                  or
+              (create_remote_thread)
+                  or
+              (modify_registry)
+                  or
+              (create_file)
+                  or
+              (
+                load_module
+                    and
+                    not
+                image.name imatches
+                    (
+                      '?:\\Program Files\\*',
+                      '?:\\Program Files (x86)\\*'
+                    )
+              )
+           )
+          | by ps.uuid
+      min-engine-version: 2.2.0

--- a/rules/macros/macros.yml
+++ b/rules/macros/macros.yml
@@ -1,6 +1,12 @@
 - macro: spawn_process
   expr: kevt.name = 'CreateProcess'
 
+- macro: create_thread
+  expr: kevt.name = 'CreateThread'
+
+- macro: create_remote_thread
+  expr: create_thread and kevt.pid != 4 and kevt.pid != thread.pid
+
 - macro: open_process
   expr: kevt.name = 'OpenProcess' and ps.access.status = 'Success'
 
@@ -113,6 +119,14 @@
 - macro: unload_driver
   expr: unload_image and (image.name iendswith '.sys' or image.is_driver)
 
+- macro: load_unsigned_module
+  expr: >
+    load_module and image.signature.type = 'NONE'
+  description: |
+    Detects when unsigned executable or DLL is loaded into process address space.
+    The module is considered as unsigned if it lacks the cert in the PE security
+    directory or the Authenticode hash is not present in any of the catalogs.
+
 - macro: load_executable
   expr: >
     load_module and (image.name iendswith '.exe' or image.is_exec)
@@ -194,7 +208,7 @@
     the minidump signature.
 
 - macro: msoffice_binaries
-  list: [EXCEL.EXE, WINWORD.EXE, MSACCESS.EXE, POWERPNT.EXE, visio.exe, mspub.exe, fltldr.exe]
+  list: [EXCEL.EXE, WINWORD.EXE, MSACCESS.EXE, POWERPNT.EXE, visio.exe, mspub.exe, fltldr.exe, eqnedt32.exe]
 
 - macro: web_browser_binaries
   list: [

--- a/rules/privilege_escalation_exploitation_for_privilege_escalation.yml
+++ b/rules/privilege_escalation_exploitation_for_privilege_escalation.yml
@@ -31,8 +31,7 @@
             and
         (file.is_driver_vulnerable or file.is_driver_malicious)
       output: >
-        %file.name is a known vulnerable/malicious driver created
-        by process %ps.name and parent process %ps.parent.name
+        Vulnerable or malicious %file.name driver dropped
       min-engine-version: 2.0.0
     - name: Vulnerable or malicious driver loaded
       description: |
@@ -44,7 +43,5 @@
             and
         (image.is_driver_vulnerable or image.is_driver_malicious)
       output: >
-        %file.name is a known vulnerable/malicious driver with the
-        certificate issued by %image.cert.issuer and valid until
-        %image.cert.after
+        Vulnerable or malicious %image.name driver loaded
       min-engine-version: 2.0.0


### PR DESCRIPTION
Identifies the execution of the Windows scripting interpreter spawning a Microsoft Office process to execute suspicious Visual Basic macro.