### PR TITLE
chore(rules): Solidify process injection rules

### DIFF
--- a/rules/defense_evasion_process_injection.yml
+++ b/rules/defense_evasion_process_injection.yml
@@ -97,7 +97,7 @@
         sequence
         maxspan 2m
           |spawn_process| by ps.child.uuid
-          |unmap_view_of_section and (length(file.name) = 0 or not ext(file.name) = '.dll')| by ps.uuid
+          |unmap_view_of_section and file.view.size > 4096 and (length(file.name) = 0 or not ext(file.name) = '.dll')| by ps.uuid
           |load_executable and pe.is_modified| by ps.uuid
       action:
       - name: kill
@@ -201,13 +201,23 @@
         section with RW protection rights followed by mapping of the same memory section in
         the remote process with RX protection.
         By definition, the mapped view in the target process mirrors the content of the local
-        process' address space. The attacker can poison the local section memory with shellcode
+        process address space. The attacker can poison the local section memory with shellcode
         and execute it in the context of the remote process.
       condition: >
         sequence
         maxspan 1m
           |map_view_of_section and file.view.protection = 'READWRITE' and kevt.pid != 4 and file.view.size >= 4096| as e1
-          |map_view_of_section and file.view.protection = 'READONLY|EXECUTE' and file.key = $e1.file.key and kevt.pid != $e1.kevt.pid|
+          |map_view_of_section and file.view.protection = 'READONLY|EXECUTE' and file.key = $e1.file.key
+              and
+           kevt.pid != $e1.kevt.pid
+              and
+              not
+           ps.exe imatches
+              (
+                '?:\\Program Files\\Mozilla Firefox\\firefox.exe',
+                '?:\\Program Files (x86)\\Mozilla Firefox\\firefox.exe'
+              )
+          |
       action:
       - name: kill
       min-engine-version: 2.2.0


### PR DESCRIPTION
Add a couple of exceptions and consider unmap section view events only for view sizes over 4096 bytes.