### PR TITLE
feat(rules) New `Thread context set unbacked memory` rule

### DIFF
--- a/pkg/kevent/callstack.go
+++ b/pkg/kevent/callstack.go
@@ -145,6 +145,9 @@ func (s Callstack) Summary() string {
 	var removeSep bool
 	for i := range s {
 		frame := s[len(s)-i-1]
+		if frame.Addr.InSystemRange() {
+			continue
+		}
 		var n string
 		if frame.IsUnbacked() {
 			n = unbacked

--- a/pkg/symbolize/symbolizer.go
+++ b/pkg/symbolize/symbolizer.go
@@ -387,15 +387,15 @@ func (s *Symbolizer) produceFrame(addr va.Address, e *kevent.Kevent, fast, looku
 		if mod != nil {
 			frame.Module = mod.Name
 			m, ok := s.mods[mod.BaseAddress]
-			peOK := false
+			peOK := true
 			if !ok {
 				// parse export directory to resolve symbols
 				m = &module{exports: make(map[uint32]string), accessed: time.Now(), hasExports: true}
 				px, err := parsePeFile(mod.Name, pe.WithSections(), pe.WithExports())
 				if err != nil {
+					peOK = false
 					m.hasExports = false
 				} else {
-					peOK = true
 					m.exports = px.Exports
 					m.hasExports = len(m.exports) > 0
 					exportRVAs := convert.MapKeysToSlice(m.exports)

--- a/rules/defense_evasion_process_injection.yml
+++ b/rules/defense_evasion_process_injection.yml
@@ -221,6 +221,13 @@
       action:
       - name: kill
       min-engine-version: 2.2.0
+    - name: Thread context set from unbacked memory
+      description: |
+        Identifies manipulation of the thread context from unbacked memory region. This may be
+        indicative of process injection.
+      condition: >
+        set_thread_context and thread.callstack.summary imatches ('ntdll.dll|kernelbase.dll|unbacked')
+      min-engine-version: 2.2.0
 
 - group: Dynamic-link Library Injection
   description: |


### PR DESCRIPTION
Identifies manipulation of the thread context from unbacked memory region. This may be indicative of process injection. This PR also fixes the thread callstack summary and the symbolized PE exports condition.