### PR TITLE
fix(rules-engine): Add partials for bound fields

### DIFF
--- a/rules/credential_access_os_credential_dumping.yml
+++ b/rules/credential_access_os_credential_dumping.yml
@@ -60,6 +60,15 @@
               )
               and
               not
+            registry.key.name imatches
+              (
+                'HKEY_LOCAL_MACHINE\\SAM\\SAM\\Domains\\Account\\Users',
+                'HKEY_LOCAL_MACHINE\\SAM\\SAM\\Domains\\Account\\Users\\Names',
+                'HKEY_LOCAL_MACHINE\\SAM\\SAM\\Domains\\Account',
+                'HKEY_LOCAL_MACHINE\\SAM\\SAM\\Account\\Aliases\\*'
+              )
+              and
+              not
             ps.exe imatches
               (
                 '?:\\Windows\\System32\\lsass.exe',


### PR DESCRIPTION
The partials for bound field rules are populated by calculating the hash and attaching it to event metadata.