### PR TITLE
feat(rules): New `Suspicious port monitor loaded` rule

### DIFF
--- a/rules/credential_access_suspicious_security_package_loaded_by_lsass.yml
+++ b/rules/credential_access_suspicious_security_package_loaded_by_lsass.yml
@@ -1,6 +1,6 @@
-name: Suspicious DLL loaded by LSASS
+name: Suspicious security package DLL loaded
 id: 2c74f176-9a95-4344-a1aa-15aa06e16919
-version: 1.0.0
+version: 1.1.0
 description: |
   Attackers can abuse Windows Security Support Provider and Authentication Packages to
   dynamically inject a Security Package into the Local Security Authority Subsystem Service
@@ -21,6 +21,8 @@ references:
 
 condition: >
   ps.name ~= 'lsass.exe'
+    and
+  thread.callstack.modules imatches ('?:\\Windows\\System32\\sspisrv.dll')
     and
   (load_unsigned_or_untrusted_module)
 

--- a/rules/persistence_suspicious_port_monitor_loaded.yml
+++ b/rules/persistence_suspicious_port_monitor_loaded.yml
@@ -1,0 +1,27 @@
+name: Suspicious port monitor loaded
+id: d6ab6bfa-1a97-46cb-a69a-7a6c98a699f1
+version: 1.0.0
+description: |
+  Identifies the loading of an unsigned DLL by the print spool service. Adversaries may use port
+  monitors to run an adversary supplied DLL during system boot for persistence or privilege escalation.
+labels:
+   tactic.id: TA0003
+   tactic.name: Persistence
+   tactic.ref: https://attack.mitre.org/tactics/TA0003/
+   technique.id: T1547
+   technique.name: Boot or Logon Autostart Execution
+   technique.ref: https://attack.mitre.org/techniques/T1547/
+   subtechnique.id: T1547.010
+   subtechnique.name: Port Monitors
+   subtechnique.ref: https://attack.mitre.org/techniques/T1547/010/
+references:
+  - https://www.ired.team/offensive-security/persistence/t1013-addmonitor
+
+condition: >
+  load_dll and ps.name ~= 'spoolsv.exe'
+    and
+  thread.callstack.symbols imatches ('localspl.dll!SplAddMonitor*', 'spoolsv.exe!PrvAddMonitor*')
+    and
+  (image.signature.level = 'UNCHECKED' or image.signature.level = 'UNSIGNED')
+
+min-engine-version: 2.2.0


### PR DESCRIPTION
Identifies the loading of an unsigned DLL by the print spool service. Adversaries may use port monitors to run an adversary supplied DLL during system boot for persistence or privilege escalation.