### PR TITLE
fix(fs): Handle Windows Sandbox paths

### DIFF
--- a/pkg/fs/dev.go
+++ b/pkg/fs/dev.go
@@ -27,6 +27,7 @@ import (
 )
 
 const deviceOffset = 8
+const vmsmbDevice = `\Device\vmsmb`
 
 // DevMapper is the minimal interface for the device converters.
 type DevMapper interface {
@@ -66,6 +67,13 @@ func (m *mapper) Convert(filename string) string {
 		return filename
 	}
 	dev := filename[:i+deviceOffset]
+	// convert Windows Sandbox path to native path
+	if dev == vmsmbDevice {
+		n := strings.Index(filename, "os")
+		if n > 0 {
+			return "C:" + filename[n+2:]
+		}
+	}
 	if drive, ok := m.cache[dev]; ok {
 		return strings.Replace(filename, dev, drive, 1)
 	}

--- a/pkg/fs/dev_test.go
+++ b/pkg/fs/dev_test.go
@@ -71,3 +71,9 @@ func TestConvertDosDevice(t *testing.T) {
 	}
 	assert.Contains(t, files, filename)
 }
+
+func TestConvertVmsmbDevice(t *testing.T) {
+	mapper := NewDevMapper()
+	path := "\\Device\\vmsmb\\VSMB-{dcc079ae-60ba-4d07-847c-3493609c0870}\\os\\Windows\\System32\\ntdll.dll"
+	assert.Equal(t, "C:\\Windows\\System32\\ntdll.dll", mapper.Convert(path))
+}


### PR DESCRIPTION
This PR contains the logic for normalizing the file paths when running Fibratus inside the isolated environment, aka silo (Windows Sandbox).