### PR TITLE
feat(rules): New `Remote thread creation into LSASS` rule

### DIFF
--- a/rules/credential_access_remote_thread_creation_into_lsass.yml
+++ b/rules/credential_access_remote_thread_creation_into_lsass.yml
@@ -1,0 +1,24 @@
+name: Remote thread creation into LSASS
+id: e3ce8d6f-c260-48d6-9398-3c1c71726297
+version: 1.0.0
+description: |
+  Identifies the creation of a remote thread in LSASS (Local Security And Authority Subsystem Service)
+  by untrusted or suspicious processes. This may indicate attempts to execute code inside the LSASS process
+  in preparation for credential stealing.
+labels:
+   tactic.id: TA0006
+   tactic.name: Credential Access
+   tactic.ref: https://attack.mitre.org/tactics/TA0006/
+   technique.id: T1003
+   technique.name: OS Credential Dumping
+   technique.ref: https://attack.mitre.org/techniques/T1003/
+   subtechnique.id: T1003.001
+   subtechnique.name: LSASS Memory
+   subtechnique.ref: https://attack.mitre.org/techniques/T1003/001/
+
+condition: >
+  create_remote_thread and kevt.arg[exe] imatches '?:\\Windows\\System32\\lsass.exe'
+    and
+  (ps.name iin script_interpreters or ps.name ~= 'rundll32.exe' or not (pe.is_signed and pe.is_trusted))
+
+min-engine-version: 2.0.0

--- a/rules/persistence_suspicious_persistence_via_registry_modification.yml
+++ b/rules/persistence_suspicious_persistence_via_registry_modification.yml
@@ -1,6 +1,6 @@
 name: Suspicious persistence via registry modification
 id: 1f496a17-4f0c-491a-823b-7a70adb9919c
-version: 1.0.0
+version: 1.0.1
 description: |
   Adversaries may abuse the registry to achieve persistence
   by modifying the keys that are unlikely modified by legitimate
@@ -24,7 +24,7 @@ condition: >
       or
      ps.exe imatches '?:\\Users\\Public\\*'
       or
-     not (pe.is_signed or pe.is_trusted)
+     not (pe.is_signed and pe.is_trusted)
   )
     and
   registry.key.name imatches registry_persistence_keys


### PR DESCRIPTION
Identifies the creation of a remote thread in LSASS (Local Security And Authority Subsystem Service) by untrusted or suspicious processes. This may indicate attempts to execute code inside the LSASS process in preparation for credential stealing.