### PR TITLE
fest: Introduce event forwarding mode flag

### DIFF
--- a/configs/fibratus.yml
+++ b/configs/fibratus.yml
@@ -93,6 +93,8 @@ api:
 # regions.
 debug-privilege: true
 
+# Indicates if event forwarding mode is engaged.
+forward: false
 
 # =============================== Filament =============================================
 

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -138,7 +138,7 @@ func NewApp(cfg *config.Config, options ...Option) (*App, error) {
 		rules *filter.Rules
 		res   *config.RulesCompileResult
 	)
-	if cfg.Filters.Rules.Enabled && !cfg.IsCaptureSet() {
+	if cfg.Filters.Rules.Enabled && !cfg.ForwardMode && !cfg.IsCaptureSet() {
 		rules = filter.NewRules(psnap, cfg)
 		var err error
 		res, err = rules.Compile()

--- a/pkg/config/alertsender.go
+++ b/pkg/config/alertsender.go
@@ -35,6 +35,10 @@ var errAlertsenderConfig = func(sender string, err error) error {
 }
 
 func (c *Config) tryLoadAlertSenders() error {
+	if c.ForwardMode {
+		// In event forwarding mode, alert senders are useless
+		return nil
+	}
 	configs := make([]alertsender.Config, 0)
 	alertsenders := c.viper.AllSettings()["alertsenders"]
 	if alertsenders == nil {

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -68,6 +68,7 @@ const (
 	enumerateHandles         = "handle.enumerate-handles"
 	symbolPaths              = "symbol-paths"
 	symbolizeKernelAddresses = "symbolize-kernel-addresses"
+	forwardMode              = "forward"
 
 	serializeThreads = "kevent.serialize-threads"
 	serializeImages  = "kevent.serialize-images"
@@ -100,6 +101,8 @@ type Config struct {
 	// DebugPrivilege dictates if the SeDebugPrivilege is injected into
 	// Fibratus process' access token.
 	DebugPrivilege bool `json:"debug-privilege" yaml:"debug-privilege"`
+	// ForwardMode designates if event forwarding mode is engaged
+	ForwardMode bool `json:"forward" yaml:"forward"`
 
 	// KcapFile represents the name of the capture file.
 	KcapFile string
@@ -278,6 +281,7 @@ func (c *Config) Init() error {
 	c.SymbolPaths = c.viper.GetString(symbolPaths)
 	c.SymbolizeKernelAddresses = c.viper.GetBool(symbolizeKernelAddresses)
 	c.DebugPrivilege = c.viper.GetBool(debugPrivilege)
+	c.ForwardMode = c.viper.GetBool(forwardMode)
 	c.KcapFile = c.viper.GetString(kcapFile)
 
 	kevent.SerializeThreads = c.viper.GetBool(serializeThreads)
@@ -356,6 +360,9 @@ func (c *Config) SymbolPathsUTF16() *uint16 {
 
 func (c *Config) addFlags() {
 	c.flags.String(configFile, filepath.Join(os.Getenv("PROGRAMFILES"), "fibratus", "config", "fibratus.yml"), "Indicates the location of the configuration file")
+	if c.opts.run {
+		c.flags.Bool(forwardMode, false, "Designates if event forwarding mode is engaged")
+	}
 	if c.opts.run || c.opts.replay || c.opts.validate {
 		c.flags.StringP(filamentName, "f", "", "Specifies the filament to execute")
 
@@ -387,6 +394,7 @@ func (c *Config) addFlags() {
 	}
 	if c.opts.run || c.opts.capture {
 		c.flags.Bool(initHandleSnapshot, false, "Indicates whether initial handle snapshot is built. This implies scanning the system handles table and producing an entry for each handle object")
+		c.flags.Bool(debugPrivilege, true, "Dictates if the SeDebugPrivilege is injected into Fibratus process' access token")
 		c.flags.Bool(enumerateHandles, false, "Indicates if process handles are collected during startup or when a new process is spawn")
 		c.flags.String(symbolPaths, "srv*c:\\\\SymCache*https://msdl.microsoft.com/download/symbols", "Designates the path or a series of paths separated by a semicolon that is used to search for symbols files")
 		c.flags.Bool(symbolizeKernelAddresses, false, "Determines if kernel stack addresses are symbolized")

--- a/pkg/config/schema_windows.go
+++ b/pkg/config/schema_windows.go
@@ -106,6 +106,7 @@ var schema = `
 		},
 		"config-file": 						{"type": "string"},
 		"debug-privilege":  				{"type": "boolean"},
+		"forward":  						{"type": "boolean"},
 		"symbol-paths":						{"type": "string"},
 		"symbolize-kernel-addresses":		{"type": "boolean"},
 		"handle": {

--- a/pkg/kevent/queue.go
+++ b/pkg/kevent/queue.go
@@ -55,17 +55,17 @@ type Queue struct {
 	backlog         *backlog
 	cd              *CallstackDecorator
 	stackEnrichment bool
-	engineEnabled   bool
+	enqueueAlways   bool
 }
 
 // NewQueue constructs a new queue with the given channel size.
-func NewQueue(size int, stackEnrichment bool, engineEnabled bool) *Queue {
+func NewQueue(size int, stackEnrichment bool, enqueueAlways bool) *Queue {
 	q := &Queue{
 		q:               make(chan *Kevent, size),
 		listeners:       make([]Listener, 0),
 		backlog:         newBacklog(backlogCacheSize),
 		stackEnrichment: stackEnrichment,
-		engineEnabled:   engineEnabled,
+		enqueueAlways:   enqueueAlways,
 	}
 	q.cd = NewCallstackDecorator(q)
 	return q
@@ -132,7 +132,7 @@ func (q *Queue) Push(e *Kevent) error {
 
 func (q *Queue) push(e *Kevent) error {
 	var enqueue bool
-	if !q.engineEnabled {
+	if q.enqueueAlways {
 		enqueue = true
 	}
 	for _, listener := range q.listeners {

--- a/pkg/kstream/consumer_windows.go
+++ b/pkg/kstream/consumer_windows.go
@@ -194,7 +194,7 @@ func (k *consumer) bufferStatsCallback(logfile *etw.EventTraceLogfile) uintptr {
 func (k *consumer) initSinks(psnap ps.Snapshotter, hsnap handle.Snapshotter) {
 	for _, trace := range k.controller.Traces() {
 		s := &sink{
-			q:          kevent.NewQueue(500, k.config.Kstream.StackEnrichment, k.config.Filters.Rules.Enabled),
+			q:          kevent.NewQueue(500, k.config.Kstream.StackEnrichment, k.config.ForwardMode || k.config.IsCaptureSet()),
 			sequencer:  k.sequencer,
 			processors: processors.NewChain(psnap, hsnap, k.config),
 			psnap:      psnap,


### PR DESCRIPTION
This new flag allows running Fibratus in event forwarding mode. When in event forwarding mode, the rule engine is disabled and all events are routed to the output sink.