### PR TITLE
fix: Adjust `dev` version identifier

### DIFF
--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -55,7 +55,7 @@ func Set(v string) { version = v }
 func Get() string { return version }
 
 // IsDev determines if this is a dev version.
-func IsDev() bool { return version == "dev" || version == "" }
+func IsDev() bool { return version == "0.0.0" || version == "" }
 
 // Sem returns a semver spec.
 func Sem() *semver.Version {


### PR DESCRIPTION
Dev versions can be flagged with an empty string or the `0.0.0` pseudo version string. `dev` is never a valid version.