### PR TITLE
ci(workflows): Upgrade deprecated actions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -18,7 +18,7 @@ jobs:
       runs-on: windows-latest
       steps:
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
            go-version: ${{ env.GO_VERSION }}
       - name: Checkout
@@ -41,7 +41,7 @@ jobs:
             libtool
             autoconf
       - name: Cache yara
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache
         with:
           path: |
@@ -80,7 +80,7 @@ jobs:
           ./make.bat
         env:
           TAGS: kcap,filament,yara,yara_static
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: "fibratus-amd64.exe"
           path: "./cmd/fibratus/fibratus.exe"
@@ -93,7 +93,7 @@ jobs:
         run: |
            export VERSION=0.0.0
            ./make.bat pkg
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: "fibratus-amd64.msi"
           path: "./build/msi/fibratus-0.0.0-amd64.msi"
@@ -102,7 +102,7 @@ jobs:
       runs-on: windows-latest
       steps:
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
            go-version: ${{ env.GO_VERSION }}
       - name: Checkout
@@ -112,7 +112,7 @@ jobs:
         run: |
           export COMMIT=$(echo $GITHUB_SHA | cut -c1-8)
           ./make.bat
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: "fibratus-amd64-slim.exe"
           path: "./cmd/fibratus/fibratus.exe"
@@ -131,7 +131,7 @@ jobs:
         run: |
            sed -i 's/C:\/Python37/C:\/hostedtoolcache\/windows\/Python\/3.7.9\/x64/' pkg-config/python-37.pc
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
            go-version: ${{ env.GO_VERSION }}
       - name: Setup msys2
@@ -147,7 +147,7 @@ jobs:
            libtool
            autoconf
       - name: Cache yara
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache
         with:
           path: |
@@ -181,7 +181,7 @@ jobs:
         run: |
            sed -i 's/C:\/Python37/C:\/hostedtoolcache\/windows\/Python\/3.7.9\/x64/' pkg-config/python-37.pc
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
            go-version: ${{ env.GO_VERSION }}
       - name: Setup msys2
@@ -197,7 +197,7 @@ jobs:
            libtool
            autoconf
       - name: Cache yara
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache
         with:
           path: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
       runs-on: windows-latest
       steps:
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
            go-version: ${{ env.GO_VERSION }}
       - name: Checkout
@@ -78,7 +78,7 @@ jobs:
           ./make.bat
         env:
           TAGS: kcap,filament,yara,yara_static
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: "fibratus-amd64.exe"
           path: "./cmd/fibratus/fibratus.exe"
@@ -91,7 +91,7 @@ jobs:
         run: |
           export VERSION=0.0.0
           ./make.bat pkg
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: "fibratus-amd64.msi"
           path: "./build/msi/fibratus-0.0.0-amd64.msi"
@@ -109,7 +109,7 @@ jobs:
         run: |
            sed -i 's/C:\/Python37/C:\/hostedtoolcache\/windows\/Python\/3.7.9\/x64/' pkg-config/python-37.pc
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
            go-version: ${{ env.GO_VERSION }}
       - name: Setup msys2
@@ -125,7 +125,7 @@ jobs:
            libtool
            autoconf
       - name: Cache yara
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache
         with:
           path: |
@@ -159,7 +159,7 @@ jobs:
         run: |
            sed -i 's/C:\/Python37/C:\/hostedtoolcache\/windows\/Python\/3.7.9\/x64/' pkg-config/python-37.pc
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
            go-version: ${{ env.GO_VERSION }}
       - name: Setup msys2
@@ -175,7 +175,7 @@ jobs:
            libtool
            autoconf
       - name: Cache yara
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache
         with:
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
            export VERSION=${{ steps.get_version.outputs.VERSION }}
            ./make.bat pkg
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: fibratus-${{ steps.get_version.outputs.VERSION }}-amd64.msi
           path: "./build/msi/fibratus-${{ steps.get_version.outputs.VERSION }}-amd64.msi"
@@ -127,7 +127,7 @@ jobs:
         run: |
            export VERSION=${{ steps.get_version.outputs.VERSION }}
            ./make.bat pkg-slim
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: fibratus-${{ steps.get_version.outputs.VERSION }}-slim-amd64.msi
           path: "./build/msi/fibratus-${{ steps.get_version.outputs.VERSION }}-slim-amd64.msi"


### PR DESCRIPTION
Upgrades cache, upload-artifact, and setup-go actions to use a newer Node version.