### PR TITLE
chore(log): Disable quoting for all values

### DIFF
--- a/pkg/util/log/logger.go
+++ b/pkg/util/log/logger.go
@@ -71,7 +71,7 @@ func InitFromConfig(c Config, filename string) error {
 	case "json":
 		formatter = &logrus.JSONFormatter{}
 	case "text":
-		formatter = &logrus.TextFormatter{}
+		formatter = &logrus.TextFormatter{DisableQuote: true}
 	default:
 		formatter = &logrus.JSONFormatter{}
 	}


### PR DESCRIPTION
Disables quoting for all values in log lines. The result is that all control chars (new line, tabs, etc.) are rendered instead of escaped which greatly improves the log message readability. 