### PR TITLE
chore: Show fibratus version in logs

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -35,6 +35,7 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/sys"
 	"github.com/rabbitstack/fibratus/pkg/util/multierror"
 	"github.com/rabbitstack/fibratus/pkg/util/signals"
+	"github.com/rabbitstack/fibratus/pkg/util/version"
 	"github.com/rabbitstack/fibratus/pkg/yara"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
@@ -184,8 +185,8 @@ func (f *App) Run(args []string) error {
 		return ErrAlreadyRunning
 	}
 
-	log.Infof("bootstrapping with pid %d", os.Getpid())
-	log.Infof("configuration settings %s", cfg.Print())
+	log.Infof("bootstrapping with pid %d. Version: %s", os.Getpid(), version.Get())
+	log.Infof("configuration dump %s", cfg.Print())
 
 	err := f.controller.Start()
 	if err != nil {

--- a/pkg/config/print.go
+++ b/pkg/config/print.go
@@ -99,8 +99,6 @@ func (c *Config) Print() string {
 	}
 	sort.Slice(sorted, func(i, j int) bool { return sorted[i].k < sorted[j].k })
 
-	buffer.WriteString("\n")
-
 	// print the options
 	for _, kv := range sorted {
 		c.printLine(&buffer, maxKeyLen, kv.k, c.print(kv.v))

--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -52,7 +52,12 @@ var sem *semver.Version
 func Set(v string) { version = v }
 
 // Get returns the version string.
-func Get() string { return version }
+func Get() string {
+	if IsDev() {
+		return "dev"
+	}
+	return version
+}
 
 // IsDev determines if this is a dev version.
 func IsDev() bool { return version == "0.0.0" || version == "" }


### PR DESCRIPTION
Dump fibratus version to logs. Having the version in the logs may help during troubleshooting or identitying bugs that are specific to the certain release.