### PR TITLE
perf(rules): Improve `Vulnerable or malicious driver dropped` rule

### DIFF
--- a/rules/privilege_escalation_vulnerable_or_malicious_driver_dropped.yml
+++ b/rules/privilege_escalation_vulnerable_or_malicious_driver_dropped.yml
@@ -16,7 +16,7 @@ references:
   - https://www.loldrivers.io/
 
 condition: >
-  create_file
+  create_file and file.is_driver
     and
   (file.is_driver_vulnerable or file.is_driver_malicious)
 


### PR DESCRIPTION
Introduce `file.is_driver` condition to stop evaluating the subsequent conditions inside the paren expression as they may consume unneeded CPU cycles.