### PR TITLE
chore(rules): Introduce `open_remote_thread` macro

### DIFF
--- a/rules/defense_evasion_potential_thread_execution_hijacking.yml
+++ b/rules/defense_evasion_potential_thread_execution_hijacking.yml
@@ -30,9 +30,7 @@ condition: >
   sequence
   maxspan 2m
   by ps.uuid
-    |open_thread and kevt.pid != 4 and kevt.pid != kevt.arg[pid]
-      and
-     thread.access.mask.names in ('ALL_ACCESS', 'SUSPEND_THREAD')
+    |open_remote_thread and thread.access.mask.names in ('ALL_ACCESS', 'SUSPEND_THREAD')
       and
       not
      ps.exe imatches

--- a/rules/macros/macros.yml
+++ b/rules/macros/macros.yml
@@ -13,6 +13,9 @@
 - macro: open_thread
   expr: kevt.name = 'OpenThread' and thread.access.status = 'Success'
 
+- macro: open_remote_thread
+  expr: open_thread and kevt.pid != 4 and kevt.pid != kevt.arg[pid]
+
 - macro: write_file
   expr: kevt.name = 'WriteFile'
 


### PR DESCRIPTION
To foster reusability, the expression for detecting remote thread access is extracted into a macro.