### PR TITLE
chore(rules): Reduce `Potential SAM hive dumping` false positives

### DIFF
--- a/rules/credential_access_potential_sam_hive_dumping.yml
+++ b/rules/credential_access_potential_sam_hive_dumping.yml
@@ -22,20 +22,18 @@ condition: >
     |spawn_process
       and
       not
-     ps.exe imatches
-      (
-        '?:\\Program Files\\*.exe',
-        '?:\\Program Files (x86)\\*.exe'
-      )
+     (ps.exe imatches
+        (
+          '?:\\Program Files\\*.exe',
+          '?:\\Program Files (x86)\\*.exe'
+        )
+      or
+      (ps.exe imatches 'C:\\Windows\\System32\\svchost.exe' and ps.args iin ('-k', 'DcomLaunch'))
+     )
     | by ps.child.uuid
     |open_registry
       and
-     registry.key.name imatches
-      (
-        'HKEY_LOCAL_MACHINE\\SAM\\SAM\\Domains\\Account\\*',
-        'HKEY_LOCAL_MACHINE\\SAM\\*',
-        'HKEY_LOCAL_MACHINE\\SAM'
-      )
+     registry.key.name imatches 'HKEY_LOCAL_MACHINE\\SAM\\SAM\\Domains\\Account\\*'
       and
       not
      registry.key.name imatches


### PR DESCRIPTION
Only keep a single registry key path for detecting potential accesses to the Security Account Manager database.