### PR TITLE
chore(rules): Reduce  `Unsigned DLL injection via remote thread` false positives

### DIFF
--- a/rules/defense_evasion_unsigned_dll_injection_via_remote_thread.yml
+++ b/rules/defense_evasion_unsigned_dll_injection_via_remote_thread.yml
@@ -22,7 +22,18 @@ references:
 condition: >
   sequence
   maxspan 1m
-    |create_remote_thread| by thread.pid
+    |create_remote_thread
+      and
+      not
+     (ps.exe imatches
+        (
+          '?:\\Program Files\\*',
+          '?:\\Program Files (x86)\\*'
+        )
+      or
+      (ps.exe imatches 'C:\\Windows\\System32\\svchost.exe' and ps.args iin ('-k', 'DcomLaunch'))
+     )
+    | by thread.pid
     |(load_unsigned_or_untrusted_dll)
       and
       not


### PR DESCRIPTION
Keep the false positive rate lower by excluding remote thread creations by some known processes.