### PR TITLE
fix(kcap): Disable alert senders in capture replay mode

### DIFF
--- a/pkg/config/alertsender.go
+++ b/pkg/config/alertsender.go
@@ -35,8 +35,8 @@ var errAlertsenderConfig = func(sender string, err error) error {
 }
 
 func (c *Config) tryLoadAlertSenders() error {
-	if c.ForwardMode {
-		// In event forwarding mode, alert senders are useless
+	if c.ForwardMode || c.IsCaptureSet() {
+		// In event forwarding mode or capture control, alert senders are useless
 		return nil
 	}
 	configs := make([]alertsender.Config, 0)


### PR DESCRIPTION
If the capture is set in the configuration flags, either the capture is being generated or replayed. In a such scenario, alert senders are useless and should be disabled.