### PR TITLE
chore(deps): Bump Go from 1.21 to 1.23

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,7 +10,7 @@ on:
       - "docs/**"
 
 env:
-  GO_VERSION: 1.21.x
+  GO_VERSION: 1.23.x
   WIX_VERSION: 5.0.0
 
 jobs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,7 @@ on:
       - "docs/**"
 
 env:
-  GO_VERSION: 1.21.x
+  GO_VERSION: 1.23.x
   WIX_VERSION: 5.0.0
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 env:
-  GO_VERSION: 1.21.x
+  GO_VERSION: 1.23.x
   WIX_VERSION: 5.0.0
 
 jobs:


### PR DESCRIPTION
Bump Go toolchain from version 1.21.x to 1.23.x