### PR TITLE
ci(workflows): Address `set-output` deprecation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         id: get_version
         shell: bash
         run: |
-          echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3 | cut -c2-)
+          echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3 | cut -c2-)" >> $GITHUB_OUTPUT
       - name: Build
         shell: bash
         run: |


### PR DESCRIPTION
This was overlooked from the previous commit and the set-output directive was only removed in the slim build job.