### PR TITLE
feat(yara): Adding yara scan trigger for PAGE_EXECUTE_READWRITE allocations

### DIFF
--- a/pkg/yara/scanner.go
+++ b/pkg/yara/scanner.go
@@ -212,11 +212,11 @@ func (s scanner) Scan(evt *kevent.Kevent) (bool, error) {
 		if s.config.ShouldSkipProcess(proc.Name) {
 			return false, nil
 		}
-		if evt.Kparams.Find(kparams.MemProtect) == nil {
-			return false, nil
+		protect, err := evt.Kparams.GetUint32(kparams.MemProtect)
+		if err != nil {
+			return false, err
 		}
-		protectVal, _ := evt.Kparams.GetUint32(kparams.MemProtect)
-		if protectVal != windows.PAGE_EXECUTE_READWRITE {
+		if protect != windows.PAGE_EXECUTE_READWRITE {
 			return false, nil
 		}
 		alertCtx.PS = proc


### PR DESCRIPTION
Adding yara scan trigger for PAGE_EXECUTE_READWRITE allocations, useful when PE image does not contain malicious code, for example, when shellcode is downloaded or decrypted after execution