### PR TITLE
feat(event): Augment process events with process flags

### DIFF
--- a/pkg/kevent/flags.go
+++ b/pkg/kevent/flags.go
@@ -55,6 +55,27 @@ func (flags ParamFlags) String(f uint64) string {
 	return n.String()
 }
 
+const (
+	// PsApplicationID identifies the packaged process
+	PsApplicationID = 0x00000001
+	// PsWOW64 indicates if the 32-bit process is created in 64-bit Windows system
+	PsWOW64 = 0x00000002
+	// PsProtected process is to be run as a protected process. The system restricts
+	// access to protected processes and the threads of protected processes.
+	PsProtected = 0x00000004
+	// PsPackaged represents a process packaged with the MSIX technology and thus has
+	// package identity.
+	PsPackaged = 0x00000008
+)
+
+// PsCreationFlags describes the process creation flags.
+var PsCreationFlags = []ParamFlag{
+	{"APPLICATION_ID", PsApplicationID},
+	{"WOW64", PsWOW64},
+	{"PROTECTED", PsProtected},
+	{"PACKAGED", PsPackaged},
+}
+
 // PsAccessRightFlags describes flags for the process access rights.
 var PsAccessRightFlags = []ParamFlag{
 	{"ALL_ACCESS", windows.STANDARD_RIGHTS_REQUIRED | windows.SYNCHRONIZE | 0xFFFF},

--- a/pkg/kevent/flags_test.go
+++ b/pkg/kevent/flags_test.go
@@ -29,6 +29,7 @@ func TestParamFlags(t *testing.T) {
 		{0x1fffff, PsAccessRightFlags, "ALL_ACCESS"},
 		{0x1400, PsAccessRightFlags, "QUERY_INFORMATION|QUERY_LIMITED_INFORMATION"},
 		{0x1800, ThreadAccessRightFlags, "QUERY_LIMITED_INFORMATION"},
+		{0x00000002, PsCreationFlags, "WOW64"},
 	}
 
 	for i, tt := range tests {

--- a/pkg/kevent/kparam_windows.go
+++ b/pkg/kevent/kparam_windows.go
@@ -217,6 +217,7 @@ func (e *Kevent) produceParams(evt *etw.EventRecord) {
 			sessionID  uint32
 			exitStatus uint32
 			dtb        uint64
+			flags      uint32
 			sid        []byte
 			name       string
 			cmdline    string
@@ -236,6 +237,9 @@ func (e *Kevent) produceParams(evt *etw.EventRecord) {
 		if evt.Version() >= 3 {
 			dtb = evt.ReadUint64(24)
 		}
+		if evt.Version() >= 4 {
+			flags = evt.ReadUint32(32)
+		}
 		switch {
 		case evt.Version() >= 4:
 			offset = 36
@@ -254,6 +258,7 @@ func (e *Kevent) produceParams(evt *etw.EventRecord) {
 		e.AppendParam(kparams.SessionID, kparams.Uint32, sessionID)
 		e.AppendParam(kparams.ExitStatus, kparams.Status, exitStatus)
 		e.AppendParam(kparams.DTB, kparams.Address, dtb)
+		e.AppendParam(kparams.ProcessFlags, kparams.Flags, flags, WithFlags(PsCreationFlags))
 		e.AppendParam(kparams.UserSID, kparams.WbemSID, sid)
 		e.AppendParam(kparams.ProcessName, kparams.AnsiString, name)
 		e.AppendParam(kparams.Cmdline, kparams.UnicodeString, cmdline)

--- a/pkg/kevent/kparams/fields_windows.go
+++ b/pkg/kevent/kparams/fields_windows.go
@@ -52,6 +52,8 @@ const (
 	Cmdline = "cmdline"
 	// DTB field denotes the address of the process directory table.
 	DTB = "directory_table_base"
+	// ProcessFlags field denotes the process creation flags
+	ProcessFlags = "flags"
 	// ExitStatus is the field that represents the process exit status.
 	ExitStatus = "exit_status"
 	// StartTime field denotes the process start time.


### PR DESCRIPTION
**What is the purpose of this PR / why it is needed?**

Process rundown, create, and terminate events are enriched with additional flags that may indicate if the created process is WoW-originated, protected, or packaged.

**What type of change does this PR introduce?**

- [x] New feature (non-breaking change which adds functionality)

**Any specific area of the project related to this PR?**

- [x] Instrumentation/telemetry

**Does this PR introduce a user-facing change?**

The process flags parameter needs to be reflected in the documentation. The parameter will serve as a backbone for building the new filter fields.