### PR TITLE
feat(alertsender): Introduce eventlog alertsender

### DIFF
--- a/configs/fibratus.yml
+++ b/configs/fibratus.yml
@@ -73,6 +73,10 @@ alertsenders:
     # Represents the emoji icon surrounded in ':' characters for the Slack bot
     #emoji: ""
 
+  # Event Log sender transports alerts to the Windows Event Log.
+  eventlog:
+    enabled: true  # Enable or disable the event log sender
+
 # =============================== API ==================================================
 
 # Settings that influence the behaviour of the HTTP server that exposes a number of endpoints such as

--- a/pkg/alertsender/eventlog/config.go
+++ b/pkg/alertsender/eventlog/config.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019-2024 by Nedim Sabic Sabic and Contributors
+ * https://www.fibratus.io
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eventlog
+
+import (
+	"github.com/spf13/pflag"
+)
+
+const (
+	enabled = "alertsenders.eventlog.enabled"
+)
+
+// Config defines the configuration for the eventlog sender.
+type Config struct {
+	Enabled bool `mapstructure:"enabled"`
+}
+
+// AddFlags registers persistent flags.
+func AddFlags(flags *pflag.FlagSet) {
+	flags.Bool(enabled, true, "Indicates if eventlog alert sender is enabled")
+}

--- a/pkg/alertsender/eventlog/eventlog.go
+++ b/pkg/alertsender/eventlog/eventlog.go
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019-2024 by Nedim Sabic Sabic and Contributors
+ * https://www.fibratus.io
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eventlog
+
+import (
+	"fmt"
+	"github.com/rabbitstack/fibratus/pkg/alertsender"
+	"golang.org/x/sys/windows"
+	"strings"
+	"syscall"
+)
+
+// source represents the event source that generates the alerts
+const source = "Fibratus"
+
+type eventlog struct {
+	log windows.Handle
+}
+
+func init() {
+	alertsender.Register(alertsender.Eventlog, makeSender)
+}
+
+func makeSender(alertsender.Config) (alertsender.Sender, error) {
+	sourceName, err := windows.UTF16PtrFromString(source)
+	if err != nil {
+		return nil, fmt.Errorf("could not convert source name: %v", err)
+	}
+
+	h, err := windows.RegisterEventSource(nil, sourceName)
+	if err != nil {
+		return nil, fmt.Errorf("could not register event source: %v", err)
+	}
+	return &eventlog{log: h}, nil
+}
+
+// Send logs the alert to the eventlog.
+func (s *eventlog) Send(alert alertsender.Alert) error {
+	var etype uint16
+	switch alert.Severity {
+	case alertsender.Normal:
+		etype = windows.EVENTLOG_INFORMATION_TYPE
+	case alertsender.Medium:
+		etype = windows.EVENTLOG_WARNING_TYPE
+	case alertsender.High, alertsender.Critical:
+		etype = windows.EVENTLOG_ERROR_TYPE
+	default:
+		etype = windows.EVENTLOG_INFORMATION_TYPE
+	}
+
+	msg := fmt.Sprintf("%s\n\n%s", alert.Title, alert.Text)
+	lines := strings.Split(msg, "\n")
+	ss := make([]*uint16, len(lines))
+	for i, line := range lines {
+		// line breaks
+		if len(line) == 0 {
+			line = "\n"
+		}
+		s, err := syscall.UTF16PtrFromString(line)
+		if err != nil {
+			continue
+		}
+		ss[i] = s
+	}
+	m, err := windows.UTF16PtrFromString(msg)
+	if err != nil {
+		return fmt.Errorf("could not convert eventlog message to UTF16: %v", err)
+	}
+	msgs := []*uint16{m}
+
+	return windows.ReportEvent(s.log, etype, 0, 0, uintptr(0), uint16(len(msgs)), 0, &msgs[0], nil)
+}
+
+// Shutdown deregisters the event source.
+func (s *eventlog) Shutdown() error {
+	if s.log != windows.InvalidHandle {
+		return windows.DeregisterEventSource(s.log)
+	}
+	return nil
+}
+
+func (s *eventlog) Type() alertsender.Type { return alertsender.Systray }
+func (s *eventlog) SupportsMarkdown() bool { return true }

--- a/pkg/alertsender/eventlog/eventlog_test.go
+++ b/pkg/alertsender/eventlog/eventlog_test.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019-2024 by Nedim Sabic Sabic and Contributors
+ * https://www.fibratus.io
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eventlog
+
+import (
+	"github.com/rabbitstack/fibratus/pkg/alertsender"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestEventlogSender(t *testing.T) {
+	s, err := alertsender.Load(alertsender.Config{Type: alertsender.Eventlog, Sender: Config{Enabled: true}})
+	require.NoError(t, err)
+	require.NotNil(t, s)
+
+	require.NoError(t, s.Send(alertsender.Alert{
+		Title: "LSASS memory dumping via legitimate or offensive tools",
+		Text: `Detected an attempt by mimikatz.exe process to access and read
+	the memory of the Local Security And Authority Subsystem Service
+	and subsequently write the C:\\temp\lsass.dmp dump file to the disk device`}))
+}

--- a/pkg/alertsender/sender.go
+++ b/pkg/alertsender/sender.go
@@ -44,6 +44,8 @@ const (
 	Noop
 	// Systray designates the systray notification alert sender
 	Systray
+	// Eventlog designate the eventlog alert sender
+	Eventlog
 	// None is the type for unknown alert sender
 	None
 )
@@ -59,6 +61,8 @@ func (s Type) String() string {
 		return "noop"
 	case Systray:
 		return "systray"
+	case Eventlog:
+		return "eventlog"
 	default:
 		return "none"
 	}

--- a/pkg/config/alertsender.go
+++ b/pkg/config/alertsender.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/rabbitstack/fibratus/pkg/alertsender"
+	"github.com/rabbitstack/fibratus/pkg/alertsender/eventlog"
 	"github.com/rabbitstack/fibratus/pkg/alertsender/mail"
 	"github.com/rabbitstack/fibratus/pkg/alertsender/slack"
 	"github.com/rabbitstack/fibratus/pkg/alertsender/systray"
@@ -39,6 +40,7 @@ func (c *Config) tryLoadAlertSenders() error {
 		// In event forwarding mode, alert senders are useless
 		return nil
 	}
+
 	configs := make([]alertsender.Config, 0)
 	alertsenders := c.viper.AllSettings()["alertsenders"]
 	if alertsenders == nil {
@@ -89,6 +91,20 @@ func (c *Config) tryLoadAlertSenders() error {
 			config := alertsender.Config{
 				Type:   alertsender.Systray,
 				Sender: systrayConfig,
+			}
+			configs = append(configs, config)
+
+		case "eventlog":
+			var eventlogConfig eventlog.Config
+			if err := decode(config, &eventlogConfig); err != nil {
+				return errAlertsenderConfig(typ, err)
+			}
+			if !eventlogConfig.Enabled {
+				continue
+			}
+			config := alertsender.Config{
+				Type:   alertsender.Eventlog,
+				Sender: eventlogConfig,
 			}
 			configs = append(configs, config)
 		}

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -49,6 +49,7 @@ import (
 	"strings"
 
 	"github.com/rabbitstack/fibratus/pkg/alertsender"
+	eventlogsender "github.com/rabbitstack/fibratus/pkg/alertsender/eventlog"
 	mailsender "github.com/rabbitstack/fibratus/pkg/alertsender/mail"
 	slacksender "github.com/rabbitstack/fibratus/pkg/alertsender/slack"
 	systraysender "github.com/rabbitstack/fibratus/pkg/alertsender/systray"
@@ -227,6 +228,7 @@ func NewWithOpts(options ...Option) *Config {
 		mailsender.AddFlags(flagSet)
 		slacksender.AddFlags(flagSet)
 		systraysender.AddFlags(flagSet)
+		eventlogsender.AddFlags(flagSet)
 		yara.AddFlags(flagSet)
 	}
 

--- a/pkg/config/config_windows_test.go
+++ b/pkg/config/config_windows_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/aggregator/transformers"
 	"github.com/rabbitstack/fibratus/pkg/aggregator/transformers/rename"
 	"github.com/rabbitstack/fibratus/pkg/alertsender"
+	"github.com/rabbitstack/fibratus/pkg/alertsender/eventlog"
 	"github.com/rabbitstack/fibratus/pkg/alertsender/mail"
 	"github.com/rabbitstack/fibratus/pkg/alertsender/slack"
 	"github.com/rabbitstack/fibratus/pkg/alertsender/systray"
@@ -48,7 +49,7 @@ func TestNewFromYamlFile(t *testing.T) {
 	assert.Equal(t, time.Millisecond*230, c.Aggregator.FlushPeriod)
 	assert.Equal(t, time.Second*8, c.Aggregator.FlushTimeout)
 
-	assert.Len(t, c.Alertsenders, 3)
+	assert.Len(t, c.Alertsenders, 4)
 
 	for _, c := range c.Alertsenders {
 		switch c.Type {
@@ -69,6 +70,10 @@ func TestNewFromYamlFile(t *testing.T) {
 			assert.True(t, systrayConfig.Enabled)
 			assert.True(t, systrayConfig.Sound)
 			assert.False(t, systrayConfig.QuietMode)
+		case alertsender.Eventlog:
+			assert.IsType(t, eventlog.Config{}, c.Sender)
+			eventlogConfig := c.Sender.(eventlog.Config)
+			assert.True(t, eventlogConfig.Enabled)
 		}
 	}
 

--- a/pkg/config/schema_windows.go
+++ b/pkg/config/schema_windows.go
@@ -90,6 +90,14 @@ var schema = `
 								"quiet-mode": 	{"type": "boolean"}
 							},
 							"additionalProperties": false
+
+						},
+		                "eventlog": {
+							"type": "object",
+							"properties": {
+								"enabled": {"type": "boolean"}
+							},
+							"additionalProperties": false
 						}
 					},
 					"additionalProperties": false


### PR DESCRIPTION
**What is the purpose of this PR / why it is needed?**

The eventlog alertsender emits the alerts to the
eventlog. By default, the message is a combination of alert title and text. The severity of the eventlog message is determined by the alert severity. The eventlog alert sender is enabled by default.

**What type of change does this PR introduce?**

> Mark the option with the `x` symbol inside the brackets. Trim leading/trailing white spaces. Remove any options that don't apply to your changeset.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that restructures the code, while not changing the original functionality) 
- [ ] Docs
- [ ] Other

**Any specific area of the project related to this PR?**

> Mark the option with the `x` symbol inside the brackets. Trim leading/trailing white spaces. Remove any options that don't apply to your changeset.

- [ ] Instrumentation/telemetry
- [ ] Rule engine
- [ ] Filters
- [ ] YARA scanner
- [ ] Captures
- [x] Alert senders
- [ ] Outputs
- [ ] Detection rules
- [ ] Filaments
- [x] Configuration
- [ ] CLI
- [ ] Tests
- [ ] CI
- [ ] Build
- [ ] Docs
- [ ] Other

**Special notes for the reviewer**:

**Does this PR introduce a user-facing change?**

The users will have the ability to send alerts to the event log. The alert sender is enabled by default along with the systray sender.
