### PR TITLE
fix(config): Prevent loading malformed yaml

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -186,7 +186,7 @@ func (f *App) Run(args []string) error {
 	}
 
 	log.Infof("bootstrapping with pid %d. Version: %s", os.Getpid(), version.Get())
-	log.Infof("configuration dump %s", cfg.Print())
+	log.Infof("rendering config flags... %s", cfg.Print())
 
 	err := f.controller.Start()
 	if err != nil {


### PR DESCRIPTION
**What is the purpose of this PR / why it is needed?**

If the YAML config contains malformed content the
error is ignored silently. To prevent this, we
only proceed with default settings loading if the
config file doesn't exist. On the contrary, the
error is raised.

**What type of change does this PR introduce?**

- [x] Bug fix (non-breaking change which fixes an issue)

**Any specific area of the project related to this PR?**

- [x] Configuration
