### PR TITLE
fix(tests): Revive event sequencer tests

### DIFF
--- a/pkg/kevent/sequencer_windows.go
+++ b/pkg/kevent/sequencer_windows.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"github.com/rabbitstack/fibratus/pkg/util/multierror"
 	"golang.org/x/sys/windows/registry"
+	"os"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -31,7 +32,7 @@ import (
 
 const (
 	// seqVName is the name of the registry value that stores the QWORD sequence.
-	seqVName   = "KeventSeq"
+	seqVName   = "EventSequence"
 	invalidKey = registry.Key(syscall.InvalidHandle)
 )
 
@@ -103,7 +104,13 @@ func (s *Sequencer) Reset() error {
 	if s.key == invalidKey {
 		return errInvalidVolatileKey
 	}
-	return s.key.DeleteValue(seqVName)
+	err := s.key.DeleteValue(seqVName)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
 }
 
 // Close shutdowns the event sequencer.

--- a/pkg/kevent/sequencer_windows_test.go
+++ b/pkg/kevent/sequencer_windows_test.go
@@ -26,6 +26,7 @@ import (
 
 func TestSequencer(t *testing.T) {
 	sequencer := NewSequencer()
+	require.NoError(t, sequencer.Reset())
 	sequencer.seq = 0
 	defer sequencer.Close()
 
@@ -45,6 +46,7 @@ func TestSequencer(t *testing.T) {
 
 func TestSequencerMonotonic(t *testing.T) {
 	sequencer := NewSequencer()
+	require.NoError(t, sequencer.Reset())
 	sequencer.seq = 0
 	defer sequencer.Close()
 


### PR DESCRIPTION
**What is the purpose of this PR / why it is needed?**

Make sure the sequencer registry value is
reset before running the tests. This implies
handling the return value of the DeleteValue
function to ignore the error if the sequencer
is trying to remove a non-existing value.

**What type of change does this PR introduce?**

- [x] Bug fix (non-breaking change which fixes an issue)

**Any specific area of the project related to this PR?**

- [x] Tests

**Special notes for the reviewer**:

**Does this PR introduce a user-facing change?**

