### PR TITLE
chore(deps, pe): Bump `saferwall/pe` from 1.4.4 to 1.5.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/Microsoft/go-winio v0.4.14
 	github.com/antchfx/htmlquery v1.2.5
+	github.com/bits-and-blooms/bitset v1.13.0
 	github.com/briandowns/spinner v1.12.0
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/enescakir/emoji v1.0.0
 	github.com/gammazero/deque v0.2.1
@@ -20,7 +22,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/qmuntal/stateless v1.6.0
 	github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5
-	github.com/saferwall/pe v1.4.4
+	github.com/saferwall/pe v1.5.4
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.5
@@ -32,6 +34,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/yuin/goldmark v1.5.2
 	go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352
+	golang.org/x/arch v0.6.0
 	golang.org/x/sys v0.13.0
 	golang.org/x/text v0.13.0
 	golang.org/x/time v0.3.0
@@ -41,11 +44,9 @@ require (
 )
 
 require (
-	github.com/bits-and-blooms/bitset v1.13.0 // indirect
-	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/rivo/uniseg v0.4.2 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
-	golang.org/x/arch v0.6.0 // indirect
+	github.com/secDre4mer/pkcs7 v0.0.0-20240322103146-665324a4461d // indirect
 )
 
 require (
@@ -56,7 +57,7 @@ require (
 	github.com/edsrzf/mmap-go v1.1.0 // indirect
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.7 // indirect
-	github.com/google/uuid v1.1.1 // indirect
+	github.com/google/uuid v1.1.1
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huandu/xstrings v1.3.1 // indirect
 	github.com/imdario/mergo v0.3.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -177,10 +177,12 @@ github.com/rivo/uniseg v0.4.2/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
-github.com/saferwall/pe v1.4.4 h1:Ml++7/2/Z1iKwV4zCsd1nIqTEAdUQKAetwbbcCarhOg=
-github.com/saferwall/pe v1.4.4/go.mod h1:SNzv3cdgk8SBI0UwHfyTcdjawfdnN+nbydnEL7GZ25s=
+github.com/saferwall/pe v1.5.4 h1:tLmMggEMUfeqrpJ25zS/okUQmyFdD5xWKL2+z9njCqg=
+github.com/saferwall/pe v1.5.4/go.mod h1:mJx+PuptmNpoPFBNhWs/uDMFL/kTHVZIkg0d4OUJFbQ=
 github.com/sebdah/goldie v1.0.0 h1:9GNhIat69MSlz/ndaBg48vl9dF5fI+NBB6kfOxgfkMc=
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
+github.com/secDre4mer/pkcs7 v0.0.0-20240322103146-665324a4461d h1:RQqyEogx5J6wPdoxqL132b100j8KjcVHO1c0KLRoIhc=
+github.com/secDre4mer/pkcs7 v0.0.0-20240322103146-665324a4461d/go.mod h1:PegD7EVqlN88z7TpCqH92hHP+GBpfomGCCnw1PFtNOA=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=

--- a/pkg/pe/parser.go
+++ b/pkg/pe/parser.go
@@ -350,13 +350,14 @@ func parse(path string, data []byte, options ...Option) (*PE, error) {
 	// parse certificate info
 	if opts.parseSecurity {
 		p.IsSigned = pe.IsSigned
-		if pe.HasCertificate {
+		if pe.HasCertificate && len(pe.Certificates.Certificates) > 0 {
+			cert := pe.Certificates.Certificates[0]
 			p.Cert = &sys.Cert{
-				Issuer:       pe.Certificates.Info.Issuer,
-				Subject:      pe.Certificates.Info.Subject,
-				NotBefore:    pe.Certificates.Info.NotBefore,
-				NotAfter:     pe.Certificates.Info.NotAfter,
-				SerialNumber: pe.Certificates.Info.SerialNumber,
+				Issuer:       cert.Info.Issuer,
+				Subject:      cert.Info.Subject,
+				NotBefore:    cert.Info.NotBefore,
+				NotAfter:     cert.Info.NotAfter,
+				SerialNumber: cert.Info.SerialNumber,
 			}
 		}
 	}


### PR DESCRIPTION
**What is the purpose of this PR / why it is needed?**

Besides bumping the `saferwall/pe` dependency, a couple of other changes are introduced in this PR. Firstly, the certificate structure is adapted to only consult the first certificate. This could change in the future if we wanted to grab the entire certificate chain. The second change concerns routing the `saferwall/pe` log messages to logrus.

**What type of change does this PR introduce?**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change that restructures the code, while not changing the original functionality) 

**Any specific area of the project related to this PR?**

- [x] Build
- [x] Other

**Special notes for the reviewer**:

**Does this PR introduce a user-facing change?**

