### PR TITLE
fix(processors, pe): Improve NTFS parser error handling

### DIFF
--- a/internal/etw/processors/processor.go
+++ b/internal/etw/processors/processor.go
@@ -98,10 +98,14 @@ func parseImageFileCharacteristics(e *kevent.Kevent) error {
 		// read file data blob from raw device
 		// if the regular file access fails
 		ntfs := libntfs.NewFS()
-		data, _, err = ntfs.Read(filename, 0, int64(os.Getpagesize()))
+		var n int
+		data, n, err = ntfs.Read(filename, 0, int64(os.Getpagesize()))
 		defer ntfs.Close()
 		if err != nil {
 			return err
+		}
+		if n > 0 {
+			data = data[:n]
 		}
 		goto parsePe
 	}

--- a/pkg/pe/parser.go
+++ b/pkg/pe/parser.go
@@ -177,6 +177,9 @@ func ParseFileWithConfig(path string, config Config) (*PE, error) {
 
 // ParseBytes tries to parse the PE from the given byte slice and parser options.
 func ParseBytes(data []byte, opts ...Option) (*PE, error) {
+	if len(data) == 0 || va.Zeroed(data) {
+		return nil, ErrEmptyVArea
+	}
 	return parse("", data, opts...)
 }
 
@@ -195,9 +198,6 @@ func ParseMem(pid uint32, base uintptr, changeProtection bool, opts ...Option) (
 	}
 	defer windows.Close(process)
 	area := va.ReadArea(process, base, MaxHeaderSize, MinHeaderSize, changeProtection)
-	if len(area) == 0 || va.Zeroed(area) {
-		return nil, ErrEmptyVArea
-	}
 	return ParseBytes(area, opts...)
 }
 


### PR DESCRIPTION
**What is the purpose of this PR / why it is needed?**

Slices the data buffer returned by the NTFS parser read operation. Additionally, prevent parsing the PE byte buffer if it is empty.

**What type of change does this PR introduce?**

- [x] Bug fix (non-breaking change which fixes an issue)

**Any specific area of the project related to this PR?**

- [x] Other

**Special notes for the reviewer**:

**Does this PR introduce a user-facing change?**

