### PR TITLE
chore(cli): Surface missing labels in rules validation subcommand

### DIFF
--- a/pkg/config/filters.go
+++ b/pkg/config/filters.go
@@ -97,6 +97,9 @@ func (f FilterConfig) DecodeActions() ([]any, error) {
 // IsDisabled determines if this filter is disabled.
 func (f FilterConfig) IsDisabled() bool { return f.Enabled != nil && !*f.Enabled }
 
+// HasLabel determines if the filter has the given label.
+func (f FilterConfig) HasLabel(l string) bool { return f.Labels[l] != "" }
+
 // Filters contains references to rule and macro definitions.
 type Filters struct {
 	Rules   Rules  `json:"rules" yaml:"rules"`


### PR DESCRIPTION
**What is the purpose of this PR / why it is needed?**

When the rule definition misses the recommended `MITRE` labels, declare the warning with the missing label.

**What type of change does this PR introduce?**

- [x] New feature (non-breaking change which adds functionality)

**Any specific area of the project related to this PR?**

- [x] CLI

**Special notes for the reviewer**:

**Does this PR introduce a user-facing change?**

Users will be able to spot rule validation warnings when any of the recommended tactic/technique labels are missing in the rule definition.
