### PR TITLE
fix(eventsource,etw): Correct file object lookup misses expvar

### DIFF
--- a/internal/etw/processors/fs_windows.go
+++ b/internal/etw/processors/fs_windows.go
@@ -307,7 +307,7 @@ func (f *fsProcessor) processEvent(e *kevent.Kevent) (*kevent.Kevent, error) {
 		}
 
 		// ignore object misses that are produced by CloseFile
-		if fileinfo == nil && e.IsCloseFile() {
+		if fileinfo == nil && !e.IsCloseFile() {
 			fileObjectMisses.Add(1)
 		}
 		if e.IsDeleteFile() {


### PR DESCRIPTION
**What is the purpose of this PR / why it is needed?**

Correct the condition to only increment missing file object lookups if the request is coming from non-CloseFile event.

**What type of change does this PR introduce?**

- [x] Bug fix (non-breaking change which fixes an issue)

**Any specific area of the project related to this PR?**

- [x] Instrumentation/telemetry

**Special notes for the reviewer**:

**Does this PR introduce a user-facing change?**

