### PR TITLE
feat(rules): New `Potential injection via .NET debugging` rule

### DIFF
--- a/rules/defense_evasion_potential_injection_via_dotnet_debugging.yml
+++ b/rules/defense_evasion_potential_injection_via_dotnet_debugging.yml
@@ -1,0 +1,37 @@
+name: Potential injection via .NET debugging
+id: 193ebf2f-e365-4f57-a639-275b7cdf0319
+version: 1.0.0
+description: |
+  Identifies creation of a process on behalf of the CLR debugging facility which may
+  be indicative of code injection. The CLR interface utilizes the OpenVirtualProcess
+  method to attach the debugger to the remote process.
+labels:
+  tactic.id: TA0005
+  tactic.name: Defense Evasion
+  tactic.ref: https://attack.mitre.org/tactics/TA0005/
+  technique.id: T1055
+  technique.name: Process Injection
+  technique.ref: https://attack.mitre.org/techniques/T1055/
+references:
+  - https://blog.xpnsec.com/debugging-into-net/
+  - https://learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/iclrdebugging-openvirtualprocess-method
+
+condition: >
+  spawn_process and thread.callstack.symbols imatches ('mscordbi.dll!OpenVirtualProcess')
+    and
+    not
+  ps.child.exe imatches
+    (
+      '?:\\Visual Studio\\Common?\\IDE\\devenv.exe',
+      '?:\\Program Files\\Microsoft Visual Studio\\*.exe',
+      '?:\\Program Files (x86)\\Microsoft Visual Studio\\*.exe',
+      '?:\\Program Files\\IIS Express\\iisexpress.exe',
+      '?:\\Program Files (x86)\\IIS Express\\iisexpress.exe'
+    )
+  and not ps.exe imatches '?:\\Program Files (x86)\\Microsoft Visual Studio\\*.exe'
+
+output: >
+  Process %ps.exe attached the .NET debugger to process %ps.child.exe for potential code injection
+severity: high
+
+min-engine-version: 2.0.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Identifies creation of a process on behalf of the CLR debugging facility which may be indicative of code injection. The CLR interface utilizes the OpenVirtualProcess method to attach the debugger to the remote process.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
