### PR TITLE
fix(rules): Reduce `RID Hijacking` rule false positives

### DIFF
--- a/rules/persistence_rid_hijacking.yml
+++ b/rules/persistence_rid_hijacking.yml
@@ -20,5 +20,8 @@ condition: >
   set_value and registry.key.name imatches 'HKEY_LOCAL_MACHINE\\SAM\\SAM\\Domains\\Account\\Users\\*\\F'
     and
   ps.sid in ('S-1-5-18', 'S-1-5-19', 'S-1-5-20')
+    and
+    not
+  ps.exe imatches '?:\\Windows\\System32\\lsass.exe'
 
 min-engine-version: 2.0.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

If the registry set value is initiated by the LSASS process, we can assume it is a false positive.


### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
