### PR TITLE
fix(proc): Spurious conditions when querying process protection attributes

### DIFF
--- a/pkg/ps/snapshotter_windows.go
+++ b/pkg/ps/snapshotter_windows.go
@@ -549,13 +549,15 @@ func (s *snapshotter) Find(pid uint32) (bool, *pstypes.PS) {
 
 	// get process creation attributes
 	var isWOW64 bool
-	if err := windows.IsWow64Process(process, &isWOW64); err != nil && isWOW64 {
+	if err := windows.IsWow64Process(process, &isWOW64); err == nil && isWOW64 {
 		proc.IsWOW64 = true
 	}
-	if p, err := sys.QueryInformationProcess[sys.PsProtection](process, sys.ProcessProtectionInformation); err != nil && p != nil {
-		proc.IsProtected = p.IsProtected()
+	if isPackaged, err := sys.IsProcessPackaged(process); err == nil && isPackaged {
+		proc.IsPackaged = true
 	}
-	proc.IsPackaged = sys.IsProcessPackaged(process)
+	if prot, err := sys.QueryInformationProcess[sys.PsProtection](process, sys.ProcessProtectionInformation); err == nil && prot != nil {
+		proc.IsProtected = prot.IsProtected()
+	}
 
 	return false, proc
 }

--- a/pkg/sys/process.go
+++ b/pkg/sys/process.go
@@ -101,14 +101,14 @@ func IsProcessRunning(proc windows.Handle) bool {
 
 // IsProcessPackaged determines if the process is packaged by trying
 // to resolve the package identifier.
-func IsProcessPackaged(proc windows.Handle) bool {
+func IsProcessPackaged(proc windows.Handle) (bool, error) {
 	var n uint32
 	err := GetPackageID(proc, &n, 0)
 	if err == windows.ERROR_INSUFFICIENT_BUFFER {
 		b := make([]byte, n)
 		err = GetPackageID(proc, &n, uintptr(unsafe.Pointer(&b[0])))
 	}
-	return err == nil
+	return err == nil, err
 }
 
 // IsWindowsService reports whether the process is currently executing


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Fixes spurious conditions when querying process protection attributes.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

/area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
