### PR TITLE
chore(kcap): Persist process flags in capture

### DIFF
--- a/pkg/kcap/version/version_windows.go
+++ b/pkg/kcap/version/version_windows.go
@@ -35,6 +35,8 @@ const (
 	ProcessSecV2
 	// ProcessSecV3 is the v3 of the process section
 	ProcessSecV3
+	// ProcessSecV4 is the v4 of the process section
+	ProcessSecV4
 )
 
 const (

--- a/pkg/kevent/marshaller_windows.go
+++ b/pkg/kevent/marshaller_windows.go
@@ -175,11 +175,11 @@ func (e *Kevent) MarshalRaw() []byte {
 	// write process state
 	if e.PS != nil && (e.IsCreateProcess() || e.IsProcessRundown()) {
 		buf := e.PS.Marshal()
-		sec := section.New(section.Process, kcapver.ProcessSecV3, 0, uint32(len(buf)))
+		sec := section.New(section.Process, kcapver.ProcessSecV4, 0, uint32(len(buf)))
 		b = append(b, sec[:]...)
 		b = append(b, buf...)
 	} else {
-		sec := section.New(section.Process, kcapver.ProcessSecV3, 0, 0)
+		sec := section.New(section.Process, kcapver.ProcessSecV4, 0, 0)
 		b = append(b, sec[:]...)
 	}
 

--- a/pkg/ps/types/marshaller_windows_test.go
+++ b/pkg/ps/types/marshaller_windows_test.go
@@ -77,10 +77,13 @@ func TestPSMarshaler(t *testing.T) {
 				Object: 357488883434455544,
 			},
 		},
+		IsProtected: true,
+		IsWOW64:     true,
+		IsPackaged:  false,
 	}
 
 	b := ps.Marshal()
-	sec := section.New(section.Process, kcapver.ProcessSecV3, 0, 0)
+	sec := section.New(section.Process, kcapver.ProcessSecV4, 0, 0)
 	clone, err := NewFromKcap(b, sec)
 	require.NoError(t, err)
 
@@ -96,6 +99,9 @@ func TestPSMarshaler(t *testing.T) {
 	assert.Equal(t, []string{"-contentproc", `--channel="6304.3.1055809391\1014207667`, "-childID", "1", "-isForBrowser", "-prefsHandle", "2584", "-prefMapHandle", "2580", "-prefsLen", "70", "-prefMapSize", "216993", "-parentBuildID"}, clone.Args)
 	assert.Equal(t, uint32(4), clone.SessionID)
 	assert.Equal(t, map[string]string{"ProgramData": "C:\\ProgramData", "COMPUTRENAME": "archrabbit"}, clone.Envs)
+	assert.True(t, clone.IsProtected)
+	assert.True(t, clone.IsWOW64)
+	assert.False(t, clone.IsPackaged)
 
 	require.Len(t, clone.Handles, 3)
 


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

The process state marshaller stores the new
`IsWow64`,  `IsPackaged`, and  `IsProtected` fields
into the binary blob.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

/area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
