### PR TITLE
feat(rules): New `DLL loaded via a callback function` rule

### DIFF
--- a/rules/defense_evasion_dll_loaded_via_callback_function.yml
+++ b/rules/defense_evasion_dll_loaded_via_callback_function.yml
@@ -1,0 +1,42 @@
+name: DLL loaded via a callback function
+id: c7f46d0a-10b2-421a-b33c-f4df79599f2e
+version: 1.0.0
+description: |
+  Identifies module proxying as a method to conceal suspicious callstacks. Adversaries use module proxying
+  the hide the origin of the LoadLibrary call from the callstack by loading the library from the callback
+  function.
+labels:
+   tactic.id: TA0005
+   tactic.name: Defense Evasion
+   tactic.ref: https://attack.mitre.org/tactics/TA0005/
+   technique.id: T1055
+   technique.name: Process Injection
+   technique.ref: https://attack.mitre.org/techniques/T1055/
+tags:
+  - https://github.com/hlldz/misc/tree/main/proxy_calls
+  - https://0xdarkvortex.dev/proxying-dll-loads-for-hiding-etwti-stack-tracing/
+
+condition: >
+  sequence
+  maxspan 2m
+   |spawn_process| by ps.child.uuid
+   |load_dll and base(image.name) iin 
+      (
+        'winhttp.dll', 'clr.dll', 'bcrypt.dll', 'bcryptprimitives.dll',
+        'wininet.dll', 'taskschd.dll', 'dnsapi.dll', 'coreclr.dll', 'ws2_32.dll',
+        'wmiutils.dll', 'vaultcli.dll', 'System.Management.Automation.dll', 'psapi.dll',
+        'mstscax.dll', 'dsquery.dll', 'mstask.dll', 'bitsproxy.dll'
+      )
+    and thread.callstack.summary 
+      imatches 
+      (
+        'ntdll.dll|kernelbase.dll|ntdll.dll|kernel32.dll|ntdll.dll', 
+        'ntdll.dll|wow64.dll|wow64cpu.dll|wow64.dll|ntdll.dll|kernelbase.dll|ntdll.dll|kernel32.dll|ntdll.dll'
+      )
+   | by ps.uuid
+
+output: >
+  %2.image.name loaded from callback function by process %ps.exe
+severity: high
+
+min-engine-version: 2.0.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Identifies module proxying as a method to conceal suspicious callstacks. Adversaries use module proxying the hide the origin of the LoadLibrary call from the callstack by loading the library from the callback function.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
