### PR TITLE
feat(rules): New `Process execution from a self-deleting binary` rule

### DIFF
--- a/rules/defense_evasion_process_execution_from_self_deleting_binary.yml
+++ b/rules/defense_evasion_process_execution_from_self_deleting_binary.yml
@@ -1,0 +1,30 @@
+name: Process execution from a self-deleting binary
+id: 0f0da517-b22c-4d14-9adc-36baeb621cf7
+version: 1.0.0
+description: |
+  Identifies the execution of the process from a self-deleting binary. The attackers can
+  abuse undocumented API functions to create a process from a file-backed section. The file 
+  is put into a delete-pending state allowing the attacker to bypass kernel callback controls
+  by closing the handle to the file before the main thread is spawned.
+labels:
+  tactic.id: TA0005
+  tactic.name: Defense Evasion
+  tactic.ref: https://attack.mitre.org/tactics/TA0005/
+  technique.id: T1055
+  technique.name: Process Injection
+  technique.ref: https://attack.mitre.org/techniques/T1055/
+references:
+  - https://github.com/hasherezade/process_ghosting
+  - https://www.elastic.co/es/blog/process-ghosting-a-new-executable-image-tampering-attack
+
+condition: >
+  sequence
+  maxspan 1m
+    |delete_file and file.info.is_disposition_delete_file| by file.name
+    |load_module| by image.name
+
+output: >
+  Process %2.image.name spawned from self-deleting binary
+severity: high
+
+min-engine-version: 2.3.0

--- a/rules/macros/macros.yml
+++ b/rules/macros/macros.yml
@@ -25,6 +25,9 @@
 - macro: create_file
   expr: kevt.name = 'CreateFile' and file.operation != 'OPEN' and file.status = 'Success'
 
+- macro: delete_file
+  expr: kevt.name = 'DeleteFile'
+
 - macro: query_registry
   expr: kevt.name in ('RegQueryKey', 'RegQueryValue') and registry.status = 'Success'
 


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Identifies the execution of the process from a self-deleting binary. The attackers can abuse undocumented API functions to create a process from a file-backed section. The file is put into a delete-pending state allowing the attacker to bypass kernel callback controls by closing the handle to the file before the main thread is spawned.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
