### PR TITLE
chore(alertsenders): Disable systray alertsender by default

### DIFF
--- a/configs/fibratus.yml
+++ b/configs/fibratus.yml
@@ -19,7 +19,7 @@ alertsenders:
   # Systray sender sends alerts as notifications to the taskbar status area.
   systray:
     # Enables/disables systray alert sender
-    enabled: true
+    enabled: false
 
     # Indicates if the associated sound is played when the balloon notification is shown
     sound: true
@@ -84,7 +84,7 @@ alertsenders:
     # Enables/disables the verbose mode. In verbose mode, the full event
     # context, including all parameters and the process information are included
     # in the log message.
-    verbose: false
+    verbose: true
 
 # =============================== API ==================================================
 

--- a/pkg/alertsender/eventlog/config.go
+++ b/pkg/alertsender/eventlog/config.go
@@ -40,5 +40,5 @@ type Config struct {
 // AddFlags registers persistent flags.
 func AddFlags(flags *pflag.FlagSet) {
 	flags.Bool(enabled, true, "Indicates if eventlog alert sender is enabled")
-	flags.Bool(verbose, false, "Enables/disables the verbose mode. In verbose mode, the full event context, including all parameters and the process information are included in the log message")
+	flags.Bool(verbose, true, "Enables/disables the verbose mode. In verbose mode, the full event context, including all parameters and the process information are included in the log message")
 }

--- a/pkg/alertsender/systray/config.go
+++ b/pkg/alertsender/systray/config.go
@@ -40,7 +40,7 @@ type Config struct {
 
 // AddFlags registers persistent flags.
 func AddFlags(flags *pflag.FlagSet) {
-	flags.Bool(enabled, true, "Determines whether systray alert sender is enabled")
+	flags.Bool(enabled, false, "Determines whether systray alert sender is enabled")
 	flags.Bool(sound, true, "Indicates if the associated sound is played when the balloon notification is shown")
 	flags.Bool(quietMode, false, "Instructs not to display the balloon notification if the current user is in quiet time")
 }

--- a/pkg/config/_fixtures/fibratus.yml
+++ b/pkg/config/_fixtures/fibratus.yml
@@ -16,6 +16,20 @@ aggregator:
 
 # Alert senders deal with emitting alerts via different channels.
 alertsenders:
+  # Systray sender sends alerts as notifications to the taskbar status area.
+  systray:
+    # Enables/disables systray alert sender
+    enabled: true
+
+    # Indicates if the associated sound is played when the balloon notification is shown
+    sound: true
+
+    # Instructs not to display the balloon notification if the current user is in quiet time.
+    # During this time, most notifications should not be sent or shown. This lets a user become
+    # accustomed to a new computer system without those distractions. Quiet time also occurs for
+    # each user after an operating system upgrade or clean installation.
+    quiet-mode: false
+
   # Mail sender transports the alerts via SMTP protocol.
   mail:
     # Enables/disables mail alert sender.


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Disable the systray alert sender by default, and enable evenlog verbose mode.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

/kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

/area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
