### PR TITLE
feat(rules): New `Image load via NTFS transaction` rule

### DIFF
--- a/rules/defense_evasion_image_load_via_ntfs_transaction.yml
+++ b/rules/defense_evasion_image_load_via_ntfs_transaction.yml
@@ -1,0 +1,28 @@
+name: Image load via NTFS transaction
+id: ce8de3d0-0768-41a7-bab9-4eca27ed1e3c
+version: 1.0.0
+description: |
+  Identifies image loading of a file written to disk via NTFS transaction. Adversaries may exploit 
+  the transactional API to execute code in the address space of the running process without committing 
+  the code to disk.
+labels:
+  tactic.id: TA0005
+  tactic.name: Defense Evasion
+  tactic.ref: https://attack.mitre.org/tactics/TA0005/
+  technique.id: T1055
+  technique.name: Process Injection
+  technique.ref: https://attack.mitre.org/techniques/T1055/
+references:
+  - https://learn.microsoft.com/en-us/windows/win32/fileio/about-transactional-ntfs
+
+condition: >
+  sequence
+  maxspan 2m
+    |create_file and thread.callstack.symbols imatches ('kernel32.dll!CreateFileTransacted*', 'ntdll.dll!RtlSetCurrentTransaction')| by file.name
+    |load_module and kevt.pid != 4| by image.name
+
+output: >
+  Image %2.image.name written via transactional NTFS and loaded afterward
+severity: high
+
+min-engine-version: 2.0.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Identifies image loading of a file written to disk via NTFS transaction. Adversaries may exploit the transactional API to execute code in the address space of the running process without committing the code to disk.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
