### PR TITLE
feat(rules): New `DLL loaded via APC queue` rule

### DIFF
--- a/rules/defense_evasion_dll_loaded_via_apc_queue.yml
+++ b/rules/defense_evasion_dll_loaded_via_apc_queue.yml
@@ -1,0 +1,33 @@
+name: DLL loaded via APC queue
+id: e1ee3912-ad7c-4acb-80f4-84db87e54d5e
+version: 1.0.0
+description: |
+  Identifies loading of a DLL with a callstack originating from the thread
+  alertable state that led to the execution of an APC routine. This may be
+  indicative of sleep obfuscation or process injection attempt.
+labels:
+  tactic.id: TA0005
+  tactic.name: Defense Evasion
+  tactic.ref: https://attack.mitre.org/tactics/TA0005/
+  technique.name: Process Injection
+  technique.ref: https://attack.mitre.org/techniques/T1055/
+  subtechnique.id: T1055.003
+references:
+  - https://github.com/Idov31/Cronos
+
+condition: >
+  load_dll and base(image.name) iin 
+    (
+      'winhttp.dll', 'clr.dll', 'bcrypt.dll', 'bcryptprimitives.dll',
+      'wininet.dll', 'taskschd.dll', 'dnsapi.dll', 'coreclr.dll', 'ws2_32.dll',
+      'wmiutils.dll', 'vaultcli.dll', 'System.Management.Automation.dll', 'psapi.dll',
+      'mstscax.dll', 'dsquery.dll', 'mstask.dll', 'bitsproxy.dll'
+    )
+    and 
+  thread.callstack.symbols imatches ('ntdll.dll!KiUserApcDispatcher')
+    and
+  thread.callstack.symbols imatches ('ntdll.dll!ZwDelayExecution')
+    and
+  thread.callstack.symbols imatches ('KernelBase.dll!Sleep*')
+
+min-engine-version: 2.0.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Identifies loading of a DLL with a callstack originating from the thread alertable state that led to the execution of an APC routine. This may be indicative of sleep obfuscation or process injection attempt.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
