### PR TITLE
fix(processors): Release file only by file object

### DIFF
--- a/internal/etw/processors/fs_windows.go
+++ b/internal/etw/processors/fs_windows.go
@@ -251,10 +251,8 @@ func (f *fsProcessor) processEvent(e *kevent.Kevent) (*kevent.Kevent, error) {
 		return ev, nil
 	case ktypes.ReleaseFile:
 		fileReleaseCount.Add(1)
-		// delete both, the file object and the file key from files map
-		fileKey := e.Kparams.MustGetUint64(kparams.FileKey)
+		// delete file metadata by file object address
 		fileObject := e.Kparams.MustGetUint64(kparams.FileObject)
-		delete(f.files, fileKey)
 		delete(f.files, fileObject)
 	case ktypes.UnmapViewFile:
 		_ = f.psnap.RemoveFileMapping(e.PID, e.Kparams.TryGetAddress(kparams.FileViewBase))


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

The file metainfo should be removed only by the file object. Doing this also by file key can lead to evicting file info that is used by subsequent events to derive the file name.


### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

/area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
