### PR TITLE
fix(processors): Skip reading value for hidden registry keys

### DIFF
--- a/internal/etw/processors/registry_windows.go
+++ b/internal/etw/processors/registry_windows.go
@@ -124,6 +124,11 @@ func (r *registryProcessor) processEvent(e *kevent.Kevent) (*kevent.Kevent, erro
 			return e, nil
 		}
 
+		// values within hidden keys cannot be read
+		if strings.HasSuffix(keyName, "\\") {
+			return e, nil
+		}
+
 		rootkey, subkey := key.Format(keyName)
 		if rootkey != key.Invalid {
 			typ, val, err := rootkey.ReadValue(subkey)


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

If the registry value is found within the hidden
key, skip reading the value as it would inevitably fail.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

/area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
