### PR TITLE
feat(rules): New `Hidden registry key creation` rule

### DIFF
--- a/rules/defense_evasion_hidden_registry_key_creation.yml
+++ b/rules/defense_evasion_hidden_registry_key_creation.yml
@@ -1,0 +1,27 @@
+name: Hidden registry key creation
+id: 65deda38-9b1d-42a0-9f40-a68903e81b49
+version: 1.0.0
+description: |
+  Identifies the creation of a hidden registry key. Adversaries can utilize the
+  native NtSetValueKey API to create a hidden registry key and conceal payloads
+  or commands used to maintain persistence.
+labels:
+  tactic.id: TA0005
+  tactic.name: Defense Evasion
+  tactic.ref: https://attack.mitre.org/tactics/TA0005/
+  technique.id: T1112
+  technique.name: Modify Registry
+  technique.ref: https://attack.mitre.org/techniques/T1112/
+references:
+  - https://github.com/outflanknl/SharpHide
+
+condition: >
+  set_value and kevt.pid != 4 and registry.key.name endswith '\\' 
+    and 
+  thread.callstack.symbols not imatches ('KernelBase.dll!RegSetValue*', 'KernelBase.dll!RegLoadAppKey*', 'KernelBase.dll!GetFileAttributes*')
+
+output: >
+  Hidden registry key %registry.key.name created by process %ps.exe
+severity: high
+
+min-engine-version: 2.2.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Identifies the creation of a hidden registry key. Adversaries can utilize the native `NtSetValueKey` API to create a hidden registry key and conceal payloads or commands used to maintain persistence.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
