### PR TITLE
fix(pe): Require sections during CLR parsing

### DIFF
--- a/pkg/pe/parser.go
+++ b/pkg/pe/parser.go
@@ -305,6 +305,11 @@ func parse(path string, data []byte, options ...Option) (*PE, error) {
 		p.EntryPoint = format.UintToHex(uint64(oh32.AddressOfEntryPoint))
 	}
 
+	// CLR directory parsing piggybacks on sections
+	if opts.parseCLR {
+		opts.parseSections = true
+	}
+
 	// parse section header
 	if opts.parseSections || opts.parseResources {
 		err = pe.ParseSectionHeader()


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

The CLR parsing logic relies on the presence
of the section headers. Enable section parsing
if CLR option is present.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

/area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
