### PR TITLE
refactor(alertsenders): Systray server spawning

### DIFF
--- a/build/msi/fibratus.wxs
+++ b/build/msi/fibratus.wxs
@@ -18,11 +18,6 @@
 
     <UI Id="UI">
       <ui:WixUI Id="WixUI_InstallDir" InstallDirectory="INSTALLDIR" />
-      <Publish Dialog="ExitDialog"
-              Control="Finish"
-              Event="DoAction"
-              Value="LaunchSystray"
-              Condition="NOT Installed"/>
     </UI>
 
     <!-- Custom banners -->
@@ -39,8 +34,6 @@
       <Files Include="!(bindpath.dir)**">
         <!-- Exclude from harvesting as its need fine-grained authoring in Windows Service -->
         <Exclude Files="!(bindpath.dir)Bin\fibratus.exe" />
-        <!-- Exclude from harvesting as it is used in custom action -->
-        <Exclude Files="!(bindpath.dir)Bin\fibratus-systray.exe" />
       </Files>
 
       <!-- Windows Service -->
@@ -56,14 +49,6 @@
               ThirdFailureActionType="restart" RestartServiceDelayInSeconds="60" />
         </ServiceInstall>
         <ServiceControl Id="Fibratus" Name="Fibratus" Start="install" Stop="both" Remove="uninstall" Wait="yes" />
-      </Component>
-      <Component Directory="BINDIR" Id="Systray" Guid="F3C06EDD-C830-4FCD-BAFA-0D15C697EE76">
-        <File Id="Systray" Source="!(bindpath.dir)Bin\fibratus-systray.exe" KeyPath="yes" Checksum="yes"/>
-        <RegistryValue Root="HKMU" Action="write"
-                       Key="Software\Microsoft\Windows\CurrentVersion\Run"
-                       Name="Fibratus Systray"
-                       Value="[BINDIR]fibratus-systray.exe"
-                       Type="string" />
       </Component>
     </ComponentGroup>
 
@@ -85,10 +70,7 @@
     <Property Id="ConfigureServiceRecovery" Value="&quot;SC.EXE&quot; failureflag fibratus 1" />
     <CustomAction Id="ConfigureServiceRecovery" BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)" DllEntry="WixQuietExec" Impersonate="no" Execute="deferred" Return="ignore" />
 
-    <!-- Systray -->
-    <Property Id="WixShellExecTarget" Value="[#Systray]"/>
-    <CustomAction Id="LaunchSystray" BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)" DllEntry="WixShellExec" Impersonate="yes" />
-    <util:CloseApplication Id="CloseSystray" CloseMessage="yes" Target="fibratus-systray" RebootPrompt="no" />
+    <util:CloseApplication Id="CloseSystray" CloseMessage="yes" Target="fibratus-systray.exe" RebootPrompt="no" />
 
     <InstallExecuteSequence>
       <Custom Action="ConfigureServiceRecovery" After="InstallServices" Condition="NOT REMOVE" />

--- a/pkg/sys/syscall.go
+++ b/pkg/sys/syscall.go
@@ -44,6 +44,8 @@ package sys
 
 // Windows Terminal Server Functions
 //sys WTSQuerySessionInformationA(handle windows.Handle, sessionID uint32, klass uint8, buf **uint16, size *uint32) (err error) = wtsapi32.WTSQuerySessionInformationW
+//sys WTSGetActiveConsoleSessionID() (n uint32) = kernel32.WTSGetActiveConsoleSessionId
+//sys WTSQueryUserToken(sessionID uint32, token *windows.Token) (ok bool) = wtsapi32.WTSQueryUserToken
 
 // Windows Trust Functions
 //sys WinVerifyTrust(handle windows.Handle, action *windows.GUID, data *WintrustData) (ret uint32, err error) [failretval!=0] = wintrust.WinVerifyTrust

--- a/pkg/sys/util.go
+++ b/pkg/sys/util.go
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021-2022 by Nedim Sabic Sabic
+ * https://www.fibratus.io
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sys
+
+import "golang.org/x/sys/windows/registry"
+
+// IsInSandbox indicates if the process is running inside an
+// isolated environment such as Windows Containers or Windows
+// Sandbox.
+func IsInSandbox() bool {
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, `SYSTEM\CurrentControlSet\Control`, registry.QUERY_VALUE)
+	if err != nil {
+		return false
+	}
+	defer key.Close()
+	v, _, err := key.GetIntegerValue("ContainerType")
+
+	return err == nil && v > 0
+}

--- a/pkg/sys/zsyscall_windows.go
+++ b/pkg/sys/zsyscall_windows.go
@@ -61,6 +61,7 @@ var (
 	procGetPackageId                         = modkernel32.NewProc("GetPackageId")
 	procGetProcessIdOfThread                 = modkernel32.NewProc("GetProcessIdOfThread")
 	procTerminateThread                      = modkernel32.NewProc("TerminateThread")
+	procWTSGetActiveConsoleSessionId         = modkernel32.NewProc("WTSGetActiveConsoleSessionId")
 	procNtAlpcQueryInformation               = modntdll.NewProc("NtAlpcQueryInformation")
 	procNtCreateSection                      = modntdll.NewProc("NtCreateSection")
 	procNtMapViewOfSection                   = modntdll.NewProc("NtMapViewOfSection")
@@ -89,6 +90,7 @@ var (
 	procCryptCATCatalogInfoFromContext       = modwintrust.NewProc("CryptCATCatalogInfoFromContext")
 	procWinVerifyTrust                       = modwintrust.NewProc("WinVerifyTrust")
 	procWTSQuerySessionInformationW          = modwtsapi32.NewProc("WTSQuerySessionInformationW")
+	procWTSQueryUserToken                    = modwtsapi32.NewProc("WTSQueryUserToken")
 )
 
 func SymEnumLoadedModules(handle windows.Handle, callback uintptr, ctx uintptr) (b bool) {
@@ -172,6 +174,12 @@ func TerminateThread(handle windows.Handle, exitCode uint32) (err error) {
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
+	return
+}
+
+func WTSGetActiveConsoleSessionID() (n uint32) {
+	r0, _, _ := syscall.Syscall(procWTSGetActiveConsoleSessionId.Addr(), 0, 0, 0, 0)
+	n = uint32(r0)
 	return
 }
 
@@ -379,5 +387,11 @@ func WTSQuerySessionInformationA(handle windows.Handle, sessionID uint32, klass 
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
+	return
+}
+
+func WTSQueryUserToken(sessionID uint32, token *windows.Token) (ok bool) {
+	r0, _, _ := syscall.Syscall(procWTSQueryUserToken.Addr(), 2, uintptr(sessionID), uintptr(unsafe.Pointer(token)), 0)
+	ok = r0 != 0
 	return
 }


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

The systray server is automatically launched when the
systray alert sender is enabled. The process is created
either via the regular CreateProcess API or CreateProcessAsUser
when Fibratus is running inside Windows Service.
This requires querying the user token of the currently logged-in
console session user. The TCB privilege must be present in the
user token.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

/kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

/area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
