### PR TITLE
chore(rules): Reorder not operators

### DIFF
--- a/rules/defense_evasion_dll_sideloading_via_copied_binary.yml
+++ b/rules/defense_evasion_dll_sideloading_via_copied_binary.yml
@@ -20,7 +20,7 @@ labels:
 condition: >
   sequence
   maxspan 8m
-    |create_file and file.is_exec and not ps.sid in ('S-1-5-18', 'S-1-5-19', 'S-1-5-20')
+    |create_file and file.is_exec and ps.sid not in ('S-1-5-18', 'S-1-5-19', 'S-1-5-20')
       and
      thread.callstack.symbols imatches ('*CopyFile*', '*MoveFile*')
     | by file.name

--- a/rules/defense_evasion_potential_process_hollowing_injection.yml
+++ b/rules/defense_evasion_potential_process_hollowing_injection.yml
@@ -29,7 +29,7 @@ references:
 condition: >
   sequence
   maxspan 2m
-    |spawn_process and not ps.sid in ('S-1-5-18', 'S-1-5-19', 'S-1-5-20') and not ps.exe imatches 
+    |spawn_process and ps.sid not in ('S-1-5-18', 'S-1-5-19', 'S-1-5-20') and not ps.exe imatches 
       (
         '?:\\Program Files\\*', 
         '?:\\Program Files (x86)\\*'


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Make sure the not operator is placed after the field.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

/kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
