### PR TITLE
chore(rules): Consider DUP_HANDLE access right

### DIFF
--- a/rules/credential_access_lsass_memory_dumping.yml
+++ b/rules/credential_access_lsass_memory_dumping.yml
@@ -23,7 +23,7 @@ condition: >
   sequence
   maxspan 2m
   by ps.uuid
-    |open_process and ps.access.mask.names in ('ALL_ACCESS', 'CREATE_PROCESS', 'VM_READ')
+    |open_process and ps.access.mask.names in ('ALL_ACCESS', 'CREATE_PROCESS', 'VM_READ', 'DUP_HANDLE')
       and
      kevt.arg[exe] imatches '?:\\Windows\\System32\\lsass.exe'
       and


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Certain tools tend to duplicate the lsass process
token and then initiate the minidump creation.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
