### PR TITLE
chore(rules): Reduce false positives

### DIFF
--- a/rules/defense_evasion_clear_eventlog.yml
+++ b/rules/defense_evasion_clear_eventlog.yml
@@ -1,6 +1,6 @@
 name: Clear Eventlog
 id: 692d3143-e1fb-4dab-8c9c-3109ff80ec85
-version: 1.0.0
+version: 1.0.1
 description: |
   Identifies attempts to clear Windows event log stores. Adversaries attempt to evade detection or 
   destroy forensic evidence on a system to cover their trails and slow down incident response.
@@ -19,11 +19,11 @@ condition: >
   sequence
   maxspan 1m
   by file.object
-    |set_file_information and file.info_class = 'EOF' and file.info.eof_size > 50000 and file.name imatches '?:\\Windows\\System32\\winevt\\Logs\\*.evtx'|
+    |set_file_information and kevt.pid != 4 and file.info_class = 'EOF' and file.info.eof_size > 50000 and file.name imatches '?:\\Windows\\System32\\winevt\\Logs\\*.evtx'|
     |set_file_information and file.info_class = 'Allocation' and file.info.allocation_size > 50000|
 
 output: >
   Windows Eventlog store %1.file.name was cleared
-severity: high
+severity: medium
 
 min-engine-version: 2.3.0

--- a/rules/defense_evasion_hidden_registry_key_creation.yml
+++ b/rules/defense_evasion_hidden_registry_key_creation.yml
@@ -1,6 +1,6 @@
 name: Hidden registry key creation
 id: 65deda38-9b1d-42a0-9f40-a68903e81b49
-version: 1.0.1
+version: 1.1.0
 description: |
   Identifies the creation of a hidden registry key. Adversaries can utilize the
   native NtSetValueKey API to create a hidden registry key and conceal payloads
@@ -17,7 +17,9 @@ references:
 
 condition: >
   set_value and kevt.pid != 4 and registry.key.name endswith '\\' 
-    and 
+    and
+  thread.callstack.symbols imatches ('ntdll.dll!NtSetValueKey', 'ntdll.dll!ZwSetValueKey')
+    and
   thread.callstack.symbols not imatches ('KernelBase.dll!RegSetValue*', 'KernelBase.dll!RegLoadAppKey*', 'KernelBase.dll!GetFileAttributes*')
     and
     not
@@ -25,7 +27,9 @@ condition: >
     (
       '?:\\Program Files (x86)\\Microsoft\\EdgeUpdate\\MicrosoftEdgeUpdate.exe',
       '?:\\Program Files\\Microsoft\\EdgeUpdate\\MicrosoftEdgeUpdate.exe',
-      '?:\\Windows\\System32\\sppsvc.exe'
+      '?:\\Windows\\System32\\sppsvc.exe',
+      '?:\\Windows\\System32\\compattelrunner.exe',
+      '?:\\Windows\\explorer.exe'
     )
 
 output: >

--- a/rules/defense_evasion_potential_process_hollowing_injection.yml
+++ b/rules/defense_evasion_potential_process_hollowing_injection.yml
@@ -1,6 +1,6 @@
 name: Potential Process Hollowing
 id: 2a3fbae8-5e8c-4b71-b9da-56c3958c0d53
-version: 1.1.1
+version: 1.1.2
 description: |
   Adversaries may inject malicious code into suspended and hollowed processes in order to
   evade process-based defenses. Process hollowing is a method of executing arbitrary code
@@ -31,8 +31,8 @@ condition: >
   maxspan 2m
     |spawn_process and ps.sid not in ('S-1-5-18', 'S-1-5-19', 'S-1-5-20') and not ps.exe imatches 
       (
-        '?:\\Program Files\\*', 
-        '?:\\Program Files (x86)\\*'
+        '?:\\Program Files\\*.exe', 
+        '?:\\Program Files (x86)\\*.exe'
       )
     | by ps.child.uuid
     |unmap_view_of_section and file.view.size > 20000 and file.view.protection != 'READONLY' and (length(file.name) = 0 or not ext(file.name) = '.dll')| by ps.uuid

--- a/rules/defense_evasion_potential_process_injection_via_tainted_memory_section.yml
+++ b/rules/defense_evasion_potential_process_injection_via_tainted_memory_section.yml
@@ -22,13 +22,13 @@ references:
 condition: >
   sequence
   maxspan 1m
-    |map_view_of_section and file.view.protection = 'READWRITE' and kevt.pid != 4 and file.view.size >= 4096| as e1
-    |map_view_of_section and file.view.protection = 'READONLY|EXECUTE' and file.key = $e1.file.key and kevt.pid != $e1.kevt.pid and not ps.exe imatches
+    |map_view_of_section and file.view.protection = 'READWRITE' and kevt.pid != 4 and file.view.size >= 4096 and not ps.exe imatches 
       (
-        '?:\\Program Files\\Mozilla Firefox\\firefox.exe',
-        '?:\\Program Files (x86)\\Mozilla Firefox\\firefox.exe'
+        '?:\\Program Files\\*.exe', 
+        '?:\\Program Files (x86)\\*.exe'
       )
-    |
+    | as e1
+    |map_view_of_section and file.view.protection = 'READONLY|EXECUTE' and file.key = $e1.file.key and kevt.pid != $e1.kevt.pid|
 action:
   - name: kill
 

--- a/rules/defense_evasion_thread_context_set_from_unbacked_memory.yml
+++ b/rules/defense_evasion_thread_context_set_from_unbacked_memory.yml
@@ -1,6 +1,6 @@
 name: Thread context set from unbacked memory
 id: f8219274-ee68-416b-8489-4d2e635c7844
-version: 1.0.1
+version: 1.0.2
 description: |
   Identifies manipulation of the thread context from unbacked memory region. This may be
   indicative of process injection.
@@ -20,7 +20,8 @@ condition: >
     (
       '?:\\Program Files\\Git\\mingw64\\bin\\git.exe',
       '?:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe',
-      '?:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe'
+      '?:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe',
+      '?:\\Windows\\System32\\taskhostw.exe'
     )
 
 min-engine-version: 2.2.0

--- a/rules/defense_evasion_unsigned_dll_injection_via_remote_thread.yml
+++ b/rules/defense_evasion_unsigned_dll_injection_via_remote_thread.yml
@@ -1,6 +1,6 @@
 name: Unsigned DLL injection via remote thread
 id: 21bdd944-3bda-464b-9a72-58fd37ba9163
-version: 1.0.0
+version: 1.0.1
 description: |
   Identifies unsigned DLL injection via remote thread creation.
   Adversaries may inject dynamic-link libraries (DLLs) into processes in order to evade process-based defenses
@@ -24,8 +24,8 @@ condition: >
   maxspan 1m
     |create_remote_thread and not (ps.exe imatches
       (
-        '?:\\Program Files\\*',
-        '?:\\Program Files (x86)\\*'
+        '?:\\Program Files\\*.exe',
+        '?:\\Program Files (x86)\\*.exe'
       )
         or
       (ps.exe imatches 'C:\\Windows\\System32\\svchost.exe' and ps.args iin ('-k', 'DcomLaunch'))

--- a/rules/persistence_script_interpreter_or_untrusted_process_persistence.yml
+++ b/rules/persistence_script_interpreter_or_untrusted_process_persistence.yml
@@ -1,6 +1,6 @@
 name: Script interpreter host or untrusted process persistence
 id: cc41ee3a-6e44-4903-85a4-0147ec6a7eea
-version: 1.0.1
+version: 1.0.2
 description: |
   Identifies the script interpreter or untrusted process writing
   to commonly abused run keys or the Startup folder locations.
@@ -31,6 +31,14 @@ condition: >
       or
     file.name imatches startup_locations
   )
+    and
+    not
+  ps.exe imatches
+    (
+      '?:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe',
+      '?:\\Program Files (x86)\\Microsoft\\Edge\\Application\\*\\msedge.exe',
+      '?:\\Program Files\\Microsoft\\Edge\\Application\\*\\msedge.exe'
+    )
 action:
   - name: kill
 


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Reduces false positives in the following rules.

- Thread context set from unbacked memory: include the taskhostw.exe exception
- Hidden registry key creation: Make sure the callstack contains the *SetValueKey symbol
- Hidden registry key creation: include explorer.exe exception
- Potential process injection via tainted memory section: discard all processes from the Program Files/Program Files (x86) directories
- Script interpreter host or untrusted process persistence: include msedge.exe exceptions

Demotes the severity to medium in the Clear Eventlog rule.


### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

/kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
