### PR TITLE
perf(pe): Disable CLR metadata parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/qmuntal/stateless v1.6.0
 	github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5
-	github.com/saferwall/pe v1.5.4
+	github.com/saferwall/pe v1.5.6
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.5
@@ -87,4 +87,4 @@ require (
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 )
 
-go 1.21
+go 1.23

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ github.com/rivo/uniseg v0.4.2/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
-github.com/saferwall/pe v1.5.4 h1:tLmMggEMUfeqrpJ25zS/okUQmyFdD5xWKL2+z9njCqg=
-github.com/saferwall/pe v1.5.4/go.mod h1:mJx+PuptmNpoPFBNhWs/uDMFL/kTHVZIkg0d4OUJFbQ=
+github.com/saferwall/pe v1.5.6 h1:DrRLnoQFxHWJ5lJUmrH7X2L0xeUu6SUS95Dc61eW2Yc=
+github.com/saferwall/pe v1.5.6/go.mod h1:mJx+PuptmNpoPFBNhWs/uDMFL/kTHVZIkg0d4OUJFbQ=
 github.com/sebdah/goldie v1.0.0 h1:9GNhIat69MSlz/ndaBg48vl9dF5fI+NBB6kfOxgfkMc=
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/secDre4mer/pkcs7 v0.0.0-20240322103146-665324a4461d h1:RQqyEogx5J6wPdoxqL132b100j8KjcVHO1c0KLRoIhc=

--- a/pkg/pe/parser.go
+++ b/pkg/pe/parser.go
@@ -211,6 +211,7 @@ func newParserOpts(opts opts) *peparser.Options {
 		OmitExceptionDirectory:    true,
 		OmitTLSDirectory:          true,
 		OmitCLRHeaderDirectory:    !opts.parseCLR,
+		OmitCLRMetadata:           true,
 		OmitDelayImportDirectory:  true,
 		OmitBoundImportDirectory:  true,
 		OmitArchitectureDirectory: true,
@@ -305,13 +306,8 @@ func parse(path string, data []byte, options ...Option) (*PE, error) {
 		p.EntryPoint = format.UintToHex(uint64(oh32.AddressOfEntryPoint))
 	}
 
-	// CLR directory parsing piggybacks on sections
-	if opts.parseCLR {
-		opts.parseSections = true
-	}
-
 	// parse section header
-	if opts.parseSections || opts.parseResources {
+	if opts.parseSections || opts.parseResources || opts.parseCLR {
 		err = pe.ParseSectionHeader()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

CLR metadata parsing is not considered useful
for detection purposes so we can safely disable
it and gain some perf improvements.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

/area deps

/area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
