### PR TITLE
chore(yara): Virtual alloc rwx once per process

### DIFF
--- a/pkg/yara/config/config.go
+++ b/pkg/yara/config/config.go
@@ -165,7 +165,7 @@ func (c Config) ShouldSkipFile(file string) bool {
 // whether the process scan took place or a file/registry
 // key was scanned.
 func (c Config) AlertTitle(e *kevent.Kevent) string {
-	if (e.Category == ktypes.File && e.Kparams.Contains(kparams.FileName)) || e.Category == ktypes.Registry {
+	if (e.Category == ktypes.File && e.GetParamAsString(kparams.FileName) != "") || e.Category == ktypes.Registry {
 		return FileThreatAlertTitle
 	}
 	return MemoryThreatAlertTitle


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

If the process is performing many VirtualAlloc calls
with RWX page protection, and one call results in a rule
match, then we don't need to repeatedly initiate the
scan for the same process.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

/area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
