### PR TITLE
feat(symbolizer): Symbolize thread start address

### DIFF
--- a/pkg/kevent/kparams/fields_windows.go
+++ b/pkg/kevent/kparams/fields_windows.go
@@ -78,6 +78,10 @@ const (
 	UstackLimit = "ustack_limit"
 	// StartAddress field is the thread start address.
 	StartAddress = "start_address"
+	// StartAddressSymbol field is the symbol associated with the thread start address.
+	StartAddressSymbol = "start_address_symbol"
+	// StartAddressModule field is the module where the thread start address is mapped.
+	StartAddressModule = "start_address_module"
 	// TEB field is the address of the Thread Environment Block (TEB)
 	TEB = "teb"
 


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Resolve the thread start address to its respective symbol name and the module from which the function call is originated.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

/area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
