### PR TITLE
feat(event): Callstack for OpenProcess/OpenThread events

### DIFF
--- a/internal/etw/source_test.go
+++ b/internal/etw/source_test.go
@@ -1162,6 +1162,40 @@ func testCallstackEnrichment(t *testing.T, hsnap handle.Snapshotter, psnap ps.Sn
 			},
 			false,
 		},
+		{
+			"open process callstack",
+			func() error {
+				_, err := windows.OpenProcess(windows.PROCESS_VM_READ, false, uint32(os.Getpid()))
+				return err
+			},
+			func(e *kevent.Kevent) bool {
+				if e.CurrentPid() && e.Type == ktypes.OpenProcess {
+					callstack := e.Callstack.String()
+					log.Infof("open process event %s: %s", e.String(), callstack)
+					return callstackContainsTestExe(callstack) &&
+						strings.Contains(strings.ToLower(callstack), strings.ToLower("\\WINDOWS\\System32\\KERNELBASE.dll!OpenProcess"))
+				}
+				return false
+			},
+			false,
+		},
+		{
+			"open thread callstack",
+			func() error {
+				_, err := windows.OpenThread(windows.THREAD_IMPERSONATE, false, windows.GetCurrentThreadId())
+				return err
+			},
+			func(e *kevent.Kevent) bool {
+				if e.CurrentPid() && e.Type == ktypes.OpenThread {
+					callstack := e.Callstack.String()
+					log.Infof("open thread event %s: %s", e.String(), callstack)
+					return callstackContainsTestExe(callstack) &&
+						strings.Contains(strings.ToLower(callstack), strings.ToLower("\\WINDOWS\\System32\\KERNELBASE.dll!OpenThread"))
+				}
+				return false
+			},
+			false,
+		},
 	}
 
 	kstreamConfig := config.KstreamConfig{

--- a/pkg/kevent/flags.go
+++ b/pkg/kevent/flags.go
@@ -76,9 +76,12 @@ var PsCreationFlags = []ParamFlag{
 	{"PACKAGED", PsPackaged},
 }
 
+// AllAccess represents the maximum process/thread access right
+const AllAccess = windows.STANDARD_RIGHTS_REQUIRED | windows.SYNCHRONIZE | 0xFFFF
+
 // PsAccessRightFlags describes flags for the process access rights.
 var PsAccessRightFlags = []ParamFlag{
-	{"ALL_ACCESS", windows.STANDARD_RIGHTS_REQUIRED | windows.SYNCHRONIZE | 0xFFFF},
+	{"ALL_ACCESS", AllAccess},
 	{"DELETE", windows.DELETE},
 	{"READ_CONTROL", windows.READ_CONTROL},
 	{"SYNCHRONIZE", windows.SYNCHRONIZE},
@@ -102,7 +105,7 @@ var PsAccessRightFlags = []ParamFlag{
 
 // ThreadAccessRightFlags describes flags for the thread access rights.
 var ThreadAccessRightFlags = []ParamFlag{
-	{"ALL_ACCESS", windows.STANDARD_RIGHTS_REQUIRED | windows.SYNCHRONIZE | 0xFFFF},
+	{"ALL_ACCESS", AllAccess},
 	{"DELETE", windows.DELETE},
 	{"READ_CONTROL", windows.READ_CONTROL},
 	{"SYNCHRONIZE", windows.SYNCHRONIZE},

--- a/pkg/kevent/kparam_windows.go
+++ b/pkg/kevent/kparam_windows.go
@@ -269,6 +269,14 @@ func (e *Kevent) produceParams(evt *etw.EventRecord) {
 		e.AppendParam(kparams.ProcessID, kparams.PID, processID)
 		e.AppendParam(kparams.DesiredAccess, kparams.Flags, desiredAccess, WithFlags(PsAccessRightFlags))
 		e.AppendParam(kparams.NTStatus, kparams.Status, status)
+
+		// append callstack for interested flags
+		if desiredAccess == AllAccess || ((desiredAccess & windows.PROCESS_VM_READ) != 0) || ((desiredAccess & windows.PROCESS_VM_WRITE) != 0) ||
+			((desiredAccess & windows.PROCESS_VM_OPERATION) != 0) || ((desiredAccess & windows.PROCESS_DUP_HANDLE) != 0) ||
+			((desiredAccess & windows.PROCESS_TERMINATE) != 0) || ((desiredAccess & windows.PROCESS_CREATE_PROCESS) != 0) ||
+			((desiredAccess & windows.PROCESS_CREATE_THREAD) != 0) || ((desiredAccess & windows.PROCESS_SET_INFORMATION) != 0) {
+			e.AppendParam(kparams.Callstack, kparams.Slice, evt.Callstack())
+		}
 	case ktypes.CreateThread,
 		ktypes.TerminateThread,
 		ktypes.ThreadRundown:
@@ -323,6 +331,14 @@ func (e *Kevent) produceParams(evt *etw.EventRecord) {
 		e.AppendParam(kparams.ThreadID, kparams.TID, threadID)
 		e.AppendParam(kparams.DesiredAccess, kparams.Flags, desiredAccess, WithFlags(ThreadAccessRightFlags))
 		e.AppendParam(kparams.NTStatus, kparams.Status, status)
+
+		// append callstack for interested flags
+		if desiredAccess == AllAccess || ((desiredAccess & windows.THREAD_SET_CONTEXT) != 0) || ((desiredAccess & windows.THREAD_SET_THREAD_TOKEN) != 0) ||
+			((desiredAccess & windows.THREAD_IMPERSONATE) != 0) || ((desiredAccess & windows.THREAD_DIRECT_IMPERSONATION) != 0) ||
+			((desiredAccess & windows.THREAD_SUSPEND_RESUME) != 0) || ((desiredAccess & windows.THREAD_TERMINATE) != 0) ||
+			((desiredAccess & windows.THREAD_SET_INFORMATION) != 0) {
+			e.AppendParam(kparams.Callstack, kparams.Slice, evt.Callstack())
+		}
 	case ktypes.SetThreadContext:
 		status := evt.ReadUint32(0)
 		e.AppendParam(kparams.NTStatus, kparams.Status, status)


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

The callstack is included in the event parameters. For the sake of performance, we're deriving the callstack only for the interesting flag set.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

/area telemetry

> /area rule-engine

> /area filters

> /area yara

/area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
