### PR TITLE
refactor(ps): Store memory mappings per process

### DIFF
--- a/internal/etw/processors/fs_windows.go
+++ b/internal/etw/processors/fs_windows.go
@@ -49,8 +49,6 @@ var (
 type fsProcessor struct {
 	// files stores the file metadata indexed by file object
 	files map[uint64]*FileInfo
-	// mmaps stores memory-mapped files by pid and file object
-	mmaps map[uint32]map[uint64]*MmapInfo
 
 	hsnap handle.Snapshotter
 	psnap ps.Snapshotter
@@ -75,13 +73,6 @@ type FileInfo struct {
 	Type fs.FileType
 }
 
-// MmapInfo stores information of the memory-mapped file.
-type MmapInfo struct {
-	File     string
-	BaseAddr uint64
-	Size     uint64
-}
-
 func newFsProcessor(
 	hsnap handle.Snapshotter,
 	psnap ps.Snapshotter,
@@ -91,7 +82,6 @@ func newFsProcessor(
 ) Processor {
 	f := &fsProcessor{
 		files:           make(map[uint64]*FileInfo),
-		mmaps:           make(map[uint32]map[uint64]*MmapInfo),
 		irps:            make(map[uint64]*kevent.Kevent),
 		hsnap:           hsnap,
 		psnap:           psnap,
@@ -139,35 +129,25 @@ func (f *fsProcessor) processEvent(e *kevent.Kevent) (*kevent.Kevent, error) {
 			f.files[fileObject] = &FileInfo{Name: filename, Type: fs.GetFileType(filename, 0)}
 		}
 	case ktypes.MapFileRundown:
-		// if the memory-mapped view refers to the image/data file
-		// we store it in internal state for each process. The state
-		// is consulted later when we process unmap events
-		sec := e.Kparams.MustGetUint32(kparams.FileViewSectionType)
-		isMapped := sec != va.SectionPagefile && sec != va.SectionPhysical
-		if !isMapped {
-			return e, nil
-		}
 		fileKey := e.Kparams.MustGetUint64(kparams.FileKey)
-		viewBase := e.Kparams.MustGetUint64(kparams.FileViewBase)
-		viewSize := e.Kparams.MustGetUint64(kparams.FileViewSize)
-		f.initMmap(e.PID)
 		fileinfo := f.files[fileKey]
+
 		if fileinfo != nil {
 			totalMapRundownFiles.Add(1)
-			f.mmaps[e.PID][fileKey] = &MmapInfo{File: fileinfo.Name, BaseAddr: viewBase, Size: viewSize}
+			e.AppendParam(kparams.FileName, kparams.FilePath, fileinfo.Name)
 		} else {
-			process, err := windows.OpenProcess(windows.PROCESS_QUERY_INFORMATION, false, e.PID)
-			if err != nil {
-				return e, nil
+			// if the view of section is backed by the data/image file
+			// try to get the mapped file name and append it to params
+			sec := e.Kparams.MustGetUint32(kparams.FileViewSectionType)
+			isMapped := sec != va.SectionPagefile && sec != va.SectionPhysical
+			if isMapped {
+				totalMapRundownFiles.Add(1)
+				addr := e.Kparams.MustGetUint64(kparams.FileViewBase) + (e.Kparams.MustGetUint64(kparams.FileOffset))
+				e.AppendParam(kparams.FileName, kparams.FilePath, f.getMappedFile(e.PID, addr))
 			}
-			defer windows.Close(process)
-			totalMapRundownFiles.Add(1)
-			addr := e.Kparams.MustGetUint64(kparams.FileViewBase) + (e.Kparams.MustGetUint64(kparams.FileOffset))
-			name := f.devMapper.Convert(sys.GetMappedFile(process, uintptr(addr)))
-			f.mmaps[e.PID][fileKey] = &MmapInfo{File: name, BaseAddr: viewBase, Size: viewSize}
 		}
-		e.AppendParam(kparams.FileName, kparams.FilePath, f.mmaps[e.PID][fileKey].File)
-		return e, f.psnap.AddFileMapping(e)
+
+		return e, f.psnap.AddMmap(e)
 	case ktypes.CreateFile:
 		// we defer the processing of the CreateFile event until we get
 		// the matching FileOpEnd event. This event contains the operation
@@ -255,24 +235,22 @@ func (f *fsProcessor) processEvent(e *kevent.Kevent) (*kevent.Kevent, error) {
 		fileObject := e.Kparams.MustGetUint64(kparams.FileObject)
 		delete(f.files, fileObject)
 	case ktypes.UnmapViewFile:
-		_ = f.psnap.RemoveFileMapping(e.PID, e.Kparams.TryGetAddress(kparams.FileViewBase))
-		fileKey := e.Kparams.MustGetUint64(kparams.FileKey)
-		if _, ok := f.mmaps[e.PID]; !ok {
-			return e, nil
+		ok, proc := f.psnap.Find(e.PID)
+		addr := e.Kparams.TryGetAddress(kparams.FileViewBase)
+		if ok {
+			mmap := proc.FindMmap(addr)
+			if mmap != nil {
+				e.AppendParam(kparams.FileName, kparams.FilePath, mmap.File)
+			}
 		}
-		mmapinfo := f.mmaps[e.PID][fileKey]
-		if mmapinfo != nil {
-			e.AppendParam(kparams.FileName, kparams.FilePath, mmapinfo.File)
-		}
+
 		totalMapRundownFiles.Add(-1)
-		delete(f.mmaps[e.PID], fileKey)
-		if len(f.mmaps[e.PID]) == 0 {
-			// process terminated, all files unmapped
-			f.removeMmap(e.PID)
-		}
+
+		return e, f.psnap.RemoveMmap(e.PID, addr)
 	default:
 		var fileObject uint64
 		fileKey := e.Kparams.MustGetUint64(kparams.FileKey)
+
 		if !e.IsMapViewFile() {
 			fileObject = e.Kparams.MustGetUint64(kparams.FileObject)
 		}
@@ -286,28 +264,18 @@ func (f *fsProcessor) processEvent(e *kevent.Kevent) (*kevent.Kevent, error) {
 		if fileinfo == nil && e.IsMapViewFile() {
 			sec := e.Kparams.MustGetUint32(kparams.FileViewSectionType)
 			isMapped := sec != va.SectionPagefile && sec != va.SectionPhysical
-			if !isMapped {
-				return e, nil
+			if isMapped {
+				totalMapRundownFiles.Add(1)
+				addr := e.Kparams.MustGetUint64(kparams.FileViewBase) + (e.Kparams.MustGetUint64(kparams.FileOffset))
+				e.AppendParam(kparams.FileName, kparams.FilePath, f.getMappedFile(e.PID, addr))
 			}
-			process, err := windows.OpenProcess(windows.PROCESS_QUERY_INFORMATION, false, e.PID)
-			if err != nil {
-				return e, nil
-			}
-			defer windows.Close(process)
-			viewBase := e.Kparams.MustGetUint64(kparams.FileViewBase)
-			viewSize := e.Kparams.MustGetUint64(kparams.FileViewSize)
-			addr := e.Kparams.MustGetUint64(kparams.FileViewBase) + (e.Kparams.MustGetUint64(kparams.FileOffset))
-			name := f.devMapper.Convert(sys.GetMappedFile(process, uintptr(addr)))
-			f.initMmap(e.PID)
-			f.mmaps[e.PID][fileKey] = &MmapInfo{File: name, BaseAddr: viewBase, Size: viewSize}
-			e.AppendParam(kparams.FileName, kparams.FilePath, name)
-			return e, f.psnap.AddFileMapping(e)
 		}
 
 		// ignore object misses that are produced by CloseFile
 		if fileinfo == nil && !e.IsCloseFile() {
 			fileObjectMisses.Add(1)
 		}
+
 		if e.IsDeleteFile() {
 			delete(f.files, fileObject)
 		}
@@ -317,14 +285,16 @@ func (f *fsProcessor) processEvent(e *kevent.Kevent) (*kevent.Kevent, error) {
 			}
 			return e, nil
 		}
+
 		if fileinfo != nil {
 			if fileinfo.Type != fs.Unknown {
 				e.AppendEnum(kparams.FileType, uint32(fileinfo.Type), fs.FileTypes)
 			}
 			e.AppendParam(kparams.FileName, kparams.FilePath, fileinfo.Name)
 		}
+
 		if e.IsMapViewFile() {
-			return e, f.psnap.AddFileMapping(e)
+			return e, f.psnap.AddMmap(e)
 		}
 	}
 	return e, nil
@@ -352,15 +322,13 @@ func (f *fsProcessor) findFile(fileKey, fileObject uint64) *FileInfo {
 	return nil
 }
 
-func (f *fsProcessor) initMmap(pid uint32) {
-	m := f.mmaps[pid]
-	if m == nil {
-		f.mmaps[pid] = make(map[uint64]*MmapInfo)
+func (f *fsProcessor) getMappedFile(pid uint32, addr uint64) string {
+	process, err := windows.OpenProcess(windows.PROCESS_QUERY_INFORMATION, false, pid)
+	if err != nil {
+		return ""
 	}
-}
-
-func (f *fsProcessor) removeMmap(pid uint32) {
-	delete(f.mmaps, pid)
+	defer windows.Close(process)
+	return f.devMapper.Convert(sys.GetMappedFile(process, uintptr(addr)))
 }
 
 func (f *fsProcessor) purge() {

--- a/internal/etw/processors/fs_windows_test.go
+++ b/internal/etw/processors/fs_windows_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/kevent/kparams"
 	"github.com/rabbitstack/fibratus/pkg/kevent/ktypes"
 	"github.com/rabbitstack/fibratus/pkg/ps"
+	pstypes "github.com/rabbitstack/fibratus/pkg/ps/types"
 	"github.com/rabbitstack/fibratus/pkg/util/va"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -89,12 +90,17 @@ func TestFsProcessor(t *testing.T) {
 			},
 			func(e *kevent.Kevent, t *testing.T, hsnap *handle.SnapshotterMock, p Processor) {
 				fsProcessor := p.(*fsProcessor)
-				assert.Contains(t, fsProcessor.mmaps, uint32(10233))
-				mapinfo := fsProcessor.mmaps[10233][124567380264]
-				require.NotNil(t, mapinfo)
-				assert.Equal(t, "C:\\Windows\\System32\\kernel32.dll", mapinfo.File)
-				assert.Equal(t, uint64(3098), mapinfo.Size)
-				assert.Equal(t, uint64(0xffff23433), mapinfo.BaseAddr)
+
+				ok, proc := fsProcessor.psnap.Find(10233)
+				require.True(t, ok)
+				require.NotNil(t, proc)
+
+				mmap := proc.FindMmap(va.Address(0xffff23433))
+				require.NotNil(t, mmap)
+
+				assert.Equal(t, "C:\\Windows\\System32\\kernel32.dll", mmap.File)
+				assert.Equal(t, uint64(3098), mmap.Size)
+				assert.Equal(t, va.Address(0xffff23433), mmap.BaseAddress)
 			},
 		},
 		{
@@ -201,19 +207,16 @@ func TestFsProcessor(t *testing.T) {
 					kparams.FileViewSectionType: {Name: kparams.FileViewSectionType, Type: kparams.Enum, Value: uint32(va.SectionImage), Enum: kevent.ViewSectionTypes},
 				},
 			},
-			func(p Processor) {
-				fsProcessor := p.(*fsProcessor)
-				fsProcessor.mmaps[10233] = make(map[uint64]*MmapInfo)
-				fsProcessor.mmaps[10233][124567380264] = &MmapInfo{File: "C:\\Windows\\System32\\kernel32.dll"}
-			},
+			nil,
 			func() *handle.SnapshotterMock {
 				hsnap := new(handle.SnapshotterMock)
 				return hsnap
 			},
 			func(e *kevent.Kevent, t *testing.T, hsnap *handle.SnapshotterMock, p Processor) {
 				fsProcessor := p.(*fsProcessor)
-				assert.True(t, e.Kparams.Contains(kparams.FileName))
-				assert.Nil(t, fsProcessor.mmaps[3098][124567380264])
+
+				psnap := fsProcessor.psnap.(*ps.SnapshotterMock)
+				psnap.AssertNumberOfCalls(t, "RemoveMmap", 1)
 			},
 		},
 		{
@@ -298,8 +301,13 @@ func TestFsProcessor(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			hsnap := tt.hsnap()
 			psnap := new(ps.SnapshotterMock)
-			psnap.On("AddFileMapping", mock.Anything).Return(nil)
-			psnap.On("RemoveFileMapping", mock.Anything, mock.Anything).Return(nil)
+			psnap.On("AddMmap", mock.Anything).Return(nil)
+			psnap.On("RemoveMmap", mock.Anything, mock.Anything).Return(nil)
+			psnap.On("Find", mock.Anything).Return(true, &pstypes.PS{
+				Mmaps: []pstypes.Mmap{
+					{File: "C:\\Windows\\System32\\kernel32.dll", BaseAddress: va.Address(0xffff23433), Size: 3098},
+				},
+			})
 			p := newFsProcessor(hsnap, psnap, fs.NewDevMapper(), fs.NewDevPathResolver(), &config.Config{})
 			if tt.setupProcessor != nil {
 				tt.setupProcessor(p)

--- a/internal/etw/source_test.go
+++ b/internal/etw/source_test.go
@@ -814,22 +814,22 @@ type NoopPsSnapshotter struct{}
 
 var fakeProc = &pstypes.PS{PID: 111111, Name: "fake.exe"}
 
-func (s *NoopPsSnapshotter) Write(kevt *kevent.Kevent) error                        { return nil }
-func (s *NoopPsSnapshotter) Remove(kevt *kevent.Kevent) error                       { return nil }
-func (s *NoopPsSnapshotter) Find(pid uint32) (bool, *pstypes.PS)                    { return true, fakeProc }
-func (s *NoopPsSnapshotter) FindAndPut(pid uint32) *pstypes.PS                      { return fakeProc }
-func (s *NoopPsSnapshotter) Put(ps *pstypes.PS)                                     {}
-func (s *NoopPsSnapshotter) Size() uint32                                           { return 1 }
-func (s *NoopPsSnapshotter) Close() error                                           { return nil }
-func (s *NoopPsSnapshotter) GetSnapshot() []*pstypes.PS                             { return nil }
-func (s *NoopPsSnapshotter) AddThread(kevt *kevent.Kevent) error                    { return nil }
-func (s *NoopPsSnapshotter) AddModule(kevt *kevent.Kevent) error                    { return nil }
-func (s *NoopPsSnapshotter) FindModule(addr va.Address) (bool, *pstypes.Module)     { return false, nil }
-func (s *NoopPsSnapshotter) RemoveThread(pid uint32, tid uint32) error              { return nil }
-func (s *NoopPsSnapshotter) RemoveModule(pid uint32, mod string) error              { return nil }
-func (s *NoopPsSnapshotter) WriteFromKcap(kevt *kevent.Kevent) error                { return nil }
-func (s *NoopPsSnapshotter) AddFileMapping(kevt *kevent.Kevent) error               { return nil }
-func (s *NoopPsSnapshotter) RemoveFileMapping(pid uint32, address va.Address) error { return nil }
+func (s *NoopPsSnapshotter) Write(kevt *kevent.Kevent) error                    { return nil }
+func (s *NoopPsSnapshotter) Remove(kevt *kevent.Kevent) error                   { return nil }
+func (s *NoopPsSnapshotter) Find(pid uint32) (bool, *pstypes.PS)                { return true, fakeProc }
+func (s *NoopPsSnapshotter) FindAndPut(pid uint32) *pstypes.PS                  { return fakeProc }
+func (s *NoopPsSnapshotter) Put(ps *pstypes.PS)                                 {}
+func (s *NoopPsSnapshotter) Size() uint32                                       { return 1 }
+func (s *NoopPsSnapshotter) Close() error                                       { return nil }
+func (s *NoopPsSnapshotter) GetSnapshot() []*pstypes.PS                         { return nil }
+func (s *NoopPsSnapshotter) AddThread(kevt *kevent.Kevent) error                { return nil }
+func (s *NoopPsSnapshotter) AddModule(kevt *kevent.Kevent) error                { return nil }
+func (s *NoopPsSnapshotter) FindModule(addr va.Address) (bool, *pstypes.Module) { return false, nil }
+func (s *NoopPsSnapshotter) RemoveThread(pid uint32, tid uint32) error          { return nil }
+func (s *NoopPsSnapshotter) RemoveModule(pid uint32, mod string) error          { return nil }
+func (s *NoopPsSnapshotter) WriteFromKcap(kevt *kevent.Kevent) error            { return nil }
+func (s *NoopPsSnapshotter) AddMmap(kevt *kevent.Kevent) error                  { return nil }
+func (s *NoopPsSnapshotter) RemoveMmap(pid uint32, address va.Address) error    { return nil }
 
 func TestCallstackEnrichment(t *testing.T) {
 	hsnap := new(handle.SnapshotterMock)

--- a/pkg/ps/snapshotter.go
+++ b/pkg/ps/snapshotter.go
@@ -40,10 +40,10 @@ type Snapshotter interface {
 	RemoveThread(pid uint32, tid uint32) error
 	// RemoveModule removes the module the given process.
 	RemoveModule(pid uint32, mod string) error
-	// AddFileMapping adds a new data memory-mapped file to this process state.
-	AddFileMapping(*kevent.Kevent) error
-	// RemoveFileMapping removes memory-mapped file at the given base address.
-	RemoveFileMapping(pid uint32, address va.Address) error
+	// AddMmap adds a new memory mapping (data memory-mapped file, image, or pagefile) to this process state.
+	AddMmap(*kevent.Kevent) error
+	// RemoveMmap removes memory mapping at the given base address.
+	RemoveMmap(pid uint32, address va.Address) error
 	// WriteFromKcap appends a new process state to the snapshotter from the captured kernel event.
 	WriteFromKcap(kevt *kevent.Kevent) error
 	// Remove deletes process's state from the snapshotter.

--- a/pkg/ps/snapshotter_mock.go
+++ b/pkg/ps/snapshotter_mock.go
@@ -106,13 +106,13 @@ func (s *SnapshotterMock) RemoveModule(pid uint32, mod string) error {
 func (s *SnapshotterMock) WriteFromKcap(kevt *kevent.Kevent) error { return nil }
 
 // AddFileMapping method
-func (s *SnapshotterMock) AddFileMapping(kevt *kevent.Kevent) error {
+func (s *SnapshotterMock) AddMmap(kevt *kevent.Kevent) error {
 	args := s.Called(kevt)
 	return args.Error(0)
 }
 
 // RemoveFileMapping method
-func (s *SnapshotterMock) RemoveFileMapping(pid uint32, address va.Address) error {
+func (s *SnapshotterMock) RemoveMmap(pid uint32, address va.Address) error {
 	args := s.Called(pid, address)
 	return args.Error(0)
 }

--- a/pkg/ps/snapshotter_windows.go
+++ b/pkg/ps/snapshotter_windows.go
@@ -25,7 +25,6 @@ import (
 	"golang.org/x/sys/windows"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -266,7 +265,7 @@ func (s *snapshotter) FindModule(addr va.Address) (bool, *pstypes.Module) {
 	return false, nil
 }
 
-func (s *snapshotter) AddFileMapping(e *kevent.Kevent) error {
+func (s *snapshotter) AddMmap(e *kevent.Kevent) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	proc, ok := s.procs[e.PID]
@@ -275,23 +274,21 @@ func (s *snapshotter) AddFileMapping(e *kevent.Kevent) error {
 	}
 
 	filename := e.GetParamAsString(kparams.FileName)
-	ext := strings.ToLower(filepath.Ext(filename))
-	// skip redundant or unneeded memory-mapped files
-	if ext == ".dll" || ext == ".exe" || ext == ".mui" {
-		return nil
-	}
+
 	mmapCount.Add(1)
 	mmap := pstypes.Mmap{}
 	mmap.File = filename
 	mmap.BaseAddress = e.Kparams.TryGetAddress(kparams.FileViewBase)
 	mmap.Size, _ = e.Kparams.GetUint64(kparams.FileViewSize)
+	mmap.Protection, _ = e.Kparams.GetUint32(kparams.MemProtect)
+	mmap.Type = e.GetParamAsString(kparams.FileViewSectionType)
 
-	proc.MapFile(mmap)
+	proc.AddMmap(mmap)
 
 	return nil
 }
 
-func (s *snapshotter) RemoveFileMapping(pid uint32, addr va.Address) error {
+func (s *snapshotter) RemoveMmap(pid uint32, addr va.Address) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	proc, ok := s.procs[pid]
@@ -299,7 +296,7 @@ func (s *snapshotter) RemoveFileMapping(pid uint32, addr va.Address) error {
 		return nil
 	}
 	mmapCount.Add(-1)
-	proc.UnmapFile(addr)
+	proc.RemoveMmap(addr)
 	return nil
 }
 

--- a/pkg/symbolize/symbolizer.go
+++ b/pkg/symbolize/symbolizer.go
@@ -367,9 +367,6 @@ func (s *Symbolizer) produceFrame(addr va.Address, e *kevent.Kevent, fast, looku
 			if mod != nil {
 				frame.Module = mod.Name
 			}
-			if frame.Module == "unbacked" || frame.Module == "" {
-				frame.Module = e.PS.FindMappingByVa(addr)
-			}
 			if lookupExport {
 				frame.Symbol = s.resolveSymbolFromExportDirectory(addr, mod)
 			}
@@ -464,9 +461,6 @@ func (s *Symbolizer) produceFrame(addr va.Address, e *kevent.Kevent, fast, looku
 
 	if frame.Module == "" {
 		mod := s.r.GetModuleName(proc.handle, addr)
-		if mod == "?" && e.PS != nil {
-			mod = e.PS.FindMappingByVa(addr)
-		}
 		frame.Module = mod
 		if frame.Module == "?" {
 			frame.Module = "unbacked"


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

The process state is refactored to store all
the memory mappings created by the process.
This effectively eliminates the need to keep the
memory mappings in the fs processor hence improving code quality, readability, and performance.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

/kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

/area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
