### PR TITLE
perf(filter): Speed up expression String methods

### DIFF
--- a/pkg/filter/ql/expr.go
+++ b/pkg/filter/ql/expr.go
@@ -18,7 +18,9 @@
 
 package ql
 
-import "fmt"
+import (
+	"strings"
+)
 
 // Node represents a node in the abstract syntax tree.
 type Node interface {
@@ -36,7 +38,14 @@ type ParenExpr struct {
 }
 
 // String returns a string representation of the parenthesized expression.
-func (e *ParenExpr) String() string { return fmt.Sprintf("(%s)", e.Expr.String()) }
+func (e *ParenExpr) String() string {
+	var b strings.Builder
+	b.Grow(len(e.Expr.String()) + 2)
+	b.WriteRune('(')
+	b.WriteString(e.Expr.String())
+	b.WriteRune(')')
+	return b.String()
+}
 
 // BinaryExpr represents an operation between two expressions.
 type BinaryExpr struct {
@@ -47,7 +56,21 @@ type BinaryExpr struct {
 
 // String returns a string representation of the binary expression.
 func (e *BinaryExpr) String() string {
-	return fmt.Sprintf("%s %s %s", e.LHS.String(), e.Op.String(), e.RHS.String())
+	var b strings.Builder
+
+	lhs := e.LHS.String()
+	op := e.Op.String()
+	rhs := e.RHS.String()
+
+	b.Grow(len(lhs) + len(op) + len(rhs) + 2)
+
+	b.WriteString(lhs)
+	b.WriteString(" ")
+	b.WriteString(op)
+	b.WriteString(" ")
+	b.WriteString(rhs)
+
+	return b.String()
 }
 
 // NotExpr represents an unary not expression.
@@ -56,4 +79,11 @@ type NotExpr struct {
 }
 
 // String returns a string representation of the not expression.
-func (e *NotExpr) String() string { return fmt.Sprintf("(%s)", e.Expr.String()) }
+func (e *NotExpr) String() string {
+	var b strings.Builder
+	b.Grow(len(e.Expr.String()) + 2)
+	b.WriteRune('(')
+	b.WriteString(e.Expr.String())
+	b.WriteRune(')')
+	return b.String()
+}

--- a/pkg/filter/ql/literal.go
+++ b/pkg/filter/ql/literal.go
@@ -19,8 +19,6 @@
 package ql
 
 import (
-	"bytes"
-	"fmt"
 	"github.com/rabbitstack/fibratus/pkg/filter/fields"
 	"github.com/rabbitstack/fibratus/pkg/kevent"
 	"github.com/rabbitstack/fibratus/pkg/kevent/ktypes"
@@ -129,16 +127,25 @@ type ListLiteral struct {
 
 // String returns a string representation of the literal.
 func (s *ListLiteral) String() string {
-	var buf bytes.Buffer
-	_, _ = buf.WriteString("(")
-	for idx, tagKey := range s.Values {
-		if idx != 0 {
-			_, _ = buf.WriteString(", ")
-		}
-		_, _ = buf.WriteString(tagKey)
+	var n int
+	for _, elem := range s.Values {
+		n += len(elem) + 2
 	}
-	_, _ = buf.WriteString(")")
-	return buf.String()
+
+	var b strings.Builder
+	b.Grow(n + 2)
+	b.WriteRune('(')
+
+	for idx, elem := range s.Values {
+		if idx != 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(elem)
+	}
+
+	b.WriteRune(')')
+
+	return b.String()
 }
 
 // Function represents a function call.
@@ -158,14 +165,18 @@ func (f *Function) ArgsSlice() []string {
 
 // String returns a string representation of the call.
 func (f *Function) String() string {
-	// join arguments.
-	var str []string
-	for _, arg := range f.Args {
-		str = append(str, arg.String())
-	}
+	args := strings.Join(f.ArgsSlice(), ", ")
+
+	var b strings.Builder
+	b.Grow(len(args) + len(f.Name) + 2)
+
+	b.WriteString(f.Name)
+	b.WriteRune('(')
+	b.WriteString(args)
+	b.WriteRune(')')
 
 	// Write function name and args.
-	return fmt.Sprintf("%s(%s)", f.Name, strings.Join(str, ", "))
+	return b.String()
 }
 
 // validate ensures that the function name obtained


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

`fmt.Sprintf` exhibits poor performance, especially when used in hot paths. To overcome this deficiency, we use the StringBuilder for a more efficient string concatenation.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

/area rule-engine

/area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
