### PR TITLE
fix(rules): Use iin operator in LSASS memory dump via Windows Error Reporting rule

### DIFF
--- a/rules/credential_access_lsass_memory_dump_via_wer.yml
+++ b/rules/credential_access_lsass_memory_dump_via_wer.yml
@@ -1,6 +1,6 @@
 name: LSASS memory dump via Windows Error Reporting
 id: 7b4a74e2-c7a7-4c1f-b2ce-0e0273c3add7
-version: 1.0.1
+version: 1.0.2
 description: |
   Adversaries may abuse Windows Error Reporting service to dump LSASS memory.
   The ALPC protocol can send a message to report an exception on LSASS and
@@ -21,7 +21,7 @@ references:
 condition: >
   sequence
   maxspan 2m
-    |spawn_process and ps.child.name in ('WerFault.exe', 'WerFaultSecure.exe')| by ps.child.uuid
-    |write_minidump_file and file.path icontains 'lsass'| by ps.uuid
+    |spawn_process and ps.child.name iin ('WerFault.exe', 'WerFaultSecure.exe')| by ps.child.uuid
+    |create_file and file.path icontains 'lsass'| by ps.uuid
 
 min-engine-version: 2.4.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

On some occasions, the process name is reported in lowercase, preventing the rule matching. In the
Similarly, to improve resilience, the `create_file `macro is used in the second condition to match when the `WER` process creates the memory dump.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
