### PR TITLE
fix(rules): Improve rules efficacy against false positives

### DIFF
--- a/rules/defense_evasion_appdomain_manager_injection_via_clr_search_order_hijacking.yml
+++ b/rules/defense_evasion_appdomain_manager_injection_via_clr_search_order_hijacking.yml
@@ -1,6 +1,6 @@
 name: AppDomain Manager injection via CLR search order hijacking
 id: 9319fafd-b7dc-4d85-b41a-54a8d4f1ab18
-version: 1.0.1
+version: 1.0.2
 description: |
   Adversaries may execute their own malicious payloads by hijacking how the .NET AppDomainManager loads assemblies. 
   The .NET framework uses the AppDomainManager class to create and manage one or more isolated runtime environments 
@@ -25,7 +25,7 @@ references:
   - https://www.rapid7.com/blog/post/2023/05/05/appdomain-manager-injection-new-techniques-for-red-teams/
 
 condition: >
-  (load_unsigned_or_untrusted_module) and ((base(dir(image.path)) ~= base(image.path, false)) or (ps.envs[APPDOMAIN_MANAGER_ASM] istartswith image.name))
+  (load_unsigned_or_untrusted_module) and ps.exe != '' and ((base(dir(image.path)) ~= base(image.path, false)) or (ps.envs[APPDOMAIN_MANAGER_ASM] istartswith image.name))
     and
   pe.is_dotnet and (image.is_dotnet or thread.callstack.symbols imatches ('clr.dll!ParseManifest*'))
 

--- a/rules/defense_evasion_dotnet_assembly_loaded_by_unmanaged_process.yml
+++ b/rules/defense_evasion_dotnet_assembly_loaded_by_unmanaged_process.yml
@@ -1,6 +1,6 @@
 name: .NET assembly loaded by unmanaged process
 id: 34be8bd1-1143-4fa8-bed4-ae2566b1394a
-version: 1.0.2
+version: 1.0.3
 description: |
   Identifies the loading of the .NET assembly by an unmanaged process. Adversaries can load the CLR runtime
   inside unmanaged process and execute the assembly via the ICLRRuntimeHost::ExecuteInDefaultAppDomain method.
@@ -16,7 +16,7 @@ references:
   - https://www.ired.team/offensive-security/code-injection-process-injection/injecting-and-executing-.net-assemblies-to-unmanaged-process
 
 condition: >
-  (load_unsigned_or_untrusted_module) and pe.is_dotnet = false
+  (load_unsigned_or_untrusted_module) and ps.exe != '' and pe.is_dotnet = false
     and
   (image.is_dotnet or thread.callstack.modules imatches ('*clr.dll'))
     and

--- a/rules/defense_evasion_hidden_registry_key_creation.yml
+++ b/rules/defense_evasion_hidden_registry_key_creation.yml
@@ -1,6 +1,6 @@
 name: Hidden registry key creation
 id: 65deda38-9b1d-42a0-9f40-a68903e81b49
-version: 1.1.1
+version: 1.1.2
 description: |
   Identifies the creation of a hidden registry key. Adversaries can utilize the
   native NtSetValueKey API to create a hidden registry key and conceal payloads
@@ -29,7 +29,8 @@ condition: >
       '?:\\Program Files\\Microsoft\\EdgeUpdate\\MicrosoftEdgeUpdate.exe',
       '?:\\Windows\\System32\\sppsvc.exe',
       '?:\\Windows\\System32\\compattelrunner.exe',
-      '?:\\Windows\\explorer.exe'
+      '?:\\Windows\\explorer.exe',
+      '?:\\Windows\\System32\\lsass.exe'
     )
 
 output: >

--- a/rules/defense_evasion_potential_injection_via_dotnet_debugging.yml
+++ b/rules/defense_evasion_potential_injection_via_dotnet_debugging.yml
@@ -1,6 +1,6 @@
 name: Potential injection via .NET debugging
 id: 193ebf2f-e365-4f57-a639-275b7cdf0319
-version: 1.0.0
+version: 1.0.1
 description: |
   Identifies creation of a process on behalf of the CLR debugging facility which may
   be indicative of code injection. The CLR interface utilizes the OpenVirtualProcess
@@ -17,7 +17,7 @@ references:
   - https://learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/iclrdebugging-openvirtualprocess-method
 
 condition: >
-  spawn_process and thread.callstack.symbols imatches ('mscordbi.dll!OpenVirtualProcess')
+  spawn_process and ps.exe != '' and thread.callstack.symbols imatches ('mscordbi.dll!OpenVirtualProcess')
     and
     not
   ps.child.exe imatches


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

To improve rules efficacy against false positives, we ensure the process has a valid state by checking the process executable path.
In `Hidden registry key creation` rule, add the exception for the `lsass.exe` process.


### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
