### PR TITLE
fix(callstack): Fix private allocation size

### DIFF
--- a/pkg/sys/mem.go
+++ b/pkg/sys/mem.go
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021-2022 by Nedim Sabic Sabic
+ * https://www.fibratus.io
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sys
+
+// MemoryWorkingSetExInformation describes the attributes of the memory region.
+type MemoryWorkingSetExInformation struct {
+	VirtualAddress    uintptr
+	VirtualAttributes MemoryWorkingSetExBlock
+}
+
+type MemoryWorkingSetExBlock uintptr
+
+// Valid if this bit is 1, the subsequent members are valid. Otherwise, they should be ignored.
+func (b MemoryWorkingSetExBlock) Valid() bool {
+	return b&1 != 0
+}
+
+// ShareCount specifies the number of processes that share this page. The maximum value of this member is 7.
+func (b MemoryWorkingSetExBlock) ShareCount() uintptr {
+	return (uintptr(b) >> 1) & ((1 << 3) - 1)
+}
+
+// Win32Protection specifies the memory protection attributes of the page.
+func (b MemoryWorkingSetExBlock) Win32Protection() uintptr {
+	return (uintptr(b) >> 4) & ((1 << 11) - 1)
+}
+
+// Shared evaluates to true if the page can be shared or false otherwise.
+func (b MemoryWorkingSetExBlock) Shared() bool {
+	return b&(1<<15) != 0
+}
+
+// Node represents the NUMA node. The maximum value of this member is 63.
+func (b MemoryWorkingSetExBlock) Node() uintptr {
+	return (uintptr(b) >> 16) & ((1 << 6) - 1)
+}
+
+// Locked returns true if the virtual page is locked in physical memory.
+func (b MemoryWorkingSetExBlock) Locked() bool {
+	return b&(1<<15) != 0
+}
+
+// LargePage returns true if the page is a large page.
+func (b MemoryWorkingSetExBlock) LargePage() bool {
+	return b&(1<<16) != 0
+}
+
+// SharedOriginal evaluates to true if the page can be shared or false otherwise.
+func (b MemoryWorkingSetExBlock) SharedOriginal() bool {
+	return b&(1<<30) != 0
+}
+
+// Bad indicates the page has been reported as bad.
+func (b MemoryWorkingSetExBlock) Bad() bool {
+	return b&(1<<31) != 0
+}

--- a/pkg/sys/syscall.go
+++ b/pkg/sys/syscall.go
@@ -82,3 +82,6 @@ package sys
 //sys ShellNotifyIcon(msg NotifyIconMessage, data *NotifyIconData) (err error) [failretval==0]  = shell32.Shell_NotifyIconW
 //sys SHGetStockIconInfo(id int32, flags uint32, icon *ShStockIcon) (err error) [failretval!=0] = shell32.SHGetStockIconInfo
 //sys FreeConsole() = kernel32.FreeConsole
+
+// Memory functions
+//sys QueryWorkingSet(handle windows.Handle, ws *MemoryWorkingSetExInformation, size uint32) (err error) = psapi.QueryWorkingSetEx

--- a/pkg/sys/zsyscall_windows.go
+++ b/pkg/sys/zsyscall_windows.go
@@ -73,6 +73,7 @@ var (
 	procEnumDeviceDrivers                    = modpsapi.NewProc("EnumDeviceDrivers")
 	procGetDeviceDriverFileNameW             = modpsapi.NewProc("GetDeviceDriverFileNameW")
 	procGetMappedFileNameW                   = modpsapi.NewProc("GetMappedFileNameW")
+	procQueryWorkingSetEx                    = modpsapi.NewProc("QueryWorkingSetEx")
 	procSHGetStockIconInfo                   = modshell32.NewProc("SHGetStockIconInfo")
 	procShell_NotifyIconW                    = modshell32.NewProc("Shell_NotifyIconW")
 	procPathIsDirectoryW                     = modshlwapi.NewProc("PathIsDirectoryW")
@@ -262,6 +263,14 @@ func GetDeviceDriverFileName(imageBase uintptr, filename *uint16, size uint32) (
 func GetMappedFileName(handle windows.Handle, addr uintptr, filename *uint16, size uint32) (n uint32) {
 	r0, _, _ := syscall.Syscall6(procGetMappedFileNameW.Addr(), 4, uintptr(handle), uintptr(addr), uintptr(unsafe.Pointer(filename)), uintptr(size), 0, 0)
 	n = uint32(r0)
+	return
+}
+
+func QueryWorkingSet(handle windows.Handle, ws *MemoryWorkingSetExInformation, size uint32) (err error) {
+	r1, _, e1 := syscall.Syscall(procQueryWorkingSetEx.Addr(), 3, uintptr(handle), uintptr(unsafe.Pointer(ws)), uintptr(size))
+	if r1 == 0 {
+		err = errnoErr(e1)
+	}
 	return
 }
 

--- a/pkg/util/va/region_test.go
+++ b/pkg/util/va/region_test.go
@@ -125,6 +125,19 @@ func TestReadArea(t *testing.T) {
 	require.True(t, Zeroed(zeroArea))
 }
 
+func TestQueryWorkingSet(t *testing.T) {
+	addr, err := getModuleBaseAddress(uint32(os.Getpid()))
+	require.NoError(t, err)
+
+	b := QueryWorkingSet(windows.CurrentProcess(), uint64(addr))
+	require.NotNil(t, b)
+
+	require.True(t, b.Valid())
+	require.False(t, b.Bad())
+	require.True(t, b.SharedOriginal())
+	require.True(t, (b.Win32Protection()&windows.PAGE_READONLY) != 0)
+}
+
 func getModuleBaseAddress(pid uint32) (uintptr, error) {
 	var moduleHandles [1024]windows.Handle
 	var cbNeeded uint32


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Attackers exploit the memory of the benign module (dll) to inject their own shellcode. When the memory of the DLL is tampered, the backing memory pages release the shared attribute and become private pages. If the callstack contains such memory regions, it is a strong indicator of module stomping.
To accomplish the detection of stomped modules, we use the `QueryWorkingSet` API to examine the pages starting from the stack return address. If the `Shared` or `SharedOriginal` bits are not set, we increment the private allocation size by OS page size.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

/area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
