### PR TITLE
fix(filter): Call stack frame bound checks

### DIFF
--- a/pkg/filter/accessor_windows.go
+++ b/pkg/filter/accessor_windows.go
@@ -667,10 +667,12 @@ func callstackFields(field string, kevt *kevent.Kevent) (kparams.Value, error) {
 	if kevt.Callstack.IsEmpty() {
 		return nil, nil
 	}
+
 	key, segment := captureInBrackets(field)
 	if key == "" || segment == "" {
 		return nil, nil
 	}
+
 	var i int
 	switch key {
 	case frameUStart:
@@ -702,9 +704,13 @@ func callstackFields(field string, kevt *kevent.Kevent) (kparams.Value, error) {
 		}
 	}
 
-	if i > kevt.Callstack.Depth() || i < 0 {
+	if i >= kevt.Callstack.Depth() {
+		i = kevt.Callstack.Depth() - 1
+	}
+	if i < 0 {
 		i = 0
 	}
+
 	f := kevt.Callstack[i]
 
 	switch segment {

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -368,7 +368,7 @@ func TestThreadFilter(t *testing.T) {
 		{`thread.callstack[uend].address = '7ffb5c1d0396'`, true},
 		{`thread.callstack[kstart].address = 'fffff8072ebc1f6f'`, true},
 		{`thread.callstack[kend].address = 'fffff8072eb8961b'`, true},
-		{`thread.callstack[112222].address = '2638e59e0a5'`, true},
+		{`thread.callstack[112222].address = 'fffff8072eb8961b'`, true},
 		{`thread.callstack[2].symbol = 'Java_java_lang_ProcessImpl_create'`, true},
 		{`thread.callstack[2].offset = 266`, true},
 		{`thread.callstack[2].module = 'C:\\Program Files\\JetBrains\\GoLand 2021.2.3\\jbr\\bin\\java.dll'`, true},


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Add more defensive checks against frame bounds
to prevent accessing the frame that is out of
bounds of the callstack.


### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

/area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
