### PR TITLE
fix(build, ci): Bring Python in CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,17 +12,22 @@ on:
 env:
   GO_VERSION: 1.23.x
   WIX_VERSION: 5.0.0
+  PYTHON_VERSION: 3.7.9
 
 jobs:
   build:
       runs-on: windows-latest
       steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-           go-version: ${{ env.GO_VERSION }}
-      - name: Checkout
-        uses: actions/checkout@v4
+          go-version: ${{ env.GO_VERSION }}
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Adjust pkg-config prefix
         shell: bash
         run: |
@@ -101,12 +106,12 @@ jobs:
   build-slim:
       runs-on: windows-latest
       steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-           go-version: ${{ env.GO_VERSION }}
-      - name: Checkout
-        uses: actions/checkout@v4
+          go-version: ${{ env.GO_VERSION }}
       - name: Build
         shell: bash
         run: |
@@ -126,14 +131,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Adjust pkg-config prefix
         shell: bash
         run: |
            sed -i 's/C:\/Python37/C:\/hostedtoolcache\/windows\/Python\/3.7.9\/x64/' pkg-config/python-37.pc
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-           go-version: ${{ env.GO_VERSION }}
       - name: Setup msys2
         uses: msys2/setup-msys2@v2
         with:
@@ -176,14 +185,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Adjust pkg-config prefix
         shell: bash
         run: |
            sed -i 's/C:\/Python37/C:\/hostedtoolcache\/windows\/Python\/3.7.9\/x64/' pkg-config/python-37.pc
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-           go-version: ${{ env.GO_VERSION }}
       - name: Setup msys2
         uses: msys2/setup-msys2@v2
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,7 @@ on:
 env:
   GO_VERSION: 1.23.x
   WIX_VERSION: 5.0.0
+  PYTHON_VERSION: 3.7.9
 
 jobs:
   build:
@@ -19,12 +20,16 @@ jobs:
         uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-           go-version: ${{ env.GO_VERSION }}
-      - name: Checkout
-        uses: actions/checkout@v4
+          go-version: ${{ env.GO_VERSION }}
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Adjust pkg-config prefix
         shell: bash
         run: |
@@ -108,14 +113,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Adjust pkg-config prefix
         shell: bash
         run: |
            sed -i 's/C:\/Python37/C:\/hostedtoolcache\/windows\/Python\/3.7.9\/x64/' pkg-config/python-37.pc
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-           go-version: ${{ env.GO_VERSION }}
       - name: Setup msys2
         uses: msys2/setup-msys2@v2
         with:
@@ -158,14 +167,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Adjust pkg-config prefix
         shell: bash
         run: |
            sed -i 's/C:\/Python37/C:\/hostedtoolcache\/windows\/Python\/3.7.9\/x64/' pkg-config/python-37.pc
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-           go-version: ${{ env.GO_VERSION }}
       - name: Setup msys2
         uses: msys2/setup-msys2@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,17 +8,22 @@ on:
 env:
   GO_VERSION: 1.23.x
   WIX_VERSION: 5.0.0
+  PYTHON_VERSION: 3.7.9
 
 jobs:
   build:
       runs-on: windows-latest
       steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-           go-version:  ${{ env.GO_VERSION }}
-      - name: Checkout
-        uses: actions/checkout@v4
+          go-version: ${{ env.GO_VERSION }}
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Adjust pkg-config prefix
         shell: bash
         run: |
@@ -115,12 +120,12 @@ jobs:
   build-slim:
       runs-on: windows-latest
       steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-           go-version:  ${{ env.GO_VERSION }}
-      - name: Checkout
-        uses: actions/checkout@v4
+          go-version: ${{ env.GO_VERSION }}
       - name: Get version
         id: get_version
         shell: bash

--- a/make.bat
+++ b/make.bat
@@ -54,6 +54,7 @@ if "%~1"=="mc" goto mc
 :build
 :: set PKG_CONFIG_PATH=pkg-config
 go build -ldflags %LDFLAGS% -tags %TAGS% -o .\cmd\fibratus\fibratus.exe .\cmd\fibratus
+if errorlevel 1 goto fail
 go build -ldflags %LDFLAGS% -o .\cmd\systray\fibratus-systray.exe .\cmd\systray
 if errorlevel 1 goto fail
 goto :EOF
@@ -79,6 +80,7 @@ goto :EOF
 :rsrc
 set RC_VER=%VERSION:.=,%
 windres --define RC_VER=%RC_VER% --define VER=%VERSION% -i cmd\fibratus\fibratus.rc -O coff -o cmd\fibratus\fibratus.syso
+if errorlevel 1 goto fail
 windres --define RC_VER=%RC_VER% --define VER=%VERSION% -i cmd\systray\fibratus-systray.rc -O coff -o cmd\systray\fibratus-systray.syso
 if errorlevel 1 goto fail
 goto :EOF


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Python 3.7 was removed from the Windows Server 2022 image, so we must set it up manually. Also, fail if the compilation doesn't succeed to make CI red.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

/area ci

/area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
