### PR TITLE
chore(function): `substr` function with optional argument

### DIFF
--- a/pkg/filter/ql/functions/substr.go
+++ b/pkg/filter/ql/functions/substr.go
@@ -22,7 +22,7 @@ package functions
 type Substr struct{}
 
 func (f Substr) Call(args []interface{}) (interface{}, bool) {
-	if len(args) < 3 {
+	if len(args) < 2 {
 		return false, false
 	}
 
@@ -40,17 +40,23 @@ func (f Substr) Call(args []interface{}) (interface{}, bool) {
 		return false, false
 	}
 
-	switch v := args[2].(type) {
-	case int:
-		end = v
-	case int64:
-		end = int(v)
-	default:
-		return false, false
-	}
+	if len(args) > 2 {
+		switch v := args[2].(type) {
+		case int:
+			end = v
+		case int64:
+			end = int(v)
+		default:
+			return false, false
+		}
 
-	if start >= 0 && (end >= start && end < len(s)) {
-		return s[start:end], true
+		if start >= 0 && (end >= start && end < len(s)) {
+			return s[start:end], true
+		}
+	} else {
+		if start >= 0 && start < len(s) {
+			return s[start:], true
+		}
 	}
 
 	return s, true
@@ -62,7 +68,7 @@ func (f Substr) Desc() FunctionDesc {
 		Args: []FunctionArgDesc{
 			{Keyword: "string", Types: []ArgType{Func, Field, BoundField, BoundSegment, BareBoundVariable}, Required: true},
 			{Keyword: "start", Types: []ArgType{Func, Number}, Required: true},
-			{Keyword: "end", Types: []ArgType{Func, Number}, Required: true},
+			{Keyword: "end", Types: []ArgType{Func, Number}},
 		},
 	}
 	return desc

--- a/pkg/filter/ql/functions/substr_test.go
+++ b/pkg/filter/ql/functions/substr_test.go
@@ -50,6 +50,14 @@ func TestSubstr(t *testing.T) {
 			[]interface{}{"Hello World!", 6, 7},
 			"W",
 		},
+		{
+			[]interface{}{"Hello World!", 6},
+			"World!",
+		},
+		{
+			[]interface{}{"Hello World!", 20},
+			"Hello World!",
+		},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Make the `substr` function optionally accept the third argument. If the third argument is not given, the string is sliced from the start index to its length.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

/area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---

Yes. Update the docs to reflect this change.