### PR TITLE
feat(filter): Add additional callstack fields

### DIFF
--- a/pkg/filter/fields/fields.go
+++ b/pkg/filter/fields/fields.go
@@ -21,6 +21,7 @@ package fields
 import (
 	"github.com/rabbitstack/fibratus/pkg/kevent/kparams"
 	"sort"
+	"unicode"
 )
 
 // FieldInfo is the field metadata descriptor.
@@ -31,6 +32,17 @@ type FieldInfo struct {
 	Examples    []string
 	Deprecation *Deprecation
 	Argument    *Argument
+}
+
+// isNumber is the field argument validation function that
+// returns true if all characters are digits.
+var isNumber = func(s string) bool {
+	for _, c := range s {
+		if !unicode.IsNumber(c) {
+			return false
+		}
+	}
+	return true
 }
 
 // Argument defines field argument information.

--- a/pkg/filter/fields/fields_windows.go
+++ b/pkg/filter/fields/fields_windows.go
@@ -216,6 +216,28 @@ const (
 	ThreadStartAddressSymbol Field = "thread.start_address.symbol"
 	// ThreadStartAddressModule represents the module corresponding to the thread start address
 	ThreadStartAddressModule Field = "thread.start_address.module"
+	// ThreadCallstackAddresses represents the all callstack return addresses
+	ThreadCallstackAddresses Field = "thread.callstack.addresses"
+	// ThreadCallstackFinalUserModuleName represents the final user space stack frame module name
+	ThreadCallstackFinalUserModuleName Field = "thread.callstack.final_user_module.name"
+	// ThreadCallstackFinalUserModulePath represents the final user space stack frame module path
+	ThreadCallstackFinalUserModulePath Field = "thread.callstack.final_user_module.path"
+	// ThreadCallstackFinalUserSymbolName represents the final user space stack frame symbol name
+	ThreadCallstackFinalUserSymbolName Field = "thread.callstack.final_user_symbol.name"
+	// ThreadCallstackFinalKernelModuleName represents the final kernel space stack frame module name
+	ThreadCallstackFinalKernelModuleName Field = "thread.callstack.final_kernel_module.name"
+	// ThreadCallstackFinalKernelModulePath represents the final kernel space stack frame module name
+	ThreadCallstackFinalKernelModulePath Field = "thread.callstack.final_kernel_module.path"
+	// ThreadCallstackFinalKernelSymbolName represents the final kernel space stack frame symbol name
+	ThreadCallstackFinalKernelSymbolName Field = "thread.callstack.final_kernel_symbol.name"
+	// ThreadCallstackFinalUserModuleSignatureIsSigned represents the signature status of the final user space stack frame module
+	ThreadCallstackFinalUserModuleSignatureIsSigned Field = "thread.callstack.final_user_module.signature.is_signed"
+	// ThreadCallstackFinalUserModuleSignatureIsTrusted represents the trust status of the final user space stack frame module signature
+	ThreadCallstackFinalUserModuleSignatureIsTrusted Field = "thread.callstack.final_user_module.signature.is_trusted"
+	// ThreadCallstackFinalUserModuleSignatureCertIssuer represents the final user space stack frame module certificate issuer
+	ThreadCallstackFinalUserModuleSignatureCertIssuer Field = "thread.callstack.final_user_module.signature.cert.issuer"
+	// ThreadCallstackFinalUserModuleSignatureCertSubject represents the final user space stack frame module certificate subject
+	ThreadCallstackFinalUserModuleSignatureCertSubject Field = "thread.callstack.final_user_module.signature.cert.subject"
 
 	// PeNumSections represents the number of sections
 	PeNumSections Field = "pe.nsections"
@@ -566,40 +588,49 @@ const (
 	IsUnbackedSegment               Segment = "is_unbacked"
 	CallsiteLeadingAssemblySegment  Segment = "callsite_leading_assembly"
 	CallsiteTrailingAssemblySegment Segment = "callsite_trailing_assembly"
+
+	ModuleSignatureIsSignedSegment    Segment = "module.signature.is_signed"
+	ModuleSignatureIsTrustedSegment   Segment = "module.signature.is_trusted"
+	ModuleSignatureCertIssuerSegment  Segment = "module.signature.cert.issuer"
+	ModuleSignatureCertSubjectSegment Segment = "module.signature.cert.subject"
 )
 
 var segments = map[Segment]bool{
-	NameSegment:                     true,
-	PathSegment:                     true,
-	TypeSegment:                     true,
-	EntropySegment:                  true,
-	SizeSegment:                     true,
-	MD5Segment:                      true,
-	AddressSegment:                  true,
-	ChecksumSegment:                 true,
-	PIDSegment:                      true,
-	CmdlineSegment:                  true,
-	ExeSegment:                      true,
-	ArgsSegment:                     true,
-	CwdSegment:                      true,
-	SIDSegment:                      true,
-	SessionIDSegment:                true,
-	UsernameSegment:                 true,
-	DomainSegment:                   true,
-	TidSegment:                      true,
-	StartAddressSegment:             true,
-	UserStackBaseSegment:            true,
-	UserStackLimitSegment:           true,
-	KernelStackBaseSegment:          true,
-	KernelStackLimitSegment:         true,
-	OffsetSegment:                   true,
-	SymbolSegment:                   true,
-	ModuleSegment:                   true,
-	AllocationSizeSegment:           true,
-	ProtectionSegment:               true,
-	IsUnbackedSegment:               true,
-	CallsiteLeadingAssemblySegment:  true,
-	CallsiteTrailingAssemblySegment: true,
+	NameSegment:                       true,
+	PathSegment:                       true,
+	TypeSegment:                       true,
+	EntropySegment:                    true,
+	SizeSegment:                       true,
+	MD5Segment:                        true,
+	AddressSegment:                    true,
+	ChecksumSegment:                   true,
+	PIDSegment:                        true,
+	CmdlineSegment:                    true,
+	ExeSegment:                        true,
+	ArgsSegment:                       true,
+	CwdSegment:                        true,
+	SIDSegment:                        true,
+	SessionIDSegment:                  true,
+	UsernameSegment:                   true,
+	DomainSegment:                     true,
+	TidSegment:                        true,
+	StartAddressSegment:               true,
+	UserStackBaseSegment:              true,
+	UserStackLimitSegment:             true,
+	KernelStackBaseSegment:            true,
+	KernelStackLimitSegment:           true,
+	OffsetSegment:                     true,
+	SymbolSegment:                     true,
+	ModuleSegment:                     true,
+	AllocationSizeSegment:             true,
+	ProtectionSegment:                 true,
+	IsUnbackedSegment:                 true,
+	CallsiteLeadingAssemblySegment:    true,
+	CallsiteTrailingAssemblySegment:   true,
+	ModuleSignatureIsSignedSegment:    true,
+	ModuleSignatureIsTrustedSegment:   true,
+	ModuleSignatureCertIssuerSegment:  true,
+	ModuleSignatureCertSubjectSegment: true,
 }
 
 var allowedSegments = map[Field][]Segment{
@@ -608,7 +639,7 @@ var allowedSegments = map[Field][]Segment{
 	PsModules:       {PathSegment, NameSegment, AddressSegment, SizeSegment, ChecksumSegment},
 	PsMmaps:         {AddressSegment, TypeSegment, AddressSegment, SizeSegment, ProtectionSegment, PathSegment},
 	PeSections:      {NameSegment, SizeSegment, EntropySegment, MD5Segment},
-	ThreadCallstack: {AddressSegment, OffsetSegment, SymbolSegment, ModuleSegment, AllocationSizeSegment, ProtectionSegment, IsUnbackedSegment, CallsiteLeadingAssemblySegment, CallsiteTrailingAssemblySegment},
+	ThreadCallstack: {AddressSegment, OffsetSegment, SymbolSegment, ModuleSegment, AllocationSizeSegment, ProtectionSegment, IsUnbackedSegment, CallsiteLeadingAssemblySegment, CallsiteTrailingAssemblySegment, ModuleSignatureIsSignedSegment, ModuleSignatureIsTrustedSegment, ModuleSignatureCertIssuerSegment, ModuleSignatureCertSubjectSegment},
 }
 
 func (s Segment) IsEntropy() bool { return s == EntropySegment }
@@ -769,40 +800,44 @@ var fields = map[Field]FieldInfo{
 	PsParentIsWOW64Field:     {PsParentIsWOW64Field, "indicates if the parent process generating the event is a 32-bit process created in 64-bit Windows system", kparams.Bool, []string{"ps.parent.is_wow64"}, nil, nil},
 	PsParentIsPackagedField:  {PsParentIsPackagedField, "indicates if the parent process generating the event is packaged with the MSIX technology", kparams.Bool, []string{"ps.parent.is_packaged"}, nil, nil},
 	PsParentIsProtectedField: {PsParentIsProtectedField, "indicates if the the parent process generating the event is a protected process", kparams.Bool, []string{"ps.parent.is_protected"}, nil, nil},
-	PsAncestor: {PsAncestor, "the process ancestor name", kparams.UnicodeString, []string{"ps.ancestor[1] = 'svchost.exe'", "ps.ancestor in ('winword.exe')"}, nil, &Argument{Optional: true, Pattern: "[0-9]+", ValidationFunc: func(s string) bool {
-		for _, c := range s {
-			if !unicode.IsNumber(c) {
-				return false
-			}
-		}
-		return true
-	}}},
+	PsAncestor:               {PsAncestor, "the process ancestor name", kparams.UnicodeString, []string{"ps.ancestor[1] = 'svchost.exe'", "ps.ancestor in ('winword.exe')"}, nil, &Argument{Optional: true, Pattern: "[0-9]+", ValidationFunc: isNumber}},
 
-	ThreadBasePrio:                          {ThreadBasePrio, "scheduler priority of the thread", kparams.Int8, []string{"thread.prio = 5"}, nil, nil},
-	ThreadIOPrio:                            {ThreadIOPrio, "I/O priority hint for scheduling I/O operations", kparams.Int8, []string{"thread.io.prio = 4"}, nil, nil},
-	ThreadPagePrio:                          {ThreadPagePrio, "memory page priority hint for memory pages accessed by the thread", kparams.Int8, []string{"thread.page.prio = 12"}, nil, nil},
-	ThreadKstackBase:                        {ThreadKstackBase, "base address of the thread's kernel space stack", kparams.Address, []string{"thread.kstack.base = 'a65d800000'"}, nil, nil},
-	ThreadKstackLimit:                       {ThreadKstackLimit, "limit of the thread's kernel space stack", kparams.Address, []string{"thread.kstack.limit = 'a85d800000'"}, nil, nil},
-	ThreadUstackBase:                        {ThreadUstackBase, "base address of the thread's user space stack", kparams.Address, []string{"thread.ustack.base = '7ffe0000'"}, nil, nil},
-	ThreadUstackLimit:                       {ThreadUstackLimit, "limit of the thread's user space stack", kparams.Address, []string{"thread.ustack.limit = '8ffe0000'"}, nil, nil},
-	ThreadEntrypoint:                        {ThreadEntrypoint, "starting address of the function to be executed by the thread", kparams.Address, []string{"thread.entrypoint = '7efe0000'"}, &Deprecation{Since: "2.3.0", Fields: []Field{ThreadStartAddress}}, nil},
-	ThreadStartAddress:                      {ThreadStartAddress, "thread start address", kparams.Address, []string{"thread.start_address = '7efe0000'"}, nil, nil},
-	ThreadPID:                               {ThreadPID, "the process identifier where the thread is created", kparams.Uint32, []string{"kevt.pid != thread.pid"}, nil, nil},
-	ThreadTEB:                               {ThreadTEB, "the base address of the thread environment block", kparams.Address, []string{"thread.teb_address = '8f30893000'"}, nil, nil},
-	ThreadAccessMask:                        {ThreadAccessMask, "thread desired access rights", kparams.AnsiString, []string{"thread.access.mask = '0x1fffff'"}, nil, nil},
-	ThreadAccessMaskNames:                   {ThreadAccessMaskNames, "thread desired access rights as a string list", kparams.Slice, []string{"thread.access.mask.names in ('IMPERSONATE')"}, nil, nil},
-	ThreadAccessStatus:                      {ThreadAccessStatus, "thread access status", kparams.UnicodeString, []string{"thread.access.status = 'success'"}, nil, nil},
-	ThreadCallstackSummary:                  {ThreadCallstackSummary, "callstack summary", kparams.UnicodeString, []string{"thread.callstack.summary contains 'ntdll.dll|KERNELBASE.dll'"}, nil, nil},
-	ThreadCallstackDetail:                   {ThreadCallstackDetail, "detailed information of each stack frame", kparams.UnicodeString, []string{"thread.callstack.detail contains 'KERNELBASE.dll!CreateProcessW'"}, nil, nil},
-	ThreadCallstackModules:                  {ThreadCallstackModules, "list of modules comprising the callstack", kparams.Slice, []string{"thread.callstack.modules in ('C:\\WINDOWS\\System32\\KERNELBASE.dll')"}, nil, nil},
-	ThreadCallstackSymbols:                  {ThreadCallstackSymbols, "list of symbols comprising the callstack", kparams.Slice, []string{"thread.callstack.symbols in ('ntdll.dll!NtCreateProcess')"}, nil, nil},
-	ThreadCallstackAllocationSizes:          {ThreadCallstackAllocationSizes, "allocation sizes of private pages", kparams.Slice, []string{"thread.callstack.allocation_sizes > 10000"}, nil, nil},
-	ThreadCallstackProtections:              {ThreadCallstackProtections, "page protections masks of each frame", kparams.Slice, []string{"thread.callstack.protections in ('RWX', 'WX')"}, nil, nil},
-	ThreadCallstackCallsiteLeadingAssembly:  {ThreadCallstackCallsiteLeadingAssembly, "callsite leading assembly instructions", kparams.Slice, []string{"thread.callstack.callsite_leading_assembly in ('mov r10,rcx', 'syscall')"}, nil, nil},
-	ThreadCallstackCallsiteTrailingAssembly: {ThreadCallstackCallsiteTrailingAssembly, "callsite trailing assembly instructions", kparams.Slice, []string{"thread.callstack.callsite_trailing_assembly in ('add esp, 0xab')"}, nil, nil},
-	ThreadCallstackIsUnbacked:               {ThreadCallstackIsUnbacked, "indicates if the callstack contains unbacked regions", kparams.Bool, []string{"thread.callstack.is_unbacked"}, nil, nil},
-	ThreadStartAddressSymbol:                {ThreadStartAddressSymbol, "thread start address symbol", kparams.UnicodeString, []string{"thread.start_address.symbol = 'LoadImage'"}, nil, nil},
-	ThreadStartAddressModule:                {ThreadStartAddressModule, "thread start address module", kparams.UnicodeString, []string{"thread.start_address.module endswith 'kernel32.dll'"}, nil, nil},
+	ThreadBasePrio:                                     {ThreadBasePrio, "scheduler priority of the thread", kparams.Int8, []string{"thread.prio = 5"}, nil, nil},
+	ThreadIOPrio:                                       {ThreadIOPrio, "I/O priority hint for scheduling I/O operations", kparams.Int8, []string{"thread.io.prio = 4"}, nil, nil},
+	ThreadPagePrio:                                     {ThreadPagePrio, "memory page priority hint for memory pages accessed by the thread", kparams.Int8, []string{"thread.page.prio = 12"}, nil, nil},
+	ThreadKstackBase:                                   {ThreadKstackBase, "base address of the thread's kernel space stack", kparams.Address, []string{"thread.kstack.base = 'a65d800000'"}, nil, nil},
+	ThreadKstackLimit:                                  {ThreadKstackLimit, "limit of the thread's kernel space stack", kparams.Address, []string{"thread.kstack.limit = 'a85d800000'"}, nil, nil},
+	ThreadUstackBase:                                   {ThreadUstackBase, "base address of the thread's user space stack", kparams.Address, []string{"thread.ustack.base = '7ffe0000'"}, nil, nil},
+	ThreadUstackLimit:                                  {ThreadUstackLimit, "limit of the thread's user space stack", kparams.Address, []string{"thread.ustack.limit = '8ffe0000'"}, nil, nil},
+	ThreadEntrypoint:                                   {ThreadEntrypoint, "starting address of the function to be executed by the thread", kparams.Address, []string{"thread.entrypoint = '7efe0000'"}, &Deprecation{Since: "2.3.0", Fields: []Field{ThreadStartAddress}}, nil},
+	ThreadStartAddress:                                 {ThreadStartAddress, "thread start address", kparams.Address, []string{"thread.start_address = '7efe0000'"}, nil, nil},
+	ThreadStartAddressSymbol:                           {ThreadStartAddressSymbol, "thread start address symbol", kparams.UnicodeString, []string{"thread.start_address.symbol = 'LoadImage'"}, nil, nil},
+	ThreadStartAddressModule:                           {ThreadStartAddressModule, "thread start address module", kparams.UnicodeString, []string{"thread.start_address.module endswith 'kernel32.dll'"}, nil, nil},
+	ThreadPID:                                          {ThreadPID, "the process identifier where the thread is created", kparams.Uint32, []string{"kevt.pid != thread.pid"}, nil, nil},
+	ThreadTEB:                                          {ThreadTEB, "the base address of the thread environment block", kparams.Address, []string{"thread.teb_address = '8f30893000'"}, nil, nil},
+	ThreadAccessMask:                                   {ThreadAccessMask, "thread desired access rights", kparams.AnsiString, []string{"thread.access.mask = '0x1fffff'"}, nil, nil},
+	ThreadAccessMaskNames:                              {ThreadAccessMaskNames, "thread desired access rights as a string list", kparams.Slice, []string{"thread.access.mask.names in ('IMPERSONATE')"}, nil, nil},
+	ThreadAccessStatus:                                 {ThreadAccessStatus, "thread access status", kparams.UnicodeString, []string{"thread.access.status = 'success'"}, nil, nil},
+	ThreadCallstackSummary:                             {ThreadCallstackSummary, "callstack summary", kparams.UnicodeString, []string{"thread.callstack.summary contains 'ntdll.dll|KERNELBASE.dll'"}, nil, nil},
+	ThreadCallstackDetail:                              {ThreadCallstackDetail, "detailed information of each stack frame", kparams.UnicodeString, []string{"thread.callstack.detail contains 'KERNELBASE.dll!CreateProcessW'"}, nil, nil},
+	ThreadCallstackModules:                             {ThreadCallstackModules, "list of modules comprising the callstack", kparams.Slice, []string{"thread.callstack.modules in ('C:\\WINDOWS\\System32\\KERNELBASE.dll')", "base(thread.callstack.modules[7]) = 'ntdll.dll'"}, nil, &Argument{Optional: true, Pattern: "[0-9]+", ValidationFunc: isNumber}},
+	ThreadCallstackSymbols:                             {ThreadCallstackSymbols, "list of symbols comprising the callstack", kparams.Slice, []string{"thread.callstack.symbols in ('ntdll.dll!NtCreateProcess')", "thread.callstack.symbols[3] = 'ntdll!NtCreateProcess'"}, nil, &Argument{Optional: true, Pattern: "[0-9]+", ValidationFunc: isNumber}},
+	ThreadCallstackAllocationSizes:                     {ThreadCallstackAllocationSizes, "allocation sizes of private pages", kparams.Slice, []string{"thread.callstack.allocation_sizes > 10000"}, nil, nil},
+	ThreadCallstackProtections:                         {ThreadCallstackProtections, "page protections masks of each frame", kparams.Slice, []string{"thread.callstack.protections in ('RWX', 'WX')"}, nil, nil},
+	ThreadCallstackCallsiteLeadingAssembly:             {ThreadCallstackCallsiteLeadingAssembly, "callsite leading assembly instructions", kparams.Slice, []string{"thread.callstack.callsite_leading_assembly in ('mov r10,rcx', 'syscall')"}, nil, nil},
+	ThreadCallstackCallsiteTrailingAssembly:            {ThreadCallstackCallsiteTrailingAssembly, "callsite trailing assembly instructions", kparams.Slice, []string{"thread.callstack.callsite_trailing_assembly in ('add esp, 0xab')"}, nil, nil},
+	ThreadCallstackIsUnbacked:                          {ThreadCallstackIsUnbacked, "indicates if the callstack contains unbacked regions", kparams.Bool, []string{"thread.callstack.is_unbacked"}, nil, nil},
+	ThreadCallstackAddresses:                           {ThreadCallstackAddresses, "list of all stack return addresses", kparams.Slice, []string{"thread.callstack.addresses in ('7ffb5c1d0396')"}, nil, nil},
+	ThreadCallstackFinalUserModuleName:                 {ThreadCallstackFinalUserModuleName, "final user space stack frame module name", kparams.UnicodeString, []string{"thread.callstack.final_user_module.name != 'ntdll.dll'"}, nil, nil},
+	ThreadCallstackFinalUserModulePath:                 {ThreadCallstackFinalUserModulePath, "final user space stack frame module path", kparams.UnicodeString, []string{"thread.callstack.final_user_module.path imatches '?:\\Windows\\System32\\ntdll.dll'"}, nil, nil},
+	ThreadCallstackFinalUserSymbolName:                 {ThreadCallstackFinalUserSymbolName, "final user space stack symbol name", kparams.UnicodeString, []string{"thread.callstack.final_user_symbol.name imatches 'CreateProcess*'"}, nil, nil},
+	ThreadCallstackFinalKernelModuleName:               {ThreadCallstackFinalKernelModuleName, "final kernel space stack frame module name", kparams.UnicodeString, []string{"thread.callstack.final_kernel_module.name = 'FLTMGR.SYS'"}, nil, nil},
+	ThreadCallstackFinalKernelModulePath:               {ThreadCallstackFinalKernelModulePath, "final kernel space stack frame module path", kparams.UnicodeString, []string{"thread.callstack.final_kernel_module.path imatches '?:\\WINDOWS\\System32\\drivers\\FLTMGR.SYS'"}, nil, nil},
+	ThreadCallstackFinalKernelSymbolName:               {ThreadCallstackFinalKernelSymbolName, "final kernel space stack symbol name", kparams.UnicodeString, []string{"thread.callstack.final_kernel_symbol.name = 'FltGetStreamContext'"}, nil, nil},
+	ThreadCallstackFinalUserModuleSignatureIsSigned:    {ThreadCallstackFinalUserModuleSignatureIsSigned, "signature status of the final user space stack frame module", kparams.Bool, []string{"thread.callstack.final_user_module.signature.is_signed = true"}, nil, nil},
+	ThreadCallstackFinalUserModuleSignatureIsTrusted:   {ThreadCallstackFinalUserModuleSignatureIsTrusted, "signature trust status of the final user space stack frame module", kparams.Bool, []string{"thread.callstack.final_user_module.signature.is_trusted = true"}, nil, nil},
+	ThreadCallstackFinalUserModuleSignatureCertIssuer:  {ThreadCallstackFinalUserModuleSignatureCertIssuer, "final user space stack frame module signature certificate issuer", kparams.UnicodeString, []string{"thread.callstack.final_user_module.signature.cert.issuer imatches '*Microsoft Corporation*'"}, nil, nil},
+	ThreadCallstackFinalUserModuleSignatureCertSubject: {ThreadCallstackFinalUserModuleSignatureCertSubject, "final user space stack frame module signature certificate subject", kparams.UnicodeString, []string{"thread.callstack.final_user_module.signature.cert.subject imatches '*Microsoft Windows*'"}, nil, nil},
 
 	ImagePath:               {ImagePath, "full image path", kparams.UnicodeString, []string{"image.patj = 'C:\\Windows\\System32\\advapi32.dll'"}, nil, nil},
 	ImageName:               {ImageName, "image name", kparams.UnicodeString, []string{"image.name = 'advapi32.dll'"}, nil, nil},

--- a/pkg/filter/util.go
+++ b/pkg/filter/util.go
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021-present by Nedim Sabic Sabic
+ * https://www.fibratus.io
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package filter
+
+import (
+	"github.com/rabbitstack/fibratus/pkg/filter/fields"
+	"github.com/rabbitstack/fibratus/pkg/kevent"
+	"github.com/rabbitstack/fibratus/pkg/kevent/kparams"
+	"github.com/rabbitstack/fibratus/pkg/kevent/ktypes"
+	"github.com/rabbitstack/fibratus/pkg/util/loldrivers"
+	"github.com/rabbitstack/fibratus/pkg/util/signature"
+	"github.com/rabbitstack/fibratus/pkg/util/va"
+	"path/filepath"
+)
+
+// isLOLDriver interacts with the loldrivers client to determine
+// whether the loaded/dropped driver is malicious or vulnerable.
+func isLOLDriver(f fields.Field, e *kevent.Kevent) (kparams.Value, error) {
+	var filename string
+
+	if e.Category == ktypes.File {
+		filename = e.GetParamAsString(kparams.FilePath)
+	} else {
+		filename = e.GetParamAsString(kparams.ImagePath)
+	}
+
+	isDriver := filepath.Ext(filename) == ".sys" || e.Kparams.TryGetBool(kparams.FileIsDriver)
+	if !isDriver {
+		return nil, nil
+	}
+	ok, driver := loldrivers.GetClient().MatchHash(filename)
+	if !ok {
+		return nil, nil
+	}
+	if (f == fields.FileIsDriverVulnerable || f == fields.ImageIsDriverVulnerable) && driver.IsVulnerable {
+		return true, nil
+	}
+	if (f == fields.FileIsDriverMalicious || f == fields.ImageIsDriverMalicious) && driver.IsMalicious {
+		return true, nil
+	}
+	return false, nil
+}
+
+// initLOLDriversClient initializes the loldrivers client if the filter expression
+// contains any of the relevant fields.
+func initLOLDriversClient(flds []Field) {
+	for _, f := range flds {
+		if f.Name == fields.FileIsDriverVulnerable || f.Name == fields.FileIsDriverMalicious ||
+			f.Name == fields.ImageIsDriverVulnerable || f.Name == fields.ImageIsDriverMalicious {
+			loldrivers.InitClient(loldrivers.WithAsyncDownload())
+		}
+	}
+}
+
+// getSignature tries to find the module signature mapped to the given address.
+// If the signature is not found in the cache, then a fresh signature instance
+// is created and verified.
+func getSignature(addr va.Address, filename string, parseCert bool) *signature.Signature {
+	sign := signature.GetSignatures().GetSignature(addr.Uint64())
+	if sign != nil {
+		if parseCert {
+			err := sign.ParseCertificate()
+			if err != nil {
+				certErrors.Add(1)
+			}
+		}
+		return sign
+	}
+
+	var err error
+	sign = &signature.Signature{Filename: filename}
+	sign.Type, sign.Level, err = sign.Check()
+	if err != nil {
+		signatureErrors.Add(1)
+	}
+
+	if sign.IsSigned() {
+		sign.Verify()
+	}
+
+	if parseCert {
+		err = sign.ParseCertificate()
+		if err != nil {
+			certErrors.Add(1)
+		}
+	}
+
+	signature.GetSignatures().PutSignature(addr.Uint64(), sign)
+
+	return sign
+}

--- a/pkg/kevent/callstack_test.go
+++ b/pkg/kevent/callstack_test.go
@@ -24,30 +24,25 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/kevent/ktypes"
 	"github.com/rabbitstack/fibratus/pkg/util/va"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 )
 
 func TestCallstack(t *testing.T) {
 	e := &Kevent{
-		Type:      ktypes.CreateFile,
+		Type:      ktypes.CreateProcess,
 		Tid:       2484,
 		PID:       859,
 		CPU:       1,
 		Seq:       2,
-		Name:      "CreateFile",
+		Name:      "CreateProcess",
 		Timestamp: time.Now(),
-		Category:  ktypes.File,
-		Kparams: Kparams{
-			kparams.FileObject:    {Name: kparams.FileObject, Type: kparams.Uint64, Value: uint64(12456738026482168384)},
-			kparams.FilePath:      {Name: kparams.FilePath, Type: kparams.UnicodeString, Value: "C:\\Windows\\system32\\user32.dll"},
-			kparams.FileType:      {Name: kparams.FileType, Type: kparams.AnsiString, Value: "file"},
-			kparams.FileOperation: {Name: kparams.FileOperation, Type: kparams.Enum, Value: uint32(1), Enum: fs.FileCreateDispositions},
-		},
+		Category:  ktypes.Process,
 	}
 
-	e.Callstack.Init(6)
-	assert.Equal(t, 6, cap(e.Callstack))
+	e.Callstack.Init(9)
+	assert.Equal(t, 9, cap(e.Callstack))
 
 	e.Callstack.PushFrame(Frame{Addr: 0x2638e59e0a5, Offset: 0, Symbol: "?", Module: "unbacked"})
 	e.Callstack.PushFrame(Frame{Addr: 0x7ffb313853b2, Offset: 0x10a, Symbol: "Java_java_lang_ProcessImpl_create", Module: "C:\\Program Files\\JetBrains\\GoLand 2021.2.3\\jbr\\bin\\java.dll"})
@@ -55,11 +50,26 @@ func TestCallstack(t *testing.T) {
 	e.Callstack.PushFrame(Frame{Addr: 0x7ffb5c1d0396, Offset: 0x61, Symbol: "CreateProcessW", Module: "C:\\WINDOWS\\System32\\KERNELBASE.dll"})
 	e.Callstack.PushFrame(Frame{Addr: 0x7ffb5d8e61f4, Offset: 0x54, Symbol: "CreateProcessW", Module: "C:\\WINDOWS\\System32\\KERNEL32.DLL"})
 	e.Callstack.PushFrame(Frame{Addr: 0x7ffb5c1d0396, Offset: 0x66, Symbol: "CreateProcessW", Module: "C:\\WINDOWS\\System32\\KERNELBASE.dll"})
+	e.Callstack.PushFrame(Frame{Addr: 0xfffff8015662a605, Offset: 0x9125, Symbol: "setjmpex", Module: "C:\\WINDOWS\\system32\\ntoskrnl.exe"})
+	e.Callstack.PushFrame(Frame{Addr: 0xfffff801568e9c33, Offset: 0x2ef3, Symbol: "LpcRequestPort", Module: "C:\\WINDOWS\\system32\\ntoskrnl.exe"})
+	e.Callstack.PushFrame(Frame{Addr: 0xfffff8015690b644, Offset: 0x45b4, Symbol: "ObDeleteCapturedInsertInfo", Module: "C:\\WINDOWS\\system32\\ntoskrnl.exe"})
 
 	assert.True(t, e.Callstack.ContainsUnbacked())
-	assert.Equal(t, 6, e.Callstack.Depth())
-	assert.Equal(t, "0x7ffb5c1d0396 C:\\WINDOWS\\System32\\KERNELBASE.dll!CreateProcessW+0x66|0x7ffb5d8e61f4 C:\\WINDOWS\\System32\\KERNEL32.DLL!CreateProcessW+0x54|0x7ffb5c1d0396 C:\\WINDOWS\\System32\\KERNELBASE.dll!CreateProcessW+0x61|0x7ffb3138592e C:\\Program Files\\JetBrains\\GoLand 2021.2.3\\jbr\\bin\\java.dll!Java_java_lang_ProcessImpl_waitForTimeoutInterruptibly+0x3a2|0x7ffb313853b2 C:\\Program Files\\JetBrains\\GoLand 2021.2.3\\jbr\\bin\\java.dll!Java_java_lang_ProcessImpl_create+0x10a|0x2638e59e0a5 unbacked!?", e.Callstack.String())
+	assert.Equal(t, 9, e.Callstack.Depth())
+	assert.Equal(t, "0xfffff8015690b644 C:\\WINDOWS\\system32\\ntoskrnl.exe!ObDeleteCapturedInsertInfo+0x45b4|0xfffff801568e9c33 C:\\WINDOWS\\system32\\ntoskrnl.exe!LpcRequestPort+0x2ef3|0xfffff8015662a605 C:\\WINDOWS\\system32\\ntoskrnl.exe!setjmpex+0x9125|0x7ffb5c1d0396 C:\\WINDOWS\\System32\\KERNELBASE.dll!CreateProcessW+0x66|0x7ffb5d8e61f4 C:\\WINDOWS\\System32\\KERNEL32.DLL!CreateProcessW+0x54|0x7ffb5c1d0396 C:\\WINDOWS\\System32\\KERNELBASE.dll!CreateProcessW+0x61|0x7ffb3138592e C:\\Program Files\\JetBrains\\GoLand 2021.2.3\\jbr\\bin\\java.dll!Java_java_lang_ProcessImpl_waitForTimeoutInterruptibly+0x3a2|0x7ffb313853b2 C:\\Program Files\\JetBrains\\GoLand 2021.2.3\\jbr\\bin\\java.dll!Java_java_lang_ProcessImpl_create+0x10a|0x2638e59e0a5 unbacked!?", e.Callstack.String())
 	assert.Equal(t, "KERNELBASE.dll|KERNEL32.DLL|KERNELBASE.dll|java.dll|unbacked", e.Callstack.Summary())
+
+	uframe := e.Callstack.FinalUserFrame()
+	require.NotNil(t, uframe)
+	assert.Equal(t, "7ffb5c1d0396", uframe.Addr.String())
+	assert.Equal(t, "CreateProcessW", uframe.Symbol)
+	assert.Equal(t, "C:\\WINDOWS\\System32\\KERNELBASE.dll", uframe.Module)
+
+	kframe := e.Callstack.FinalKernelFrame()
+	require.NotNil(t, kframe)
+	assert.Equal(t, "fffff8015690b644", kframe.Addr.String())
+	assert.Equal(t, "ObDeleteCapturedInsertInfo", kframe.Symbol)
+	assert.Equal(t, "C:\\WINDOWS\\system32\\ntoskrnl.exe", kframe.Module)
 }
 
 func TestCallstackDecorator(t *testing.T) {

--- a/pkg/symbolize/symbolizer.go
+++ b/pkg/symbolize/symbolizer.go
@@ -453,6 +453,7 @@ func (s *Symbolizer) produceFrame(addr va.Address, e *kevent.Kevent, fast, looku
 			mod := e.PS.FindModuleByVa(addr)
 			if mod != nil {
 				frame.Module = mod.Name
+				frame.ModuleAddress = mod.BaseAddress
 			}
 			if lookupExport {
 				frame.Symbol = s.resolveSymbolFromExportDirectory(addr, mod)
@@ -470,6 +471,7 @@ func (s *Symbolizer) produceFrame(addr va.Address, e *kevent.Kevent, fast, looku
 		}
 		if mod != nil {
 			frame.Module = mod.Name
+			frame.ModuleAddress = mod.BaseAddress
 			m, ok := s.mods[mod.BaseAddress]
 			peOK := true
 			if !ok {

--- a/pkg/util/va/address.go
+++ b/pkg/util/va/address.go
@@ -27,6 +27,7 @@ type Address uint64
 func (a Address) String() string   { return strconv.FormatUint(uint64(a), 16) }
 func (a Address) Uint64() uint64   { return uint64(a) }
 func (a Address) Uintptr() uintptr { return uintptr(a) }
+func (a Address) IsZero() bool     { return a == 0 }
 
 // Inc increments the address by given offset.
 func (a Address) Inc(offset uint64) Address {


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

The new filter fields allow accessing the attributes of the last user/kernel space frame. Additionally, symbols/module filter fields are modified to accept an optional frame index argument and only retrieve the symbol/module name of the accessed frame. The callstack segments are added to access the signature info of the iterated frame.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

/area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---

Reflect the availability of new fields in the docs.
