### PR TITLE
fix(rule): Improve `Hidden local account creation` rule

### DIFF
--- a/rules/macros/macros.yml
+++ b/rules/macros/macros.yml
@@ -50,7 +50,7 @@
   expr: kevt.name = 'RegCreateKey' and registry.status = 'Success'
 
 - macro: modify_registry
-  expr: (set_value or create_key)
+  expr: ((set_value) or (create_key))
 
 - macro: send_socket
   expr: kevt.name = 'Send'

--- a/rules/persistence_hidden_local_account_creation.yml
+++ b/rules/persistence_hidden_local_account_creation.yml
@@ -17,10 +17,10 @@ labels:
   subtechnique.ref: https://attack.mitre.org/techniques/T1136/001/
 
 condition: >
-  set_value and registry.path imatches 
+  modify_registry and registry.path imatches 
     (
-      'HKEY_LOCAL_MACHINE\\SAM\\SAM\\Domains\\Account\\Users\\Names\\*$\\',
-      'HKEY_LOCAL_MACHINE\\SAM\\SAM\\Domains\\Account\\Users\\*$\\'
+      'HKEY_LOCAL_MACHINE\\SAM\\SAM\\Domains\\Account\\Users\\Names\\*$',
+      'HKEY_LOCAL_MACHINE\\SAM\\SAM\\Domains\\Account\\Users\\*$'
     )
 
 severity: high


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

The condition is modified to consider both, `RegCreateKey` and `RegSetValue` events. The registry key path trailing backslashes are removed because in case of `RegCreateKey` events, the registry key is reported without ending backslashes.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
