### PR TITLE
fix(rules): Correct `Process spawned from macro-enabled Microsoft Office document` rule

### DIFF
--- a/rules/initial_access_process_spawned_from_macro_enabled_microsoft_office_document.yml
+++ b/rules/initial_access_process_spawned_from_macro_enabled_microsoft_office_document.yml
@@ -20,10 +20,10 @@ labels:
 condition: >
   spawn_process
     and
-  ps.parent.name iin msoffice_binaries
+  ps.name iin msoffice_binaries
     and
   (
-    thread.callstack.modules imatches '*vbe?.dll'
+    thread.callstack.modules imatches ('*vbe?.dll')
       or
     thread.callstack.symbols imatches
       (


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

The process name condition should evaluate the current process name. The callstack modules are matched against the list.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
