### PR TITLE
refactor(event): Improve callstack decorator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/enescakir/emoji v1.0.0
-	github.com/gammazero/deque v0.2.1
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
 	github.com/hashicorp/go-version v1.2.1
 	github.com/hillu/go-yara/v4 v4.2.4

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,6 @@ github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fzipp/gocyclo v0.3.1/go.mod h1:DJHO6AUmbdqj2ET4Z9iArSuwWgYDRryYt2wASxc7x3E=
-github.com/gammazero/deque v0.2.1 h1:qSdsbG6pgp6nL7A0+K/B7s12mcCY/5l5SIUpMOl+dC0=
-github.com/gammazero/deque v0.2.1/go.mod h1:LFroj8x4cMYCukHJDbxFCkT+r9AndaJnFMuZDV34tuU=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=

--- a/pkg/kevent/callstack_test.go
+++ b/pkg/kevent/callstack_test.go
@@ -113,7 +113,7 @@ func TestCallstackDecorator(t *testing.T) {
 	cd.Push(e)
 	cd.Push(e1)
 
-	assert.True(t, cd.deq.Len() == 2)
+	assert.Len(t, cd.buckets[e.StackID()], 2)
 
 	sw := &Kevent{
 		Type:      ktypes.StackWalk,
@@ -129,7 +129,7 @@ func TestCallstackDecorator(t *testing.T) {
 	}
 
 	evt := cd.Pop(sw)
-	assert.True(t, cd.deq.Len() == 1)
+	assert.Len(t, cd.buckets[e.StackID()], 1)
 	assert.Equal(t, ktypes.CreateFile, evt.Type)
 	assert.True(t, evt.Kparams.Contains(kparams.Callstack))
 	assert.Equal(t, "C:\\Windows\\system32\\user32.dll", evt.GetParamAsString(kparams.FilePath))
@@ -164,11 +164,11 @@ func TestCallstackDecoratorFlush(t *testing.T) {
 	}
 
 	cd.Push(e)
-	assert.True(t, cd.deq.Len() == 1)
+	assert.Len(t, cd.buckets[e.StackID()], 1)
 	time.Sleep(time.Millisecond * 3100)
 
 	evt := <-q.Events()
-	assert.True(t, cd.deq.Len() == 0)
+	assert.Len(t, cd.buckets[e.StackID()], 0)
 	assert.Equal(t, ktypes.CreateFile, evt.Type)
 	assert.False(t, evt.Kparams.Contains(kparams.Callstack))
 }

--- a/pkg/kevent/queue.go
+++ b/pkg/kevent/queue.go
@@ -157,6 +157,10 @@ func (q *Queue) push(e *Kevent) error {
 			enqueue = true
 		}
 	}
+	if q.stackEnrichment && e.IsTerminateThread() {
+		id := uint64(e.Kparams.MustGetPid() + e.Kparams.MustGetTid())
+		q.cd.RemoveBucket(id)
+	}
 	if enqueue || len(q.listeners) == 0 {
 		q.q <- e
 		keventsEnqueued.Add(1)


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Keep the stack walk events indexed by stack id. The stack id is a tuple of pid,tid associated with the thread executing the code. For every unique stack id, the queue of pending events is maintained. When the corresponding stack walk event arrives, the oldest event is pulled from the queue and enriched with stack addresses.


### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

/kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

/area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
