### PR TITLE
perf(symbolizer): Speed up symbol resolution

### DIFF
--- a/pkg/symbolize/symbolizer_test.go
+++ b/pkg/symbolize/symbolizer_test.go
@@ -258,7 +258,7 @@ func TestProcessCallstackPeExports(t *testing.T) {
 
 	// should have populated the symbols cache
 	assert.Len(t, s.symbols, 1)
-	assert.Equal(t, "unbacked!?", s.symbols[e.PID][0x2638e59e0a5])
+	assert.Equal(t, syminfo{module: "unbacked", symbol: "?"}, s.symbols[e.PID][0x2638e59e0a5])
 
 	// image load event should add module exports
 	// and when the image is unloaded and there are


### PR DESCRIPTION
Keep all resolved symbols in the map indexed by pid and return address. Before entering the address symbolisation path, consult the cached symbols. If the symbol is already resolved, we can skip the costly symbolisation process.

### What is the purpose of this PR / why it is needed?


### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

/area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
