### PR TITLE
fix(rule): Add exclusion for `Process execution from a self-deleting binary` rule

### DIFF
--- a/rules/defense_evasion_process_execution_from_self_deleting_binary.yml
+++ b/rules/defense_evasion_process_execution_from_self_deleting_binary.yml
@@ -19,8 +19,13 @@ references:
 
 condition: >
   sequence
-  maxspan 1m
-    |delete_file and file.info.is_disposition_delete_file| by file.name
+  maxspan 1m 
+    |delete_file 
+      and 
+    file.info.is_disposition_delete_file
+      and
+    not file.name imatches '?:\\Windows\\SoftwareDistribution\\Download\\*'
+    | by file.name
     |load_module| by image.name
 
 output: >


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Adding an exclusion to the defense_evasion_process_execution_from_self_deleting_binary.yml rule in order to prevent false positives from Windows updates. 

### What type of change does this PR introduce?

Adding the following path exclusion: '?:\\Windows\\SoftwareDistribution\\Download\\*'

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

 /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
