### PR TITLE
chore(telemetry): Ditch registry system provider

### DIFF
--- a/internal/etw/processors/registry_windows.go
+++ b/internal/etw/processors/registry_windows.go
@@ -87,9 +87,7 @@ func (r *registryProcessor) processEvent(e *kevent.Kevent) (*kevent.Kevent, erro
 	switch e.Type {
 	case ktypes.RegKCBRundown, ktypes.RegCreateKCB:
 		khandle := e.Kparams.MustGetUint64(kparams.RegKeyHandle)
-		if _, ok := r.keys[khandle]; !ok {
-			r.keys[khandle], _ = e.Kparams.GetString(kparams.RegPath)
-		}
+		r.keys[khandle] = e.Kparams.MustGetString(kparams.RegPath)
 		kcbCount.Add(1)
 	case ktypes.RegDeleteKCB:
 		khandle := e.Kparams.MustGetUint64(kparams.RegKeyHandle)

--- a/internal/etw/source_test.go
+++ b/internal/etw/source_test.go
@@ -127,21 +127,17 @@ func TestEventSourceStartTraces(t *testing.T) {
 			evs := NewEventSource(psnap, hsnap, tt.cfg, nil)
 			require.NoError(t, evs.Open(tt.cfg))
 			defer evs.Close()
-			if !SupportsSystemProviders() {
-				assert.Equal(t, tt.wantSessions, len(evs.(*EventSource).traces))
-			}
+			assert.Equal(t, tt.wantSessions, len(evs.(*EventSource).traces))
 
 			for _, trace := range evs.(*EventSource).traces {
 				require.True(t, trace.Handle().IsValid())
 				require.NoError(t, etw.ControlTrace(0, trace.Name, trace.GUID, etw.Query))
-				if !SupportsSystemProviders() {
-					if tt.wantFlags != nil && trace.IsKernelTrace() {
-						flags, err := etw.GetTraceSystemFlags(trace.Handle())
-						require.NoError(t, err)
-						// check enabled system event flags
-						require.Equal(t, tt.wantFlags[0], flags[0])
-						require.Equal(t, tt.wantFlags[1], flags[4])
-					}
+				if tt.wantFlags != nil && trace.IsKernelTrace() {
+					flags, err := etw.GetTraceSystemFlags(trace.Handle())
+					require.NoError(t, err)
+					// check enabled system event flags
+					require.Equal(t, tt.wantFlags[0], flags[0])
+					require.Equal(t, tt.wantFlags[1], flags[4])
 				}
 			}
 		})
@@ -204,11 +200,7 @@ func TestEventSourceEnableFlagsDynamically(t *testing.T) {
 
 	flags := evs.(*EventSource).traces[0].enableFlagsDynamically(cfg.Kstream)
 
-	if SupportsSystemProviders() {
-		require.Len(t, evs.(*EventSource).traces, 3)
-	} else {
-		require.Len(t, evs.(*EventSource).traces, 2)
-	}
+	require.Len(t, evs.(*EventSource).traces, 2)
 
 	require.True(t, flags&etw.FileIO != 0)
 	require.True(t, flags&etw.Process != 0)

--- a/pkg/kevent/ktypes/ktypes_windows.go
+++ b/pkg/kevent/ktypes/ktypes_windows.go
@@ -595,7 +595,7 @@ func (k Ktype) Source() EventSource {
 // events, but it appears first on the consumer callback
 // before other events published before it.
 func (k Ktype) CanArriveOutOfOrder() bool {
-	return k.Category() == Registry || k.Category() == Threadpool || k.Subcategory() == DNS ||
+	return k.Category() == Threadpool || k.Subcategory() == DNS ||
 		k == OpenProcess || k == OpenThread || k == SetThreadContext || k == CreateSymbolicLinkObject
 }
 

--- a/pkg/kevent/ktypes/ktypes_windows_test.go
+++ b/pkg/kevent/ktypes/ktypes_windows_test.go
@@ -130,7 +130,7 @@ func TestGUIDAndHookIDFromKtype(t *testing.T) {
 }
 
 func TestCanArriveOutOfOrder(t *testing.T) {
-	assert.True(t, RegSetValue.CanArriveOutOfOrder())
+	assert.False(t, RegSetValue.CanArriveOutOfOrder())
 	assert.False(t, VirtualAlloc.CanArriveOutOfOrder())
 	assert.True(t, OpenProcess.CanArriveOutOfOrder())
 }

--- a/pkg/sys/etw/types.go
+++ b/pkg/sys/etw/types.go
@@ -66,48 +66,12 @@ const (
 	// ThreadpoolSession represents the session name for the thread pool logger
 	ThreadpoolSession = "Threadpool Logger"
 
-	// SystemRegistrySession represents system registry logger
-	SystemRegistrySession = "System Registry Logger"
-
 	// WnodeTraceFlagGUID indicates that the structure contains event tracing information
 	WnodeTraceFlagGUID = 0x00020000
 	// ProcessTraceModeRealtime denotes that there will be a real-time consumers for events forwarded from the providers
 	ProcessTraceModeRealtime = 0x00000100
 	// ProcessTraceModeEventRecord is the mode that enables the "event record" format for kernel events
 	ProcessTraceModeEventRecord = 0x10000000
-	// EventTraceSystemLoggerMode enables events from system loggers
-	EventTraceSystemLoggerMode = 0x02000000
-)
-
-var (
-	// SystemProcessProviderID provides events related to the process, including lifetime information, image load events, and thread related events.
-	SystemProcessProviderID = windows.GUID{Data1: 0x151f55dc, Data2: 0x467d, Data3: 0x471f, Data4: [8]byte{0x83, 0xb5, 0x5f, 0x88, 0x9d, 0x46, 0xff, 0x66}}
-	// SystemIOProviderID provides events related to multiple kinds of IO including disk, cache, and network.
-	SystemIOProviderID = windows.GUID{Data1: 0x3d5c43e3, Data2: 0x0f1c, Data3: 0x4202, Data4: [8]byte{0xb8, 0x17, 0x17, 0x4c, 0x00, 0x70, 0xdc, 0x79}}
-	// SystemRegistryProviderID provides events related to the registry.
-	SystemRegistryProviderID = windows.GUID{Data1: 0x16156bd9, Data2: 0xfab4, Data3: 0x4cfa, Data4: [8]byte{0xa2, 0x32, 0x89, 0xd1, 0x09, 0x90, 0x58, 0xe3}}
-	// SystemMemoryProviderID provides events related to the memory manager.
-	SystemMemoryProviderID = windows.GUID{Data1: 0x82958ca9, Data2: 0xb6cd, Data3: 0x47f8, Data4: [8]byte{0xa3, 0xa8, 0x03, 0xae, 0x85, 0xa4, 0xbc, 0x24}}
-)
-
-const (
-	// ProcessKeywordGeneral enables process events
-	ProcessKeywordGeneral = 0x1
-	// ProcessKeywordThread enables thread events
-	ProcessKeywordThread = 0x800
-	// ProcessKeywordLoader enables image load/unload events
-	ProcessKeywordLoader = 0x1000
-
-	// RegistryKeywordGeneral enables registry events
-	RegistryKeywordGeneral = 0x1
-
-	// IOKeywordNetwork enables network events
-	IOKeywordNetwork = 0x200
-
-	// MemoryVirtualAlloc enables memory alloc events
-	MemoryVirtualAlloc = 0x400
-	// MemoryVAMap enables section mapping/unmapping events
-	MemoryVAMap = 0x4000
 )
 
 const (


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

After exhaustive triaging, it was spotted that the system registry provider can miss stackwalk samples. This can have disastrous consequences such as wrongly attributing stack return addresses or accumulated events. To elegantly mitigate the problem, we enable the registry flags on the system logger and receive all events within the same session. As a result, the Registry System Logger session/consumer are eliminated.


### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

/kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

/area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
