### PR TITLE
Added rename_file and read_file to macros.yml

### DIFF
--- a/rules/macros/macros.yml
+++ b/rules/macros/macros.yml
@@ -25,6 +25,12 @@
 - macro: create_file
   expr: kevt.name = 'CreateFile' and file.operation != 'OPEN' and file.status = 'Success'
 
+- macro: rename_file
+  expr: kevt.name = 'RenameFile'
+
+- macro: read_file
+  expr: kevt.name = 'ReadFile'
+
 - macro: delete_file
   expr: kevt.name = 'DeleteFile'
 


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

rename_file and read_file are used in new existing rules.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

Yes, this will allow users to use rename_file and read_file in their rule files. 
---
