### PR TITLE
Modified defense_evasion_process_execution_from_self_deleting_binary.yml

### DIFF
--- a/rules/defense_evasion_process_execution_from_self_deleting_binary.yml
+++ b/rules/defense_evasion_process_execution_from_self_deleting_binary.yml
@@ -19,30 +19,15 @@ references:
 
 condition: >
   sequence
-  maxspan 1m 
-    |delete_file and file.info.is_disposition_delete_file
+    maxspan 1m
+    |delete_file
       and
-      not
-     ps.exe imatches 
-      (
-        '?:\\$WINDOWS.~BT\\Sources\\SetupHost.exe',
-        '?:\\WINDOWS\\uus\\packages\\preview\\*\\wuaucltcore.exe'
-      )
-      and 
-      not
-     ps.cmdline imatches 
-      (
-        '?:\\Windows\\system32\\svchost.exe -k wsappx -p -s AppXSvc'
-      )
+    file.info.is_disposition_delete_file
       and
-      not 
-     file.path imatches 
-      (
-        '?:\\Windows\\SoftwareDistribution\\Download\\*',
-        '?:\\Windows\\uus\\packages\\preview\\*'
-      )
+    not file.name imatches '?:\\Windows\\SoftwareDistribution\\Download\\*'
     | by file.name
-    |load_module and ext(image.path) != '.dll'| by image.name
+    |load_module
+    | by image.name
 
 output: >
   Process %2.image.path spawned from self-deleting binary


### PR DESCRIPTION


### What is the purpose of this PR / why it is needed?

Simplified defense_evasion_process_execution_from_self_deleting_binary.yml to tune for false positives with Windows updates.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
