### PR TITLE
fix(rules): Add `CompatTelRunner.exe` as an exclusion in `Unusual process modified registry run key` rule

### DIFF
--- a/rules/persistence_unusual_process_modified_registry_run_key.yml
+++ b/rules/persistence_unusual_process_modified_registry_run_key.yml
@@ -1,6 +1,6 @@
 name: Unusual process modified registry run key
 id: 921508a5-b627-4c02-a295-6c6863c0897b
-version: 1.0.2
+version: 1.0.3
 description: |
   Identifies an attempt by unusual Windows native processes to modify
   the run key and gain persistence on users logons or machine reboots.
@@ -41,7 +41,8 @@ condition: >
       '?:\\Windows\\SysWOW64\\prevhost.exe',
       '?:\\Windows\\System32\\conhost.exe',
       '?:\\Windows\\System32\\taskhostw.exe',
-      '?:\\Windows\\System32\\backgroundTaskHost.exe'
+      '?:\\Windows\\System32\\backgroundTaskHost.exe',
+      '?:\\Windows\\System32\\CompatTelRunner.exe'
     )
 
 min-engine-version: 2.4.0


### PR DESCRIPTION

### What is the purpose of this PR / why it is needed?

Added CompatTelRunner.exe as an exclusion to reduce false positives on this rule.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
