### PR TITLE
fix(rules): Exclusion for OneDrive to tune false positives in `Potential process hollowing` rule

### DIFF
--- a/rules/defense_evasion_potential_process_hollowing_injection.yml
+++ b/rules/defense_evasion_potential_process_hollowing_injection.yml
@@ -1,6 +1,6 @@
 name: Potential Process Hollowing
 id: 2a3fbae8-5e8c-4b71-b9da-56c3958c0d53
-version: 1.1.2
+version: 1.1.3
 description: |
   Adversaries may inject malicious code into suspended and hollowed processes in order to
   evade process-based defenses. Process hollowing is a method of executing arbitrary code
@@ -32,7 +32,8 @@ condition: >
     |spawn_process and ps.sid not in ('S-1-5-18', 'S-1-5-19', 'S-1-5-20') and not ps.exe imatches 
       (
         '?:\\Program Files\\*.exe', 
-        '?:\\Program Files (x86)\\*.exe'
+        '?:\\Program Files (x86)\\*.exe',
+        '?:\\Users\\*\\AppData\\Local\\Programs\\Common\\OneDriveCloud\\taskhostw.exe'
       )
     | by ps.child.uuid
     |unmap_view_of_section and file.view.size > 20000 and file.view.protection != 'READONLY' and (length(file.name) = 0 or not ext(file.name) = '.dll')| by ps.uuid


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Added an exclusion for OneDrive to tune false positives on this rule to reduce false positives

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
