### PR TITLE
chore(callstack): Better expvar insights for stackwalk decorator

### DIFF
--- a/cmd/fibratus/app/stats/stats.go
+++ b/cmd/fibratus/app/stats/stats.go
@@ -108,6 +108,10 @@ type Stats struct {
 	RegistryKcbMisses                   int            `json:"registry.kcb.misses"`
 	RegistryKeyHandleHits               int            `json:"registry.key.handle.hits"`
 	RegistryUnknownKeysCount            int            `json:"registry.unknown.keys.count"`
+	StackwalkEnqueued                   int            `json:"stackwalk.enqueued"`
+	StackwalkFlushes                    int            `json:"stackwalk.flushes"`
+	StackwalkFlushesProcs               map[string]int `json:"stackwalk.flushes.procs"`
+	StackwalkFlushesEvents              map[string]int `json:"stackwalk.flushes.events"`
 	YaraImageScans                      int            `json:"yara.image.scans"`
 	YaraProcScans                       int            `json:"yara.proc.scans"`
 	YaraRuleMatches                     int            `json:"yara.rule.matches"`

--- a/pkg/kevent/stackwalk_test.go
+++ b/pkg/kevent/stackwalk_test.go
@@ -92,7 +92,7 @@ func TestStackwalkDecorator(t *testing.T) {
 }
 
 func init() {
-	maxDequeFlushPeriod = time.Second * 2
+	maxQueueTTLPeriod = time.Second * 2
 	flusherInterval = time.Second
 }
 


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

This PR improves the `expvar` counters for various stackwalk decorator statistics.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

/area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
