### PR TITLE
fix(action): Fix isolate action

### DIFF
--- a/pkg/rules/action/isolate_windows.go
+++ b/pkg/rules/action/isolate_windows.go
@@ -53,7 +53,9 @@ type firewall struct {
 }
 
 func newFirewall() (*firewall, error) {
-	opts := &wf.Options{}
+	opts := &wf.Options{
+		Dynamic: true, // remove filters when the process terminates
+	}
 
 	sess, err := wf.New(opts)
 	if err != nil {

--- a/pkg/rules/action/isolate_windows.go
+++ b/pkg/rules/action/isolate_windows.go
@@ -157,8 +157,6 @@ func (f *firewall) hasAllowRules() bool {
 }
 
 func (f *firewall) addIPCondition(addr net.IP) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
 	ip := netip.AddrFrom4([4]byte(addr))
 	f.inbound.Conditions = append(f.inbound.Conditions, &wf.Match{Field: wf.FieldIPLocalAddress, Op: wf.MatchTypeEqual, Value: ip})
 	f.inbound.Conditions = append(f.inbound.Conditions, &wf.Match{Field: wf.FieldIPRemoteAddress, Op: wf.MatchTypeEqual, Value: ip})


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

This PR brings various changes to the `isolate` action. The first of them is declaring the WFP session as dynamic, Dynamic sessions are meant to add firewall configuration that should not outlast the program's execution. The second fix prevents the deadlock on mutex when adding whitelist IP addresses. Lastly, The current limitation of the `fw` library, makes it impossible to install a filter with multiple IP addresses, so we shrink the list to always append the first IP address in the list.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

/area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
