### PR TITLE
chore(rules): Improve `Unsigned DLL injection via remote thread` rule

### DIFF
--- a/rules/defense_evasion_unsigned_dll_injection_via_remote_thread.yml
+++ b/rules/defense_evasion_unsigned_dll_injection_via_remote_thread.yml
@@ -1,6 +1,6 @@
 name: Unsigned DLL injection via remote thread
 id: 21bdd944-3bda-464b-9a72-58fd37ba9163
-version: 1.0.2
+version: 1.1.0
 description: |
   Identifies unsigned DLL injection via remote thread creation.
   Adversaries may inject dynamic-link libraries (DLLs) into processes in order to evade process-based defenses
@@ -22,15 +22,15 @@ references:
 condition: >
   sequence
   maxspan 1m
-    |create_remote_thread and not (ps.exe imatches
+    |create_remote_thread and thread.start_address.symbol imatches ('LoadLibrary*', 'LdrLoadDLL*') and not (ps.exe imatches
       (
         '?:\\Program Files\\*.exe',
         '?:\\Program Files (x86)\\*.exe'
       )
         or
-      (ps.exe imatches 'C:\\Windows\\System32\\svchost.exe' and ps.args intersects ('-k', 'DcomLaunch'))
+      (ps.exe imatches '?:\\Windows\\System32\\svchost.exe' and ps.args intersects ('-k', 'DcomLaunch'))
         or
-      (ps.cmdline imatches '?:\\Windows\\Microsoft.NET\\Framework\\*\\ngen.exe ExecuteQueuedItems /LegacyServiceBehavior')
+      (ps.cmdline imatches '"?:\\Windows\\Microsoft.NET\\Framework\\*\\ngen.exe" ExecuteQueuedItems /LegacyServiceBehavior')
      )
     | by thread.pid
     |(load_unsigned_or_untrusted_dll)


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

To make the rule more resistant to false positives, add the condition to evaluate the symbol pertaining to the thread start address.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
