### PR TITLE
feat(rules): New `LSASS memory dump via MiniDumpWriteDump` rule

### DIFF
--- a/rules/credential_access_lsass_memory_dump_via_minidumpwritedump.yml
+++ b/rules/credential_access_lsass_memory_dump_via_minidumpwritedump.yml
@@ -1,0 +1,33 @@
+name: LSASS memory dump via MiniDumpWriteDump
+id: fd7ced77-4a95-4658-80f6-6b9d7b5e3777
+version: 1.0.0
+description: |
+  Identifies access to the Local Security Authority Subsystem Service (LSASS) process to dump the
+  memory via MiniDumpWriteDump API.
+labels:
+  tactic.id: TA0006
+  tactic.name: Credential Access
+  tactic.ref: https://attack.mitre.org/tactics/TA0006/
+  technique.id: T1003
+  technique.name: OS Credential Dumping
+  technique.ref: https://attack.mitre.org/techniques/T1003/
+  subtechnique.id: T1003.001
+  subtechnique.name: LSASS Memory
+  subtechnique.ref: https://attack.mitre.org/techniques/T1003/001/
+references:
+  - https://redcanary.com/threat-detection-report/techniques/lsass-memory/
+  - https://modexp.wordpress.com/2019/08/30/minidumpwritedump-via-com-services-dll/
+  - https://www.ired.team/offensive-security/credential-access-and-credential-dumping/dumping-lsass-passwords-without-mimikatz-minidumpwritedump-av-signature-bypass
+
+condition: >
+  ((open_process) or (open_thread)) and kevt.arg[exe] imatches '?:\\Windows\\System32\\lsass.exe'
+    and
+  (thread.callstack.modules imatches ('*dbgcore.dll', '*comsvcs.dll') or thread.callstack.symbols imatches ('*MiniDumpWriteDump'))
+action:
+  - name: kill
+
+output: >
+  LSASS memory dump attempt by process %ps.exe via MiniDumpWriteDump
+severity: high
+
+min-engine-version: 2.4.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Identifies access to the Local Security Authority Subsystem Service (LSASS) process to dump the memory via MiniDumpWriteDump API.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
