### PR TITLE
feat(rules): New `LSASS access from unsigned executable` rule

### DIFF
--- a/rules/credential_access_lsass_access_from_unsigned_executable.yml
+++ b/rules/credential_access_lsass_access_from_unsigned_executable.yml
@@ -1,0 +1,32 @@
+name: LSASS access from unsigned executable
+id: 348bf896-2201-444f-b1c9-e957a1f063bf
+version: 1.0.0
+description: |
+  Detects attempts by an unsigned process to access the Local Security Authority Subsystem Service (LSASS). 
+  Adversaries may try to dump credential information stored in the process memory of LSASS.
+labels:
+  tactic.id: TA0006
+  tactic.name: Credential Access
+  tactic.ref: https://attack.mitre.org/tactics/TA0006/
+  technique.name: OS Credential Dumping
+  technique.ref: https://attack.mitre.org/techniques/T1003/
+  subtechnique.id: T1003.001
+  subtechnique.name: LSASS Memory
+  subtechnique.ref: https://attack.mitre.org/techniques/T1003/001/
+references:
+  - https://redcanary.com/threat-detection-report/techniques/lsass-memory/
+
+condition: >
+  sequence
+  maxspan 7m
+  by ps.uuid
+    |load_unsigned_executable|
+    |((open_process) or (open_thread)) and kevt.arg[exe] imatches '?:\\Windows\\System32\\lsass.exe'|
+action:
+  - name: kill
+
+output: >
+  Unsigned executable %1.image.path attempted to access Local Security Authority Subsystem Service
+severity: high
+
+min-engine-version: 2.2.0

--- a/rules/macros/macros.yml
+++ b/rules/macros/macros.yml
@@ -150,6 +150,12 @@
   expr: >
     load_module and (image.name iendswith '.dll' or image.is_dll)
 
+- macro: load_unsigned_executable
+  expr: >
+    load_executable
+      and
+    image.signature.type = 'NONE'
+
 - macro: load_untrusted_executable
   expr: >
     load_executable


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Detects attempts by an unsigned process to access the Local Security Authority Subsystem Service (LSASS). Adversaries may try to dump credential information stored in the process memory of LSASS.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
