### PR TITLE
fix(rule-engine): Check process state before evaluation

### DIFF
--- a/pkg/rules/engine.go
+++ b/pkg/rules/engine.go
@@ -210,7 +210,7 @@ func (e *Engine) Compile() (*config.RulesCompileResult, error) {
 	for c, f := range filters {
 		var ss *sequenceState
 		if f.IsSequence() {
-			ss = newSequenceState(f, c)
+			ss = newSequenceState(f, c, e.psnap)
 		}
 		fltr := newCompiledFilter(f, c, ss)
 		if ss != nil {

--- a/pkg/rules/sequence_test.go
+++ b/pkg/rules/sequence_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/kevent"
 	"github.com/rabbitstack/fibratus/pkg/kevent/kparams"
 	"github.com/rabbitstack/fibratus/pkg/kevent/ktypes"
+	"github.com/rabbitstack/fibratus/pkg/ps"
 	pstypes "github.com/rabbitstack/fibratus/pkg/ps/types"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -50,7 +51,7 @@ func TestSequenceState(t *testing.T) {
 
 	require.NoError(t, f.Compile())
 
-	ss := newSequenceState(f, c)
+	ss := newSequenceState(f, c, new(ps.SnapshotterMock))
 
 	assert.Equal(t, 0, ss.currentState())
 	assert.True(t, ss.isInitialState())
@@ -190,7 +191,7 @@ func TestSimpleSequence(t *testing.T) {
 	`, &config.Config{Kstream: config.KstreamConfig{EnableFileIOKevents: true}, Filters: &config.Filters{}})
 	require.NoError(t, f.Compile())
 
-	ss := newSequenceState(f, c)
+	ss := newSequenceState(f, c, new(ps.SnapshotterMock))
 
 	var tests = []struct {
 		evts    []*kevent.Kevent
@@ -276,7 +277,7 @@ func TestSimpleSequenceMultiplePartials(t *testing.T) {
 	`, &config.Config{Kstream: config.KstreamConfig{EnableFileIOKevents: true}, Filters: &config.Filters{}})
 	require.NoError(t, f.Compile())
 
-	ss := newSequenceState(f, c)
+	ss := newSequenceState(f, c, new(ps.SnapshotterMock))
 
 	// create random matches which don't satisfy the sequence link
 	for i, pid := range []uint32{2343, 1024, 11122, 3450, 12319} {
@@ -382,7 +383,7 @@ func TestSimpleSequenceDeadline(t *testing.T) {
 	`, &config.Config{Kstream: config.KstreamConfig{EnableFileIOKevents: true}, Filters: &config.Filters{}})
 	require.NoError(t, f.Compile())
 
-	ss := newSequenceState(f, c)
+	ss := newSequenceState(f, c, new(ps.SnapshotterMock))
 
 	e1 := &kevent.Kevent{
 		Type:      ktypes.CreateProcess,
@@ -453,7 +454,7 @@ func TestComplexSequence(t *testing.T) {
 	`, &config.Config{Kstream: config.KstreamConfig{EnableFileIOKevents: true}, Filters: &config.Filters{}})
 	require.NoError(t, f.Compile())
 
-	ss := newSequenceState(f, c)
+	ss := newSequenceState(f, c, new(ps.SnapshotterMock))
 
 	e1 := &kevent.Kevent{
 		Seq:       1,
@@ -546,7 +547,7 @@ func TestSequenceOOO(t *testing.T) {
 	`, &config.Config{Kstream: config.KstreamConfig{EnableFileIOKevents: true}, Filters: &config.Filters{}})
 	require.NoError(t, f.Compile())
 
-	ss := newSequenceState(f, c)
+	ss := newSequenceState(f, c, new(ps.SnapshotterMock))
 
 	e1 := &kevent.Kevent{
 		Type:      ktypes.CreateFile,
@@ -606,7 +607,7 @@ func TestSequenceGC(t *testing.T) {
 	`, &config.Config{Kstream: config.KstreamConfig{EnableFileIOKevents: true}, Filters: &config.Filters{}})
 	require.NoError(t, f.Compile())
 
-	ss := newSequenceState(f, c)
+	ss := newSequenceState(f, c, new(ps.SnapshotterMock))
 
 	e := &kevent.Kevent{
 		Type:      ktypes.OpenProcess,
@@ -755,7 +756,7 @@ func TestSequenceExpire(t *testing.T) {
 			f := filter.New(tt.expr, &config.Config{Kstream: config.KstreamConfig{EnableFileIOKevents: true}, Filters: &config.Filters{}})
 			require.NoError(t, f.Compile())
 
-			ss := newSequenceState(f, tt.c)
+			ss := newSequenceState(f, tt.c, new(ps.SnapshotterMock))
 			for _, evt := range tt.evts {
 				if evt.IsTerminateProcess() {
 					ss.expire(evt)
@@ -787,7 +788,7 @@ func TestSequenceBoundFields(t *testing.T) {
 	`, &config.Config{Kstream: config.KstreamConfig{EnableFileIOKevents: true}, Filters: &config.Filters{}})
 	require.NoError(t, f.Compile())
 
-	ss := newSequenceState(f, c)
+	ss := newSequenceState(f, c, new(ps.SnapshotterMock))
 
 	e1 := &kevent.Kevent{
 		Type:      ktypes.CreateProcess,
@@ -882,7 +883,7 @@ func TestSequenceBoundFieldsWithFunctions(t *testing.T) {
 	`, &config.Config{Kstream: config.KstreamConfig{EnableFileIOKevents: true, EnableRegistryKevents: true}, Filters: &config.Filters{}})
 	require.NoError(t, f.Compile())
 
-	ss := newSequenceState(f, c)
+	ss := newSequenceState(f, c, new(ps.SnapshotterMock))
 
 	e1 := &kevent.Kevent{
 		Type:     ktypes.CreateFile,
@@ -942,7 +943,7 @@ func TestIsExpressionEvaluable(t *testing.T) {
 	`, &config.Config{Kstream: config.KstreamConfig{EnableFileIOKevents: true}, Filters: &config.Filters{}})
 	require.NoError(t, f.Compile())
 
-	ss := newSequenceState(f, c)
+	ss := newSequenceState(f, c, new(ps.SnapshotterMock))
 
 	e1 := &kevent.Kevent{
 		Type: ktypes.CreateProcess,


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Events can arrive in non-deterministic order since they are published by independent providers. The side effect of this can translate in the form of a missing process state. Imagine the `OpenProcess` event arriving from the process before the process's own creation event. To mitigate this bad behavior, we always check the process state before evaluating out-of-order events.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

/area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
