### PR TITLE
feat(rules): New `Suspicious Netsh Helper DLL execution` rule

### DIFF
--- a/rules/persistence_suspicious_netsh_helper_dll_execution.yml
+++ b/rules/persistence_suspicious_netsh_helper_dll_execution.yml
@@ -1,0 +1,35 @@
+name: Suspicious Netsh Helper DLL execution
+id: bd17781d-38ca-4b9a-a12a-f807a1eb45e0
+version: 1.0.0
+description: |
+  Identifies the execution of a suspicious Netsh Helper DLL. Adversaries may establish persistence 
+  by executing malicious content triggered by Netsh Helper DLLs. Netsh.exe is a command-line scripting 
+  utility used to interact with the network configuration of a system. It supports the addition of 
+  custom DLLs to extend its functionality that attackers can weaponize.
+labels:
+  tactic.id: TA0003
+  tactic.name: Persistence
+  tactic.ref: https://attack.mitre.org/tactics/TA0003/
+  technique.id: T1546
+  technique.name: Event Triggered Execution
+  technique.ref: https://attack.mitre.org/techniques/T1546/
+  subtechnique.id: T1546.007
+  subtechnique.name: Netsh Helper DLL
+  subtechnique.ref: https://attack.mitre.org/techniques/T1546/007/
+references:
+  - https://github.com/outflanknl/NetshHelperBeacon
+  - https://www.ired.team/offensive-security/persistence/t1128-netsh-helper-dll
+
+condition: >
+  sequence
+  maxspan 1m
+    |spawn_process and (ps.child.name ~= 'netsh.exe' or ps.child.pe.file.name ~= 'netsh.exe')| by ps.child.uuid
+    |create_thread and foreach(thread._callstack, $frame, $frame.symbol imatches '*!InitHelperDll' 
+                               and ($frame.module.signature.is_signed = false or $frame.module.signature.is_trusted = false))
+    | by ps.uuid
+
+output: >
+  Suspicious Netsh Helper DLL %2.thread.start_address.module executed
+severity: high
+
+min-engine-version: 2.4.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Identifies the execution of a suspicious Netsh Helper DLL. Adversaries may establish persistence by executing malicious content triggered by Netsh Helper DLLs. Netsh.exe is a command-line scripting utility used to interact with the network configuration of a system. It supports the addition of custom DLLs to extend its functionality that attackers can weaponize.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
