### PR TITLE
fix(filter): Allow interpolation for fields with underscore characters

### DIFF
--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -350,7 +350,7 @@ func (f *filter) GetSequence() *ql.Sequence { return f.seq }
 // which refers to the event in particular sequence stage. Otherwise, the modifier is
 // a well-known field name prepended with the `%` symbol.
 func InterpolateFields(s string, evts []*kevent.Kevent) string {
-	var fieldsReplRegexp = regexp.MustCompile(`%([1-9]?)\.?([a-z0-9A-Z\[\].]+)`)
+	var fieldsReplRegexp = regexp.MustCompile(`%([1-9]?)\.?([a-z0-9A-Z\[\]._]+)`)
 	matches := fieldsReplRegexp.FindAllStringSubmatch(s, -1)
 	r := s
 	if len(matches) == 0 {

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -1326,6 +1326,21 @@ func TestInterpolateFields(t *testing.T) {
 			},
 		},
 		{
+			original:     "Suspicious thread start module %thread.start_address.module",
+			interpolated: "Suspicious thread start module C:\\Windows\\System32\\vault.dll",
+			evts: []*kevent.Kevent{
+				{
+					Type:     ktypes.CreateThread,
+					Category: ktypes.Thread,
+					Name:     "CreateThread",
+					PID:      1023,
+					Kparams: kevent.Kparams{
+						kparams.StartAddressModule: {Name: kparams.StartAddressModule, Type: kparams.UnicodeString, Value: "C:\\Windows\\System32\\vault.dll"},
+					},
+				},
+			},
+		},
+		{
 			original: `Detected an attempt by <code>%1.ps.name</code> process to access
 and read the memory of the <b>Local Security And Authority Subsystem Service</b>
 and subsequently write the <code>%2.file.path</code> dump file to the disk device`,


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Allow interpolation for fields with underscore characters.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

/area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
