### PR TITLE
feat(rules): New `Potential shellcode execution via ETW logger thread` rule

### DIFF
--- a/rules/defense_evasion_potential_shellcode_execution_via_etw_logger_thread.yml
+++ b/rules/defense_evasion_potential_shellcode_execution_via_etw_logger_thread.yml
@@ -1,0 +1,35 @@
+name: Potential shellcode execution via ETW logger thread
+id: 3e915273-5ea0-4576-afc9-b018e2d53545
+version: 1.0.0
+description: |
+  Adversaries may employ the undocumented EtwpCreateEtwThread function to execute shellcode 
+  within the local process address space.
+labels:
+  tactic.id: TA0005
+  tactic.name: Defense Evasion
+  tactic.ref: https://attack.mitre.org/tactics/TA0005/
+  technique.id: T1055
+  technique.name: Process Injection
+  technique.ref: https://attack.mitre.org/techniques/T1055/
+references:
+  - https://www.geoffchappell.com/studies/windows/win32/ntdll/api/etw/index.htm
+  - https://github.com/Ne0nd0g/go-shellcode/tree/master?tab=readme-ov-file#EtwpCreateEtwThread
+
+condition: >
+  create_thread and kevt.pid != 4 and thread.callstack.symbols iin ('ntdll.dll!EtwpCreateEtwThread')
+    and
+    not
+  (ps.exe imatches
+    (
+      '?:\\WINDOWS\\System32\\ProvTool.exe',
+      '?:\\Windows\\System32\\LogonUI.exe'
+    )
+    or
+   thread.callstack.symbols imatches ('ntdll.dll!EtwProcessPrivateLoggerRequest', 'sechost.dll!ControlTrace*')
+  )
+
+output: >
+  Potential shellcode execution via EtwpCreateEtwThread API initiated by process %ps.exe
+severity: high
+
+min-engine-version: 2.2.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Adversaries may employ the undocumented EtwpCreateEtwThread function to execute shellcode within the local process address space.


### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
