### PR TITLE
feat(rules): New `LSASS process clone creation via reflection` rule

### DIFF
--- a/rules/credential_access_lsass_process_clone_creation_via_reflection.yml
+++ b/rules/credential_access_lsass_process_clone_creation_via_reflection.yml
@@ -1,0 +1,31 @@
+name: LSASS process clone creation via reflection
+id: cdf3810a-4832-446a-ac9d-d108cf2e313c
+version: 1.0.0
+description: |
+  Identifies the creation of an LSASS clone process via RtlCreateProcessReflection API function.
+  Adversaries can use this technique to dump credentials material from the LSASS fork and evade
+  defenses.
+labels:
+  tactic.id: TA0006
+  tactic.name: Credential Access
+  tactic.ref: https://attack.mitre.org/tactics/TA0006/
+  technique.id: T1003
+  technique.name: OS Credential Dumping
+  technique.ref: https://attack.mitre.org/techniques/T1003/
+  subtechnique.id: T1003.001
+  subtechnique.name: LSASS Memory
+  subtechnique.ref: https://attack.mitre.org/techniques/T1003/001/
+references:
+  - https://github.com/Offensive-Panda/LsassReflectDumping
+  - https://s3cur3th1ssh1t.github.io/Reflective-Dump-Tools/
+
+condition: >
+  spawn_process and ps.name ~= 'lsass.exe' and ps.child.name ~= 'lsass.exe'
+    and
+  thread.callstack.symbols imatches ('ntdll.dll!RtlCloneUserProcess', 'ntdll.dll!RtlCreateProcessReflection')
+action:
+  - name: kill
+
+severity: high
+
+min-engine-version: 2.2.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Identifies the creation of an LSASS clone process via `RtlCreateProcessReflection` API function. Adversaries can use this technique to dump credentials material from the LSASS fork and evade defenses.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
