### PR TITLE
feat(rules): New `Suspicious print processor loaded` rule

### DIFF
--- a/rules/persistence_suspicious_port_monitor_loaded.yml
+++ b/rules/persistence_suspicious_port_monitor_loaded.yml
@@ -1,6 +1,6 @@
 name: Suspicious port monitor loaded
 id: d6ab6bfa-1a97-46cb-a69a-7a6c98a699f1
-version: 1.0.0
+version: 1.0.1
 description: |
   Identifies the loading of an unsigned DLL by the print spool service. Adversaries may use port
   monitors to run an adversary supplied DLL during system boot for persistence or privilege escalation.
@@ -18,10 +18,8 @@ references:
   - https://www.ired.team/offensive-security/persistence/t1013-addmonitor
 
 condition: >
-  load_dll and ps.name ~= 'spoolsv.exe'
+  (load_unsigned_or_untrusted_dll) and ps.name ~= 'spoolsv.exe'
     and
   thread.callstack.symbols imatches ('localspl.dll!SplAddMonitor*', 'spoolsv.exe!PrvAddMonitor*')
-    and
-  (image.signature.level = 'UNCHECKED' or image.signature.level = 'UNSIGNED')
 
 min-engine-version: 2.2.0

--- a/rules/persistence_suspicious_print_processor_loaded.yml
+++ b/rules/persistence_suspicious_print_processor_loaded.yml
@@ -1,0 +1,32 @@
+name: Suspicious print processor loaded
+id: 3e0f5ef7-8a0a-4604-b2bf-d09606f45483
+version: 1.0.0
+description: |
+  Identifies when the print spooler service loads unsigned or untrusted DLL and the callstack pattern
+  indicates the print processor is loaded. Adversaries may abuse print processors to run malicious DLLs 
+  during system boot for persistence and/or privilege escalation.
+labels:
+  tactic.id: TA0003
+  tactic.name: Persistence
+  tactic.ref: https://attack.mitre.org/tactics/TA0003/
+  technique.id: T1547
+  technique.name: Boot or Logon Autostart Execution
+  technique.ref: https://attack.mitre.org/techniques/T1547/
+  subtechnique.id: T1547.012
+  subtechnique.name: Print Processors
+  subtechnique.ref: https://attack.mitre.org/techniques/T1547/012/
+references:
+  - https://stmxcsr.com/persistence/print-processor.html
+
+condition: >
+  (load_unsigned_or_untrusted_dll) and ps.name ~= 'spoolsv.exe' 
+    and
+  thread.callstack.summary imatches 'ntdll.dll|KernelBase.dll|localspl.dll|spoolsv.exe|kernel32.dll|ntdll.dll'
+    and
+  thread.callstack.symbols imatches ('localspl.dll!SplSetPrinterData') and thread.callstack.symbols not imatches ('KernelBase.dll!RegisterGPNotificationInternal')
+
+output: >
+  Print spooler service loaded suspicious print processor DLL %image.path
+severity: high
+
+min-engine-version: 2.4.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Identifies when the print spooler service loads unsigned or untrusted DLL and the callstack pattern indicates the print processor is loaded. Adversaries may abuse print processors to run malicious DLLs during system boot for persistence and/or privilege escalation.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
