### PR TITLE
feat(rules): New `Microsoft office file execution via script interpreter` rule

### DIFF
--- a/rules/initial_access_microsoft_office_file_execution_via_script_interpreter.yml
+++ b/rules/initial_access_microsoft_office_file_execution_via_script_interpreter.yml
@@ -1,0 +1,35 @@
+name: Microsoft Office file execution via script interpreter
+id: bf3ea547-1470-4bcc-9945-3b495d962c2c
+version: 1.0.0
+description: |
+  Identifies the execution via Windows script interpreter of the executable file written 
+  by the Microsoft Office process.
+labels:
+  tactic.id: TA0001
+  tactic.name: Initial Access
+  tactic.ref: https://attack.mitre.org/tactics/TA0001/
+  technique.id: T1566
+  technique.name: Phishing
+  technique.ref: https://attack.mitre.org/techniques/T1566/
+  subtechnique.id: T1566.001
+  subtechnique.name: Spearphishing Attachment
+  subtechnique.ref: https://attack.mitre.org/techniques/T1566/001/
+
+condition: >
+  sequence
+  maxspan 2m
+    |create_file and ps.name iin msoffice_binaries and (file.extension iin ('.exe', '.com', '.scr', '.pif', '.bat') or file.is_exec = true)| by file.path
+    |spawn_process and ps.name iin script_interpreters and ps.child.exe not imatches 
+      (
+        '?:\\Program Files\\*.exe',
+        '?:\\Program Files (x86)\\*.exe'
+      )
+    | by ps.child.exe
+action:
+  - name: kill
+
+output: >
+  Microsoft Office process %1.ps.exe wrote the file %1.file.path and subsequently executed it via script interpreter %2.ps.exe
+severity: high
+
+min-engine-version: 2.4.0

--- a/rules/macros/macros.yml
+++ b/rules/macros/macros.yml
@@ -323,7 +323,7 @@
     gaining persistence on the compromised endpoint.
 
 - macro: script_interpreters
-  list: ["powershell.exe", "pwsh.exe", "cscript.exe", "wscript.exe", "mshta.exe"]
+  list: ["powershell.exe", "pwsh.exe", "cscript.exe", "wscript.exe", "mshta.exe", "cmd.exe"]
 
 - macro: startup_shell_folder_registry_keys
   list: [


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Identifies the execution via Windows script interpreter of the executable file written by the Microsoft Office process.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
