### PR TITLE
feat(rules): New `Windows Defender protection tampering via registry` rule

### DIFF
--- a/rules/defense_evasion_windows_defender_protection_tampering_via_registry.yml
+++ b/rules/defense_evasion_windows_defender_protection_tampering_via_registry.yml
@@ -1,0 +1,65 @@
+name: Windows Defender protection tampering via registry
+id: 47ad962b-be0f-44f8-9467-34109f41e5ff
+version: 1.0.0
+description: |
+  Detects suspicious processes modifying Windows Defender configuration settings via registry 
+  to disable protection features.
+labels:
+  tactic.id: TA0005
+  tactic.name: Defense Evasion
+  tactic.ref: https://attack.mitre.org/tactics/TA0005/
+  technique.id: T1562
+  technique.name: Impair Defenses
+  technique.ref: https://attack.mitre.org/techniques/T1562/
+  subtechnique.id: T1562.001
+  subtechnique.name: Disable or Modify Tools
+  subtechnique.ref: https://attack.mitre.org/techniques/T1562/001
+references:
+  - https://symantec-enterprise-blogs.security.com/blogs/threat-intelligence/ransomware-hive-conti-avoslocker
+
+condition: >
+  set_value 
+    and 
+  ((base(registry.path) iin 
+    (
+      'DisableAntiSpyware',
+      'DisableAntiVirus',
+      'DisableBehaviorMonitoring',
+      'DisableBlockAtFirstSeen',
+      'DisableEnhancedNotifications',
+      'DisableIntrusionPreventionSystem',
+      'DisableIOAVProtection',
+      'DisableOnAccessProtection',
+      'DisableRealtimeMonitoring',
+      'DisableScanOnRealtimeEnable',
+      'DisableScriptScanning',
+      'DisableArchiveScanning',
+      'DisableRawWriteNotification'
+    ) and registry.value = 1)
+      or
+    (registry.path imatches
+      (
+        '*\\Windows Defender\\Spynet\\SpyNetReporting',
+        '*\\Windows Defender\\Spynet\\SubmitSamplesConsent',
+        '*\\DisallowExploitProtectionOverride',
+        '*\\Windows Defender\\Features\\TamperProtection',
+        '*\\Windows Defender\\MpEngine\\MpEnablePus'
+      ) and registry.value = 0
+    )
+  )
+    and
+  ps.exe not imatches
+    (
+      '?:\\Program Files\\Symantec\\Symantec Endpoint Protection\\sepWscSvc64.exe',
+      '?:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\*\\ConfigSecurityPolicy.exe',
+      '?:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\*\\MsMpEng.exe',
+      '?:\\ProgramData\\Microsoft\\Windows Defender\\*\\NisSrv.exe'
+    )
+action:
+  - name: kill
+
+output: >
+  Suspicious process %ps.exe tampered Windows Defender security settings in registry value %registry.path
+severity: high
+
+min-engine-version: 2.4.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Detects suspicious processes modifying Windows Defender configuration settings via registry to disable protection features.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
