### PR TITLE
fix(rules): Rearrange the not operator in binary expressions

### DIFF
--- a/pkg/filter/ql/expr.go
+++ b/pkg/filter/ql/expr.go
@@ -81,9 +81,8 @@ type NotExpr struct {
 // String returns a string representation of the not expression.
 func (e *NotExpr) String() string {
 	var b strings.Builder
-	b.Grow(len(e.Expr.String()) + 2)
-	b.WriteRune('(')
+	b.Grow(len(e.Expr.String()) + 4)
+	b.WriteString("NOT ")
 	b.WriteString(e.Expr.String())
-	b.WriteRune(')')
 	return b.String()
 }

--- a/rules/credentail_access_file_access_to_sam_database.yml
+++ b/rules/credentail_access_file_access_to_sam_database.yml
@@ -1,6 +1,6 @@
 name: File access to SAM database
 id: e3dace20-4962-4381-884e-40dcdde66626
-version: 1.0.1
+version: 1.0.2
 description: |
   Identifies access to the Security Account Manager on-disk database.
 labels:
@@ -24,8 +24,7 @@ condition: >
       '\\??\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy*\\WINDOWS\\SYSTEM32\\CONFIG\\SAM'
     )
     and
-    not
-  ps.exe imatches
+  ps.exe not imatches
     (
       '?:\\Program Files\\*',
       '?:\\Program Files (x86)\\*',

--- a/rules/credential_access_lsass_memory_dumping.yml
+++ b/rules/credential_access_lsass_memory_dumping.yml
@@ -1,6 +1,6 @@
 name: LSASS memory dumping via legitimate or offensive tools
 id: 335795af-246b-483e-8657-09a30c102e63
-version: 1.0.1
+version: 1.0.2
 description: |
   Detects an attempt to dump the LSAAS memory to the disk by employing legitimate
   tools such as procdump, Task Manager, Process Explorer or built-in Windows tools
@@ -27,8 +27,7 @@ condition: >
       and
      kevt.arg[exe] imatches '?:\\Windows\\System32\\lsass.exe'
       and
-      not
-     ps.exe imatches
+     ps.exe not imatches
       (
         '?:\\Windows\\System32\\svchost.exe',
         '?:\\ProgramData\\Microsoft\\Windows Defender\\*\\MsMpEng.exe'

--- a/rules/credential_access_potential_sam_hive_dumping.yml
+++ b/rules/credential_access_potential_sam_hive_dumping.yml
@@ -1,6 +1,6 @@
 name: Potential SAM hive dumping
 id: 2f326557-0291-4eb1-a87a-7a17b7d941cb
-version: 1.0.2
+version: 1.0.3
 description:
   Identifies access to the Security Account Manager registry hives.
 labels:
@@ -40,8 +40,7 @@ condition: >
       and
      registry.path imatches 'HKEY_LOCAL_MACHINE\\SAM\\SAM\\Domains\\Account\\*'
       and
-      not
-     registry.path imatches
+     registry.path not imatches
       (
         'HKEY_LOCAL_MACHINE\\SAM\\SAM\\Domains\\Account\\Users',
         'HKEY_LOCAL_MACHINE\\SAM\\SAM\\Domains\\Account\\Users\\Names',
@@ -49,8 +48,7 @@ condition: >
         'HKEY_LOCAL_MACHINE\\SAM\\SAM\\Account\\Aliases\\*'
       )
       and
-      not
-     ps.exe imatches
+     ps.exe not imatches
       (
         '?:\\Windows\\System32\\lsass.exe',
         '?:\\Windows\\System32\\RuntimeBroker.exe',

--- a/rules/credential_access_suspicious_access_to_active_directory_domain_database.yml
+++ b/rules/credential_access_suspicious_access_to_active_directory_domain_database.yml
@@ -1,6 +1,6 @@
 name: Suspicious access to Active Directory domain database
 id: a30c100e-28d0-4aa0-b98d-0d38025c2c29
-version: 1.0.1
+version: 1.0.2
 description: |
   Detects suspicious access to the Active Directory domain database.
   Adversaries may attempt to access or create a copy of the Active Directory
@@ -25,8 +25,7 @@ condition: >
       '?:\\WINDOWS\\NTDS\\ntds.dit'
     )
     and
-    not
-  ps.exe imatches
+  ps.exe not imatches
     (
       '?:\\Windows\\System32\\lsass.exe',
       '?:\\ProgramData\\Microsoft\\Windows Defender\\*\\MsMpEng.exe'

--- a/rules/credential_access_suspicious_access_to_unattended_panther_files.yml
+++ b/rules/credential_access_suspicious_access_to_unattended_panther_files.yml
@@ -1,6 +1,6 @@
 name: Suspicious access to Unattended Panther files
 id: d305fb15-6ad1-4d61-a84b-ada462f23a55
-version: 1.0.1
+version: 1.0.2
 description: |
   Identifies suspicious to access to unattend.xml files where credentials
   are commonly stored within the Panther directory. Adversaries may search local
@@ -27,8 +27,7 @@ condition: >
       '?:\\Windows\\Panther\\Unattend.xml'
     )
     and
-    not
-  ps.exe imatches
+  ps.exe not imatches
     (
       '?:\\Program Files\\*',
       '?:\\Program Files(x86)\\*',

--- a/rules/credential_access_suspicious_access_to_windows_dpapi_master_keys.yml
+++ b/rules/credential_access_suspicious_access_to_windows_dpapi_master_keys.yml
@@ -1,6 +1,6 @@
 name: Suspicious access to Windows DPAPI Master Keys
 id: b1d5732a-5ad4-4cdd-8791-c22e34c591e5
-version: 1.0.1
+version: 1.0.2
 description: |
   Detects suspicious processes accessing the Windows Data Protection API Master keys
   which is a sign of potential credential stealing.
@@ -33,8 +33,7 @@ condition: >
       '?:\\Users\\*\\AppData\\*\\Microsoft\\Protect\\S-1-12-1-*\\*'
     )
     and
-    not
-  ps.exe imatches
+  ps.exe not imatches
     (
       '?:\\Program Files\\*',
       '?:\\Program Files(x86)\\*',

--- a/rules/credential_access_suspicious_access_to_windows_manager_files.yml
+++ b/rules/credential_access_suspicious_access_to_windows_manager_files.yml
@@ -1,6 +1,6 @@
 name: Suspicious access to Windows Credential Manager files
 id: 4ab688f7-94e2-481b-9c7f-c49f3a79a379
-version: 1.0.1
+version: 1.0.2
 description: |
   Identifies suspicious processes trying to acquire credentials from the Windows Credential Manager.
 labels:
@@ -23,8 +23,7 @@ condition: >
       '?:\\Windows\\System32\\config\\systemprofile\\AppData\\*\\Microsoft\\Credentials\\*'
     )
     and
-    not
-  ps.exe imatches
+  ps.exe not imatches
     (
       '?:\\Program Files\\*',
       '?:\\Program Files(x86)\\*',

--- a/rules/credential_access_suspicious_access_to_windows_vault_files.yml
+++ b/rules/credential_access_suspicious_access_to_windows_vault_files.yml
@@ -1,6 +1,6 @@
 name: Suspicious access to Windows Vault files
 id: 44400221-f98d-424a-9388-497c75b18924
-version: 1.0.1
+version: 1.0.2
 description: |
   Identifies attempts from adversaries to acquire credentials from Vault files.
 labels:
@@ -25,8 +25,7 @@ condition: >
     and
   file.extension in vault_extensions
     and
-    not
-  ps.exe imatches
+  ps.exe not imatches
     (
       '?:\\Program Files\\*',
       '?:\\Program Files(x86)\\*',

--- a/rules/credential_access_unusual_access_to_ssh_keys.yml
+++ b/rules/credential_access_unusual_access_to_ssh_keys.yml
@@ -1,6 +1,6 @@
 name: Unusual access to SSH keys
 id: 90f5c1bd-abd6-4d1b-94e0-229f04473d60
-version: 1.0.2
+version: 1.0.3
 description: |
   Identifies access by unusual process to saved SSH keys.
 labels:
@@ -17,8 +17,7 @@ labels:
 condition: >
   open_file and file.path imatches '?:\\Users\\*\\.ssh\\known_hosts'
     and
-    not
-  ps.exe imatches
+  ps.exe not imatches
     (
       '?:\\Program Files\\*',
       '?:\\Program Files(x86)\\*',
@@ -26,8 +25,7 @@ condition: >
       '?:\\Windows\\System32\\svchost.exe'
     )
     and
-    not
-  ps.name imatches
+  ps.name not imatches
     (
       'PuTTYNG.exe',
       'putty*.exe',

--- a/rules/credential_access_unusual_access_to_windows_credential_history.yml
+++ b/rules/credential_access_unusual_access_to_windows_credential_history.yml
@@ -1,6 +1,6 @@
 name: Unusual access to Windows Credential history files
 id: 9d94062f-2cf3-407c-bd65-4072fe4b167f
-version: 1.0.2
+version: 1.0.3
 description: |
   Detects unusual accesses to the Windows Credential history file.
   The CREDHIST file contains all previous password-linked master key hashes used by
@@ -20,8 +20,7 @@ labels:
 condition: >
   open_file and file.path imatches '?:\\Users\\*\\AppData\\*\\Microsoft\\Protect\\CREDHIST'
     and
-    not
-  ps.exe imatches
+  ps.exe not imatches
     (
       '?:\\Program Files\\*',
       '?:\\Windows\\System32\\lsass.exe',

--- a/rules/defense_evasion_dll_loaded_via_ldrpkernel32_overwrite.yml
+++ b/rules/defense_evasion_dll_loaded_via_ldrpkernel32_overwrite.yml
@@ -1,6 +1,6 @@
 name: DLL loaded via LdrpKernel32 overwrite
 id: 56739eda-210f-4a30-a114-d55ca60976df
-version: 1.0.0
+version: 1.0.1
 description: |
   Detects attempts to bypass the standard NTDLL bootstrap process by loading a malicious DLL early through hijacking. 
   The malicious DLL, containing attacker-controlled code, is loaded in place of the legitimate kernel32 DLL.
@@ -20,14 +20,15 @@ references:
 condition: >
   (load_unsigned_or_untrusted_dll) and thread.callstack.symbols imatches ('*!BaseThreadInitThunk*')
     and
+  image.path not imatches '?:\\Windows\\assembly\\NativeImages_*\\System.Numerics.ni.dll'
+    and
     not
   foreach(thread._callstack, $frame, 
           $frame.symbol imatches ('?:\\Windows\\System32\\kernel32.dll!BaseThreadInitThunk*',
                                   '?:\\Windows\\SysWOW64\\kernel32.dll!BaseThreadInitThunk*',
                                   '?:\\Windows\\WinSxS\\*\\kernel32.dll!BaseThreadInitThunk*',
                                   '?:\\Windows\\WinSxS\\Temp\\PendingDeletes\\*!BaseThreadInitThunk*',
-                                  '\\Device\\*\\Windows\\*\\kernel32.dll!BaseThreadInitThunk*')) and
-  not image.path imatches '?:\\Windows\\assembly\\NativeImages_*\\System.Numerics.ni.dll'
+                                  '\\Device\\*\\Windows\\*\\kernel32.dll!BaseThreadInitThunk*'))
 action:
   - name: kill
 

--- a/rules/defense_evasion_dotnet_assembly_loaded_by_unmanaged_process.yml
+++ b/rules/defense_evasion_dotnet_assembly_loaded_by_unmanaged_process.yml
@@ -1,6 +1,6 @@
 name: .NET assembly loaded by unmanaged process
 id: 34be8bd1-1143-4fa8-bed4-ae2566b1394a
-version: 1.0.4
+version: 1.0.5
 description: |
   Identifies the loading of the .NET assembly by an unmanaged process. Adversaries can load the CLR runtime
   inside unmanaged process and execute the assembly via the ICLRRuntimeHost::ExecuteInDefaultAppDomain method.
@@ -20,16 +20,14 @@ condition: >
     and
   (image.is_dotnet or thread.callstack.modules imatches ('*clr.dll'))
     and
-    not
-  image.path imatches
+  image.path not imatches
     (
       '?:\\Windows\\assembly\\*\\*.ni.dll',
       '?:\\Program Files\\WindowsPowerShell\\Modules\\*\\*.dll',
       '?:\\Windows\\Microsoft.NET\\assembly\\*\\*.dll'
     )
     and
-    not
-  ps.exe imatches
+  ps.exe not imatches
     (
       '?:\\Program Files\\WindowsApps\\*\\CrossDeviceService.exe',
       '?:\\Windows\\Microsoft.NET\\Framework\\*\\mscorsvw.exe'

--- a/rules/defense_evasion_hidden_registry_key_creation.yml
+++ b/rules/defense_evasion_hidden_registry_key_creation.yml
@@ -1,6 +1,6 @@
 name: Hidden registry key creation
 id: 65deda38-9b1d-42a0-9f40-a68903e81b49
-version: 1.1.2
+version: 1.1.3
 description: |
   Identifies the creation of a hidden registry key. Adversaries can utilize the
   native NtSetValueKey API to create a hidden registry key and conceal payloads
@@ -22,8 +22,7 @@ condition: >
     and
   thread.callstack.symbols not imatches ('KernelBase.dll!RegSetValue*', 'KernelBase.dll!RegLoadAppKey*', 'KernelBase.dll!GetFileAttributes*')
     and
-    not
-  ps.exe imatches
+  ps.exe not imatches
     (
       '?:\\Program Files (x86)\\Microsoft\\EdgeUpdate\\MicrosoftEdgeUpdate.exe',
       '?:\\Program Files\\Microsoft\\EdgeUpdate\\MicrosoftEdgeUpdate.exe',

--- a/rules/defense_evasion_potential_injection_via_dotnet_debugging.yml
+++ b/rules/defense_evasion_potential_injection_via_dotnet_debugging.yml
@@ -1,6 +1,6 @@
 name: Potential injection via .NET debugging
 id: 193ebf2f-e365-4f57-a639-275b7cdf0319
-version: 1.0.1
+version: 1.0.2
 description: |
   Identifies creation of a process on behalf of the CLR debugging facility which may
   be indicative of code injection. The CLR interface utilizes the OpenVirtualProcess
@@ -19,8 +19,7 @@ references:
 condition: >
   spawn_process and ps.exe != '' and thread.callstack.symbols imatches ('mscordbi.dll!OpenVirtualProcess')
     and
-    not
-  ps.child.exe imatches
+  ps.child.exe not imatches
     (
       '?:\\Visual Studio\\Common?\\IDE\\devenv.exe',
       '?:\\Program Files\\Microsoft Visual Studio\\*.exe',
@@ -28,7 +27,7 @@ condition: >
       '?:\\Program Files\\IIS Express\\iisexpress.exe',
       '?:\\Program Files (x86)\\IIS Express\\iisexpress.exe'
     )
-  and not ps.exe imatches '?:\\Program Files (x86)\\Microsoft Visual Studio\\*.exe'
+  and ps.exe not imatches '?:\\Program Files (x86)\\Microsoft Visual Studio\\*.exe'
 
 output: >
   Process %ps.exe attached the .NET debugger to process %ps.child.exe for potential code injection

--- a/rules/defense_evasion_potential_process_hollowing_injection.yml
+++ b/rules/defense_evasion_potential_process_hollowing_injection.yml
@@ -1,6 +1,6 @@
 name: Potential Process Hollowing
 id: 2a3fbae8-5e8c-4b71-b9da-56c3958c0d53
-version: 1.1.3
+version: 1.1.4
 description: |
   Adversaries may inject malicious code into suspended and hollowed processes in order to
   evade process-based defenses. Process hollowing is a method of executing arbitrary code
@@ -29,7 +29,7 @@ references:
 condition: >
   sequence
   maxspan 2m
-    |spawn_process and ps.sid not in ('S-1-5-18', 'S-1-5-19', 'S-1-5-20') and not ps.exe imatches 
+    |spawn_process and ps.sid not in ('S-1-5-18', 'S-1-5-19', 'S-1-5-20') and ps.exe not imatches 
       (
         '?:\\Program Files\\*.exe', 
         '?:\\Program Files (x86)\\*.exe',

--- a/rules/defense_evasion_potential_process_injection_via_tainted_memory_section.yml
+++ b/rules/defense_evasion_potential_process_injection_via_tainted_memory_section.yml
@@ -1,6 +1,6 @@
 name: Potential process injection via tainted memory section
 id: 8e4182f3-02e7-4e95-afc3-93d18c9a9c09
-version: 1.0.1
+version: 1.0.2
 description: |
   Identifies potential process injection when the adversary creates and maps a memory
   section with RW protection rights followed by mapping of the same memory section in
@@ -22,7 +22,7 @@ references:
 condition: >
   sequence
   maxspan 1m
-    |map_view_of_section and file.view.protection = 'READWRITE' and kevt.pid != 4 and file.view.size >= 4096 and not ps.exe imatches 
+    |map_view_of_section and file.view.protection = 'READWRITE' and kevt.pid != 4 and file.view.size >= 4096 and ps.exe not imatches 
       (
         '?:\\Program Files\\*.exe', 
         '?:\\Program Files (x86)\\*.exe',

--- a/rules/defense_evasion_potential_thread_execution_hijacking.yml
+++ b/rules/defense_evasion_potential_thread_execution_hijacking.yml
@@ -1,6 +1,6 @@
 name: Potential thread execution hijacking
 id: 8b9f6d47-e9ba-4b3a-9da2-d7bf27e08ca9
-version: 1.0.0
+version: 1.0.1
 description: |
   Adversaries may inject malicious code into hijacked processes in order to evade process-based
   defenses as well as possibly elevate privileges. Thread Execution Hijacking is a method of
@@ -30,7 +30,7 @@ condition: >
   sequence
   maxspan 2m
   by ps.uuid
-    |open_remote_thread and thread.access.mask.names in ('ALL_ACCESS', 'SUSPEND_THREAD') and not ps.exe imatches
+    |open_remote_thread and thread.access.mask.names in ('ALL_ACCESS', 'SUSPEND_THREAD') and ps.exe not imatches
       (
         '?:\\Program Files\\*',
         '?:\\Program Files (x86)\\*'

--- a/rules/defense_evasion_process_execution_from_self_deleting_binary.yml
+++ b/rules/defense_evasion_process_execution_from_self_deleting_binary.yml
@@ -1,6 +1,6 @@
 name: Process execution from a self-deleting binary
 id: 0f0da517-b22c-4d14-9adc-36baeb621cf7
-version: 1.0.2
+version: 1.0.3
 description: |
   Identifies the execution of the process from a self-deleting binary. The attackers can
   abuse undocumented API functions to create a process from a file-backed section. The file 
@@ -22,21 +22,18 @@ condition: >
   maxspan 1m 
     |delete_file and file.info.is_disposition_delete_file
       and
-      not
-     ps.exe imatches 
+     ps.exe not imatches 
       (
         '?:\\$WINDOWS.~BT\\Sources\\SetupHost.exe',
         '?:\\WINDOWS\\uus\\packages\\preview\\*\\wuaucltcore.exe'
       )
       and 
-      not
-     ps.cmdline imatches 
+     ps.cmdline not imatches 
       (
         '?:\\Windows\\system32\\svchost.exe -k wsappx -p -s AppXSvc'
       )
-      and
-      not 
-     file.path imatches 
+      and 
+     file.path not imatches 
       (
         '?:\\Windows\\SoftwareDistribution\\Download\\*',
         '?:\\Windows\\uus\\packages\\preview\\*'

--- a/rules/defense_evasion_process_spawned_via_remote_thread.yml
+++ b/rules/defense_evasion_process_spawned_via_remote_thread.yml
@@ -1,6 +1,6 @@
 name: Process spawned via remote thread
 id: 9a2c7b40-4e5f-4edf-b02e-79cd33c9a137
-version: 1.0.1
+version: 1.0.2
 description: |
   Identifies the creation of a process with the parent call stack not
   revealing normal API functions for process creation. This may be a
@@ -18,8 +18,7 @@ condition: >
     and
   thread.callstack.symbols imatches ('ntdll.dll!ZwCreateThreadEx*', 'ntdll.dll!NtCreateThreadEx*', 'ntdll.dll!RtlCreateUserThread')
     and
-    not
-  thread.callstack.symbols imatches ('*CreateProcess*', '*CreateUserProcess*')
+  thread.callstack.symbols not imatches ('*CreateProcess*', '*CreateUserProcess*')
 action:
   - name: kill
 

--- a/rules/defense_evasion_regsvr32_scriptlet_execution.yml
+++ b/rules/defense_evasion_regsvr32_scriptlet_execution.yml
@@ -1,6 +1,6 @@
 name: Regsvr32 scriptlet execution
 id: 128f5254-67c9-43ac-b901-18b3731b1d0b
-version: 1.0.0
+version: 1.0.1
 description: |
   Identifies the execution of a scriptlet file by regsvr32.exe process. regsvr32.exe
   allows attackers to run arbitrary scripts to proxy execution of malicious code.
@@ -61,8 +61,7 @@ condition: >
     )
   )
     and
-    not
-  ps.child.exe imatches
+  ps.child.exe not imatches
     (
       '?:\\Program Files\\*.exe',
       '?:\\Program Files (x86)\\*.exe'

--- a/rules/defense_evasion_suspicious_access_to_the_hosts_file.yml
+++ b/rules/defense_evasion_suspicious_access_to_the_hosts_file.yml
@@ -1,6 +1,6 @@
 name: Suspicious access to the hosts file
 id: f7b2c9d3-99e7-41d5-bb4a-6ea1a5f7f9e2
-version: 1.0.0
+version: 1.0.1
 description: >
   Identifies suspicious process accessing the Windows hosts file for potential tampering.
   Adversaries can hijack the hosts files to block traffic to download/update servers or redirect the
@@ -18,7 +18,7 @@ references:
 condition: >
   sequence
   maxspan 5m
-    |spawn_process and not ps.child.exe imatches 
+    |spawn_process and ps.child.exe not imatches 
       (
         '?:\\Windows\\servicing\\TrustedInstaller.exe',
         '?:\\Windows\\System32\\svchost.exe',

--- a/rules/defense_evasion_suspicious_html_application_script_execution.yml
+++ b/rules/defense_evasion_suspicious_html_application_script_execution.yml
@@ -1,6 +1,6 @@
 name: Suspicious HTML Application script execution
 id: 4ec64ac2-851d-41b4-b7d2-910c21de334d
-version: 1.0.0
+version: 1.0.1
 description: |  
   Identifies the execution of scripts via Microsoft HTML Application Host interpreter. Adversaries 
   can proxy the execution of arbitrary script code through a trusted, signed utility to evade defenses.
@@ -49,8 +49,7 @@ condition: >
       '*.xls*'
     )
     and
-    not
-  ps.exe imatches
+  ps.exe not imatches
     (
       '?:\\Program Files (x86)\\Microsoft Office\\Office*\\MSACCESS.EXE'
     )

--- a/rules/defense_evasion_suspicious_object_symbolic_link_creation.yml
+++ b/rules/defense_evasion_suspicious_object_symbolic_link_creation.yml
@@ -1,6 +1,6 @@
 name: Suspicious object symbolic link creation
 id: f9306355-1f5f-4a06-9779-195aa681db80
-version: 1.0.0
+version: 1.0.1
 description: |
   Identifies the creation of the object symbolic link inside the object manager namespace
   by untrusted or unusual processes.
@@ -20,7 +20,7 @@ references:
 condition: >
   create_symbolic_link_object and kevt.pid != 4 
     and 
-  (pe.is_signed = false or pe.is_trusted = false or not ps.exe imatches
+  (pe.is_signed = false or pe.is_trusted = false or ps.exe not imatches
     (
       '?:\\ProgramData\\Microsoft\\Windows Defender\\*\\MsMpEng.exe',
       '?:\\WINDOWS\\system32\\svchost.exe',

--- a/rules/defense_evasion_suspicious_xsl_script_execution.yml
+++ b/rules/defense_evasion_suspicious_xsl_script_execution.yml
@@ -1,6 +1,6 @@
 name: Suspicious XSL script execution
 id: 65136b30-14ae-46dd-b8e5-9dfa99690d74
-version: 1.0.0
+version: 1.0.1
 description: |
   Identifies a suspicious execution of XSL script via Windows Management Instrumentation command line tool or XSL
   transformation utility. Adversaries may bypass application control and obscure the execution of code by embedding 
@@ -22,8 +22,7 @@ condition: >
     |spawn_process and (((ps.child.name ~= 'wmic.exe' or ps.child.pe.file.name ~= 'wmic.exe') and ps.child.cmdline imatches
       ('* format*:*', '*/format*:*', '*-format*:*')
         and
-        not
-      ps.child.cmdline imatches
+      ps.child.cmdline not imatches
         (
           '*format:list*',
           '*format:htable*',

--- a/rules/defense_evasion_system_binary_proxy_execution_via_rundll32.yml
+++ b/rules/defense_evasion_system_binary_proxy_execution_via_rundll32.yml
@@ -1,6 +1,6 @@
 name: System Binary Proxy Execution via Rundll32
 id: 43d76718-cc46-485e-8f47-996eb7a9f83b
-version: 1.0.0
+version: 1.0.1
 description: |
   Detects the execution of rundll32.exe process with suspicious command line
   followed by the creation of a possibly malicious child process.
@@ -54,10 +54,7 @@ condition: >
       regex(ps.child.cmdline, '(?i)[A-Z]:\\\\.+:.+$')
      )
     | by ps.child.uuid
-    |spawn_process
-      and
-      not
-     ps.child.exe imatches
+    |spawn_process and ps.child.exe not imatches
       (
         '?:\\Program Files\\*.exe',
         '?:\\Program Files (x86)\\*.exe'

--- a/rules/defense_evasion_thread_context_set_from_unbacked_memory.yml
+++ b/rules/defense_evasion_thread_context_set_from_unbacked_memory.yml
@@ -1,6 +1,6 @@
 name: Thread context set from unbacked memory
 id: f8219274-ee68-416b-8489-4d2e635c7844
-version: 1.0.2
+version: 1.0.3
 description: |
   Identifies manipulation of the thread context from unbacked memory region. This may be
   indicative of process injection.
@@ -15,8 +15,7 @@ labels:
 condition: >
   set_thread_context and thread.callstack.summary imatches ('ntdll.dll|kernelbase.dll|unbacked')
     and
-    not
-  ps.exe imatches
+  ps.exe not imatches
     (
       '?:\\Program Files\\Git\\mingw64\\bin\\git.exe',
       '?:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe',

--- a/rules/defense_evasion_unsigned_dll_injection_via_remote_thread.yml
+++ b/rules/defense_evasion_unsigned_dll_injection_via_remote_thread.yml
@@ -1,6 +1,6 @@
 name: Unsigned DLL injection via remote thread
 id: 21bdd944-3bda-464b-9a72-58fd37ba9163
-version: 1.1.0
+version: 1.1.1
 description: |
   Identifies unsigned DLL injection via remote thread creation.
   Adversaries may inject dynamic-link libraries (DLLs) into processes in order to evade process-based defenses
@@ -35,8 +35,7 @@ condition: >
     | by thread.pid
     |(load_unsigned_or_untrusted_dll)
       and
-      not
-     image.path imatches
+     image.path not imatches
       (
         '?:\\Program Files\\Git\\mingw64\\bin\\*.dll',
         '?:\\Windows\\assembly\\*\\*.ni.dll',

--- a/rules/initial_access_macro_execution_via_script_interpreter.yml
+++ b/rules/initial_access_macro_execution_via_script_interpreter.yml
@@ -1,6 +1,6 @@
 name: Macro execution via script interpreter
 id: 845404de-df6f-472f-bd74-72148a7f5166
-version: 1.0.1
+version: 1.0.2
 description: |
   Identifies the execution of the Windows scripting interpreter spawning
   a Microsoft Office process to execute suspicious Visual Basic macro.
@@ -23,8 +23,8 @@ condition: >
       and
      (spawn_process or (create_remote_thread) or (modify_registry) or (create_file)
         or
-      (load_module and not image.name imatches ('?:\\Program Files\\*', '?:\\Program Files (x86)\\*'))
+      (load_module and image.path not imatches ('?:\\Program Files\\*', '?:\\Program Files (x86)\\*'))
      )
     | by ps.uuid
 
-min-engine-version: 2.2.0
+min-engine-version: 2.4.0

--- a/rules/initial_access_potential_clickfix_infection_chain_via_run_window.yml
+++ b/rules/initial_access_potential_clickfix_infection_chain_via_run_window.yml
@@ -1,6 +1,6 @@
 name: Potential ClickFix infection chain via Run window
 id: ffe1fc54-2893-4760-ab50-51a83bd71d13
-version: 1.0.0
+version: 1.0.1
 description: |
   Identifies the execution of the process via the Run command dialog box followed by spawning of the potential 
   infostealer process. 
@@ -32,7 +32,7 @@ condition: >
       (thread.callstack.summary imatches '*shell32.dll|explorer.exe|*' and thread.callstack.symbols imatches ('*shell32.dll!GetFileNameFromBrowse*'))
      )
     | by ps.child.uuid
-    |spawn_process and not ps.child.exe imatches 
+    |spawn_process and ps.child.exe not imatches 
       (
         '?:\\Program Files\\*.exe',
         '?:\\Program Files (x86)\\*.exe',

--- a/rules/initial_access_process_spawned_from_macro_enabled_microsoft_office_document.yml
+++ b/rules/initial_access_process_spawned_from_macro_enabled_microsoft_office_document.yml
@@ -1,6 +1,6 @@
 name: Process spawned from macro-enabled Microsoft Office document
 id: 47521206-e19d-4608-9dbc-dc3a1df99db5
-version: 1.0.1
+version: 1.0.2
 description: |
   Identifies the execution of the child process spawned by Microsoft
   Office parent process where the call stack contains the Visual Basic
@@ -33,8 +33,7 @@ condition: >
       )
   )
     and
-    not
-  ps.child.exe imatches
+  ps.child.exe not imatches
     (
       '?:\\Windows\\explorer.exe',
       '?:\\Windows\\hh.exe',

--- a/rules/persistence_rid_hijacking.yml
+++ b/rules/persistence_rid_hijacking.yml
@@ -1,6 +1,6 @@
 name: RID Hijacking
 id: 5c25666a-4a9f-4b7c-b02f-db0b5cdbde83
-version: 1.0.1
+version: 1.0.2
 description: |
   RID (Relative ID part of security identifier) hijacking allows an attacker with SYSTEM
   level privileges to covertly replace the RID of a low privileged account effectively making
@@ -21,7 +21,6 @@ condition: >
     and
   ps.sid in ('S-1-5-18', 'S-1-5-19', 'S-1-5-20')
     and
-    not
-  ps.exe imatches '?:\\Windows\\System32\\lsass.exe'
+  ps.exe not imatches '?:\\Windows\\System32\\lsass.exe'
 
 min-engine-version: 2.4.0

--- a/rules/persistence_suspicious_microsoft_office_template.yml
+++ b/rules/persistence_suspicious_microsoft_office_template.yml
@@ -1,6 +1,6 @@
 name: Suspicious Microsoft Office template
 id: c4be3b30-9d23-4a33-b974-fb12e17487a2
-version: 1.0.1
+version: 1.0.2
 description: |
   Detects when attackers drop macro-enabled files in specific
   folders to trigger their execution every time the victim user
@@ -30,11 +30,9 @@ condition: >
       '?:\\Users\\*\\AppData\\Roaming\\Microsoft\\Outlook\\*.otm'
     )
     and
-    not
-  ps.name iin msoffice_binaries
+  ps.name not iin msoffice_binaries
     and
-    not
-  ps.exe imatches
+  ps.exe not imatches
     (
       '?:\\Program Files\\*.exe',
       '?:\\Program Files (x86)\\*.exe'

--- a/rules/persistence_unusual_file_written_in_startup_folder.yml
+++ b/rules/persistence_unusual_file_written_in_startup_folder.yml
@@ -1,6 +1,6 @@
 name: Unusual file written in Startup folder
 id: c5ffe15c-d94f-416b-bec7-c47f89843267
-version: 1.0.1
+version: 1.0.2
 description: |
   Identifies suspicious files written to the startup folder that would
   allow adversaries to maintain persistence on the endpoint.
@@ -26,8 +26,7 @@ condition: >
     and
   file.path imatches startup_locations
     and
-    not
-  ps.exe imatches
+  ps.exe not imatches
     (
       '?:\\Windows\\System32\\wuauclt.exe',
       '?:\\Windows\\System32\\msiexec.exe',

--- a/rules/persistence_unusual_process_modified_registry_run_key.yml
+++ b/rules/persistence_unusual_process_modified_registry_run_key.yml
@@ -1,6 +1,6 @@
 name: Unusual process modified registry run key
 id: 921508a5-b627-4c02-a295-6c6863c0897b
-version: 1.0.3
+version: 1.0.4
 description: |
   Identifies an attempt by unusual Windows native processes to modify
   the run key and gain persistence on users logons or machine reboots.
@@ -20,8 +20,7 @@ condition: >
     and
   registry.path imatches registry_run_keys
     and
-    not
-  ps.exe imatches
+  ps.exe not imatches
     (
       '?:\\Windows\\System32\\svchost.exe',
       '?:\\Windows\\SysWOW64\\msiexec.exe',

--- a/rules/privilege_escalation_potential_privilege_escalation_via_phantom_dll_hijacking.yml
+++ b/rules/privilege_escalation_potential_privilege_escalation_via_phantom_dll_hijacking.yml
@@ -1,6 +1,6 @@
 name: Potential privilege escalation via phantom DLL hijacking
 id: 5ccdb5c2-3a30-4e14-87d2-d7aeb4c45fad
-version: 1.0.2
+version: 1.0.3
 description: |
   Identifies the loading of the phantom DLL that was previously dropped
   to the System directory. Adversaries may exploit this flow to escalate
@@ -44,9 +44,8 @@ condition: >
         '?:\\Windows\\System32\\Speech\\Engines\\TTS\\MSTTSLocEnUS.dll',
         '?:\\Windows\\System32\\DXGIDebug.dll'
       )
-      and 
-      not 
-     ps.exe imatches
+      and  
+     ps.exe not imatches
       (
         '?:\\Windows\\System32\\RuntimeBroker.exe',
         '?:\\Windows\\System32\\svchost.exe',


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

The `not` operator has two variants. If used in front of
other operator it negates its evaluation.
If used in front of the binary expression, it negates
the entire expression. When not used adequately, it can
lead to issues, such as erroneous rule matching. To mitigate this misbehaviour, it is better to standardize the
usage of the `not` operator and if meant to solely negate
the result of the adjacent operator, use the `lhs not operator rhs` pattern.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
