### PR TITLE
fix(ps): Spurious process executable override

### DIFF
--- a/pkg/ps/snapshotter_windows.go
+++ b/pkg/ps/snapshotter_windows.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/sys/windows"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -228,7 +229,10 @@ func (s *snapshotter) AddModule(e *kevent.Kevent) error {
 	module.SignatureLevel, _ = e.Kparams.GetUint32(kparams.ImageSignatureLevel)
 	module.SignatureType, _ = e.Kparams.GetUint32(kparams.ImageSignatureType)
 
-	if module.IsExecutable() && len(proc.Exe) < len(module.Name) {
+	if strings.EqualFold(proc.Name, filepath.Base(module.Name)) && len(proc.Exe) < len(module.Name) {
+		// if the module is loaded for the process executable, and
+		// we don't have the full executable path, override with
+		// the one from the image path
 		proc.Exe = module.Name
 	}
 


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

If the module is loaded for the process executable, and we don't have the full executable path, override it with the one from the image path if it corresponds to the process executable

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

/area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
