### PR TITLE
fix(rules): Use `ps.name` field in `Macro execution via script interpreter` rule

### DIFF
--- a/rules/initial_access_macro_execution_via_script_interpreter.yml
+++ b/rules/initial_access_macro_execution_via_script_interpreter.yml
@@ -1,6 +1,6 @@
 name: Macro execution via script interpreter
 id: 845404de-df6f-472f-bd74-72148a7f5166
-version: 1.0.2
+version: 1.0.3
 description: |
   Identifies the execution of the Windows scripting interpreter spawning
   a Microsoft Office process to execute suspicious Visual Basic macro.
@@ -18,7 +18,7 @@ labels:
 condition: >
   sequence
   maxspan 5m
-    |spawn_process and ps.parent.name iin script_interpreters and ps.child.name iin msoffice_binaries| by ps.child.uuid
+    |spawn_process and ps.name iin script_interpreters and ps.child.name iin msoffice_binaries| by ps.child.uuid
     |ps.name iin msoffice_binaries and thread.callstack.modules imatches '*vbe?.dll'
       and
      (spawn_process or (create_remote_thread) or (modify_registry) or (create_file)


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

The condition on whether the Microsoft Office process is spawned by the script interpreter should be evaluated on the `ps.name` field.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
