### PR TITLE
feat(rules): New `DLL Side-Loading via Microsoft Office dropped file` rule

### DIFF
--- a/rules/defense_evasion_dll_sideloading_via_microsoft_office_dropped_file.yml
+++ b/rules/defense_evasion_dll_sideloading_via_microsoft_office_dropped_file.yml
@@ -1,0 +1,39 @@
+name: DLL Side-Loading via Microsoft Office dropped file
+id: d808175d-c4f8-459d-b17f-ca9a88890c04
+version: 1.0.0
+description: |
+  Identifies Microsoft Office process creating a DLL or other variant of an executable object which
+  is later loaded by a trusted binary. Adversaries may exploit this behavior by delivering malicious 
+  modules via Microsoft Office documents.
+labels:
+  tactic.id: TA0005
+  tactic.name: Defense Evasion
+  tactic.ref: https://attack.mitre.org/tactics/TA0005/
+  technique.id: T1574
+  technique.name: Hijack Execution Flow
+  technique.ref: https://attack.mitre.org/techniques/T1574/
+  subtechnique.id: T1574.002
+  subtechnique.name: DLL Side-Loading
+  subtechnique.ref: https://attack.mitre.org/techniques/T1574/002/
+
+condition: >
+  sequence
+  maxspan 6m
+    |create_file and (file.extension iin ('.dll', '.cpl', '.ocx') or file.is_dll) and ps.name iin msoffice_binaries| by file.path
+    |(load_unsigned_or_untrusted_dll) and pe.is_signed = true and ps.name not iin msoffice_binaries
+      and
+     image.path not imatches '?:\\Windows\\assembly\\NativeImages_*'
+      and
+     ps.exe not imatches
+      (
+        '?:\\Windows\\System32\\msiexec.exe',
+        '?:\\Windows\\SysWOW64\\msiexec.exe',
+        '?:\\Windows\\System32\\spoolsv.exe'
+      )
+    | by image.path
+
+output: >
+  Suspicious DLL %1.file.path dropped by Microsoft Office process %1.ps.exe and subsequently loaded by process %2.ps.exe
+severity: high
+
+min-engine-version: 2.4.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Identifies Microsoft Office process creating a DLL or other variant of an executable object which is later loaded by a trusted binary. Adversaries may exploit this behavior by delivering malicious modules via Microsoft Office documents.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
