### PR TITLE
chore(build): Initialize version variable to dev  if unset

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,6 @@ $ dotnet tool install --global wix --version 5.0.0
 Now use the `pkg` target from the `./make.bat` script to build the MSI package.
 
 ```
-$ $env:VERSION="0.0.0"
 $ ./make.bat pkg
 ```
 

--- a/make.bat
+++ b/make.bat
@@ -22,6 +22,10 @@ set GOTEST=go test -timeout=10m -v -gcflags=all=-d=checkptr=0
 set GOFMT=gofmt -e -s -l -w
 set GOLINT=%GOBIN%\golangci-lint
 
+if NOT DEFINED VERSION (
+    set VERSION="0.0.0"
+)
+
 FOR /F "tokens=* USEBACKQ" %%F IN (`powershell -Command get-date -format "{dd-MM-yyyy.HH:mm:ss}"`) DO (
     SET BUILD_DATE=%%F
 )


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Initialize the `VERSION` variable to `0.0.0` (dev) if it is not provided.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

/area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
