### PR TITLE
perf(rule-engine): More efficient filter indexing

### DIFF
--- a/pkg/event/category.go
+++ b/pkg/event/category.go
@@ -19,6 +19,7 @@
 package event
 
 import (
+	"github.com/bits-and-blooms/bitset"
 	"github.com/rabbitstack/fibratus/pkg/util/hashers"
 )
 
@@ -67,6 +68,56 @@ const (
 // Hash obtains the hash of the category string.
 func (c Category) Hash() uint32 {
 	return hashers.FnvUint32([]byte(c))
+}
+
+// CategoryMasks allows setting and checking the category bit mask.
+type CategoryMasks struct {
+	bs bitset.BitSet
+}
+
+// Set sets the category bit in the bit mask.
+func (m *CategoryMasks) Set(c Category) {
+	m.bs.Set(uint(c.Index()))
+}
+
+// Test checks if the given category bit is set.
+func (m *CategoryMasks) Test(c Category) bool {
+	return m.bs.Test(uint(c.Index()))
+}
+
+// MaxCategoryIndex designates the maximum category index.
+const MaxCategoryIndex = 13
+
+// Index returns a numerical category index.
+func (c Category) Index() uint8 {
+	switch c {
+	case Registry:
+		return 1
+	case File:
+		return 2
+	case Net:
+		return 3
+	case Process:
+		return 4
+	case Thread:
+		return 5
+	case Image:
+		return 6
+	case Handle:
+		return 7
+	case Driver:
+		return 8
+	case Mem:
+		return 9
+	case Object:
+		return 10
+	case Threadpool:
+		return 11
+	case Other:
+		return 12
+	default:
+		return MaxCategoryIndex
+	}
 }
 
 // Categories returns all available categories.

--- a/pkg/event/category_test.go
+++ b/pkg/event/category_test.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021-present by Nedim Sabic Sabic
+ * https://www.fibratus.io
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package event
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCategoryMasks(t *testing.T) {
+	var masks CategoryMasks
+	masks.Set(File)
+	masks.Set(Process)
+
+	assert.True(t, masks.Test(File))
+	assert.True(t, masks.Test(Process))
+	assert.False(t, masks.Test(Registry))
+}

--- a/pkg/rules/engine_test.go
+++ b/pkg/rules/engine_test.go
@@ -141,7 +141,8 @@ func TestCompileIndexableFilters(t *testing.T) {
 
 	compileRules(t, e)
 
-	assert.Len(t, e.filters, 3)
+	assert.Len(t, e.filters.types, 5)
+	assert.Len(t, e.filters.categories, 1)
 
 	var tests = []struct {
 		evt   *event.Event
@@ -156,17 +157,9 @@ func TestCompileIndexableFilters(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.evt.Type.String(), func(t *testing.T) {
-			assert.Len(t, e.filters.collect(e.hashCache, tt.evt), tt.wants)
+			assert.Len(t, e.filters.collect(tt.evt), tt.wants)
 		})
 	}
-
-	assert.Len(t, e.hashCache.types, 4)
-
-	evt := &event.Event{Type: event.RecvTCPv4}
-
-	h1, h2 := e.hashCache.typeHash(evt), e.hashCache.categoryHash(evt)
-	assert.Equal(t, uint32(0xfa4dab59), h1)
-	assert.Equal(t, uint32(0x811c9dc5), h2)
 }
 
 func TestRunSimpleRules(t *testing.T) {


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Move away from FNV hash-based filter indexing to two separate buckets - one for event type filters and one for category filters.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

/area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
