### PR TITLE
refactor(eventsource): Unified security telemetry logger session

### DIFF
--- a/internal/etw/source_test.go
+++ b/internal/etw/source_test.go
@@ -101,7 +101,7 @@ func TestEventSourceStartTraces(t *testing.T) {
 			1,
 			[]etw.EventTraceFlags{0x6018203, 0},
 		},
-		{"start kernel logger and audit api sessions",
+		{"start kernel and security telemetry logger sessions",
 			&config.Config{
 				EventSource: config.EventSourceConfig{
 					EnableThreadEvents:   true,

--- a/internal/etw/stackext.go
+++ b/internal/etw/stackext.go
@@ -38,9 +38,9 @@ func NewStackExtensions(config config.EventSourceConfig) *StackExtensions {
 }
 
 // AddStackTracing enables stack tracing for the specified event type.
-func (s *StackExtensions) AddStackTracing(Type event.Type) {
-	if !s.config.TestDropMask(Type) {
-		s.ids = append(s.ids, etw.NewClassicEventID(Type.GUID(), Type.HookID()))
+func (s *StackExtensions) AddStackTracing(typ event.Type) {
+	if !s.config.TestDropMask(typ) {
+		s.ids = append(s.ids, etw.NewClassicEventID(typ.GUID(), typ.HookID()))
 	}
 }
 
@@ -53,6 +53,9 @@ func (s *StackExtensions) AddStackTracingWith(guid windows.GUID, hookID uint16) 
 
 // EventIds returns all event types eligible for stack tracing.
 func (s *StackExtensions) EventIds() []etw.ClassicEventID { return s.ids }
+
+// Empty determines if this stack extensions has registered event identifiers.
+func (s *StackExtensions) Empty() bool { return len(s.ids) == 0 }
 
 // EnableProcessCallstack populates the stack identifiers
 // with event types eligible for emitting stack walk events

--- a/internal/etw/trace_test.go
+++ b/internal/etw/trace_test.go
@@ -20,7 +20,6 @@ package etw
 
 import (
 	"github.com/rabbitstack/fibratus/pkg/config"
-	"github.com/rabbitstack/fibratus/pkg/sys/etw"
 	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
@@ -37,7 +36,7 @@ func TestStartTrace(t *testing.T) {
 		},
 	}
 
-	trace := NewTrace(etw.KernelLoggerSession, etw.KernelTraceControlGUID, 0, cfg)
+	trace := NewKernelTrace(cfg)
 	require.NoError(t, trace.Start())
 	require.True(t, trace.IsStarted())
 	defer trace.Stop()

--- a/pkg/event/types_windows_test.go
+++ b/pkg/event/types_windows_test.go
@@ -128,9 +128,3 @@ func TestGUIDAndHookIDFromEventType(t *testing.T) {
 		})
 	}
 }
-
-func TestCanArriveOutOfOrder(t *testing.T) {
-	assert.False(t, RegSetValue.CanArriveOutOfOrder())
-	assert.False(t, VirtualAlloc.CanArriveOutOfOrder())
-	assert.True(t, OpenProcess.CanArriveOutOfOrder())
-}

--- a/pkg/filter/ql/parser_test.go
+++ b/pkg/filter/ql/parser_test.go
@@ -436,6 +436,12 @@ func TestIsSequenceUnordered(t *testing.T) {
 			`,
 			false,
 		},
+		{
+			`|evt.name = 'OpenProcess'| by ps.uuid
+			 |evt.name = 'QueryDns'| by ps.uuid
+			`,
+			false,
+		},
 	}
 
 	for i, tt := range tests {

--- a/pkg/sys/etw/types.go
+++ b/pkg/sys/etw/types.go
@@ -59,12 +59,8 @@ const (
 const (
 	// KernelLoggerSession represents the default session name for NT kernel logger
 	KernelLoggerSession = "NT Kernel Logger"
-	// KernelAuditAPICallsSession represents the session name for the kernel audit API logger
-	KernelAuditAPICallsSession = "Kernel Audit API Calls Logger"
-	// DNSClientSession represents the session name for the DNS client logger
-	DNSClientSession = "DNS Client Logger"
-	// ThreadpoolSession represents the session name for the thread pool logger
-	ThreadpoolSession = "Threadpool Logger"
+	// SecurityTelemetrySession represents the session name for all security telemetry
+	SecurityTelemetrySession = "Security Telemetry Logger"
 
 	// WnodeTraceFlagGUID indicates that the structure contains event tracing information
 	WnodeTraceFlagGUID = 0x00020000


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Unified security telemetry session serves as a container for the events published by all ETW providers except the core NT Kernel Logger provider. By enabling all providers inside the same session, we can preserve event ordering and save extra resources allocated for the ETW session buffers.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

/kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

/area instrumentation

/area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
