### PR TITLE
fix(bootstrap): Don't compile rules if filament is supplied

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -138,7 +138,7 @@ func NewApp(cfg *config.Config, options ...Option) (*App, error) {
 	var engine *rules.Engine
 	var rs *config.RulesCompileResult
 
-	if cfg.Filters.Rules.Enabled && !cfg.ForwardMode && !cfg.IsCaptureSet() {
+	if cfg.Filters.Rules.Enabled && !cfg.ForwardMode && !cfg.IsCaptureSet() && !cfg.IsFilamentSet() {
 		engine = rules.NewEngine(psnap, cfg)
 		var err error
 		rs, err = engine.Compile()
@@ -203,9 +203,8 @@ func (f *App) Run(args []string) error {
 	// In case of a regular run, we additionally set up the aggregator.
 	// The aggregator will grab the events from the queue, assemble them
 	// into batches and hand over to output sinks.
-	filamentName := cfg.Filament.Name
-	if filamentName != "" {
-		f.filament, err = filament.New(filamentName, f.psnap, f.hsnap, cfg)
+	if cfg.IsFilamentSet() {
+		f.filament, err = filament.New(cfg.Filament.Name, f.psnap, f.hsnap, cfg)
 		if err != nil {
 			return err
 		}
@@ -314,9 +313,9 @@ func (f *App) ReadCapture(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	filamentName := f.config.Filament.Name
-	if filamentName != "" {
-		f.filament, err = filament.New(filamentName, f.psnap, f.hsnap, f.config)
+
+	if f.config.IsFilamentSet() {
+		f.filament, err = filament.New(f.config.Filament.Name, f.psnap, f.hsnap, f.config)
 		if err != nil {
 			return err
 		}
@@ -355,6 +354,7 @@ func (f *App) ReadCapture(ctx context.Context, args []string) error {
 			return err
 		}
 	}
+
 	return api.StartServer(f.config)
 }
 

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -310,6 +310,9 @@ func (c *Config) Init() error {
 // in the capture file.
 func (c *Config) IsCaptureSet() bool { return c.CapFile != "" }
 
+// IsFilamentSet indicates if the filament is supplied.
+func (c *Config) IsFilamentSet() bool { return c.Filament.Name != "" }
+
 // TryLoadFile attempts to load the configuration file from specified path on the file system.
 func (c *Config) TryLoadFile(file string) error {
 	c.viper.SetConfigFile(file)


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

This PR introduces a change to avoid compiling the ruleset if Fibratus is instructed to run the filament.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

/area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
