### PR TITLE
refactor(bitset): Introduce `IsInitalized` method

### DIFF
--- a/pkg/event/bitset.go
+++ b/pkg/event/bitset.go
@@ -89,6 +89,15 @@ func (b *BitSets) IsBitSet(evt *Event) bool {
 		(b.cats != nil && b.cats.Test(uint(evt.Category.Index())))
 }
 
-func (b *BitSets) IsBitmaskInitialized() bool  { return b.bitmask != nil }
-func (b *BitSets) IsTypesInitialized() bool    { return b.types != nil }
-func (b *BitSets) IsCategoryInitialized() bool { return b.cats != nil }
+// IsInitialized checks if the given bitset type is initialized.
+func (b *BitSets) IsInitialized(bs BitSetType) bool {
+	switch bs {
+	case BitmaskBitSet:
+		return b.bitmask != nil
+	case TypeBitSet:
+		return b.types != nil
+	case CategoryBitSet:
+		return b.cats != nil
+	}
+	return false
+}

--- a/pkg/filter/ql/literal_test.go
+++ b/pkg/filter/ql/literal_test.go
@@ -34,9 +34,9 @@ func TestSequenceExprIsEvaluable(t *testing.T) {
 	}{
 		{"evt.name = 'CreateProcess'", &event.Event{Type: event.CreateProcess, Category: event.Process}, true,
 			func(t *testing.T, sexpr *SequenceExpr) {
-				assert.True(t, sexpr.bitsets.IsTypesInitialized())
-				assert.False(t, sexpr.bitsets.IsBitmaskInitialized())
-				assert.False(t, sexpr.bitsets.IsCategoryInitialized())
+				assert.True(t, sexpr.bitsets.IsInitialized(event.TypeBitSet))
+				assert.False(t, sexpr.bitsets.IsInitialized(event.BitmaskBitSet))
+				assert.False(t, sexpr.bitsets.IsInitialized(event.CategoryBitSet))
 			},
 		},
 		{"evt.name = 'CreateProcess'", &event.Event{Type: event.TerminateProcess, Category: event.Process}, false, nil},
@@ -44,37 +44,37 @@ func TestSequenceExprIsEvaluable(t *testing.T) {
 		{"evt.name = 'CreateProcess' or evt.category = 'object'", &event.Event{Type: event.TerminateProcess, Category: event.Process}, false, nil},
 		{"evt.name = 'CreateProcess' or evt.name = 'OpenProcess'", &event.Event{Type: event.OpenProcess, Category: event.Process}, true,
 			func(t *testing.T, sexpr *SequenceExpr) {
-				assert.True(t, sexpr.bitsets.IsTypesInitialized())
-				assert.False(t, sexpr.bitsets.IsBitmaskInitialized())
-				assert.False(t, sexpr.bitsets.IsCategoryInitialized())
+				assert.True(t, sexpr.bitsets.IsInitialized(event.TypeBitSet))
+				assert.False(t, sexpr.bitsets.IsInitialized(event.BitmaskBitSet))
+				assert.False(t, sexpr.bitsets.IsInitialized(event.CategoryBitSet))
 			},
 		},
 		{"evt.name = 'CreateProcess' or evt.name = 'CreateThread'", &event.Event{Type: event.CreateThread, Category: event.Thread}, true,
 			func(t *testing.T, sexpr *SequenceExpr) {
-				assert.False(t, sexpr.bitsets.IsTypesInitialized())
-				assert.True(t, sexpr.bitsets.IsBitmaskInitialized())
-				assert.False(t, sexpr.bitsets.IsCategoryInitialized())
+				assert.False(t, sexpr.bitsets.IsInitialized(event.TypeBitSet))
+				assert.True(t, sexpr.bitsets.IsInitialized(event.BitmaskBitSet))
+				assert.False(t, sexpr.bitsets.IsInitialized(event.CategoryBitSet))
 			},
 		},
 		{"evt.name = 'CreateProcess' or evt.category = 'registry'", &event.Event{Type: event.RegSetValue, Category: event.Registry}, true,
 			func(t *testing.T, sexpr *SequenceExpr) {
-				assert.True(t, sexpr.bitsets.IsTypesInitialized())
-				assert.False(t, sexpr.bitsets.IsBitmaskInitialized())
-				assert.True(t, sexpr.bitsets.IsCategoryInitialized())
+				assert.True(t, sexpr.bitsets.IsInitialized(event.TypeBitSet))
+				assert.False(t, sexpr.bitsets.IsInitialized(event.BitmaskBitSet))
+				assert.True(t, sexpr.bitsets.IsInitialized(event.CategoryBitSet))
 			},
 		},
 		{"evt.name = 'CreateProcess' or evt.name = 'OpenProcess' or evt.category = 'registry'", &event.Event{Type: event.OpenProcess, Category: event.Process}, true,
 			func(t *testing.T, sexpr *SequenceExpr) {
-				assert.True(t, sexpr.bitsets.IsTypesInitialized())
-				assert.False(t, sexpr.bitsets.IsBitmaskInitialized())
-				assert.True(t, sexpr.bitsets.IsCategoryInitialized())
+				assert.True(t, sexpr.bitsets.IsInitialized(event.TypeBitSet))
+				assert.False(t, sexpr.bitsets.IsInitialized(event.BitmaskBitSet))
+				assert.True(t, sexpr.bitsets.IsInitialized(event.CategoryBitSet))
 			},
 		},
 		{"evt.name = 'CreateProcess' or evt.name = 'SetThreadContext' or evt.category = 'registry'", &event.Event{Type: event.CreateProcess, Category: event.Process}, true,
 			func(t *testing.T, sexpr *SequenceExpr) {
-				assert.False(t, sexpr.bitsets.IsTypesInitialized())
-				assert.True(t, sexpr.bitsets.IsBitmaskInitialized())
-				assert.True(t, sexpr.bitsets.IsCategoryInitialized())
+				assert.False(t, sexpr.bitsets.IsInitialized(event.TypeBitSet))
+				assert.True(t, sexpr.bitsets.IsInitialized(event.BitmaskBitSet))
+				assert.True(t, sexpr.bitsets.IsInitialized(event.CategoryBitSet))
 			},
 		},
 	}


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Introduces a single `IsInitialized` method that checks whether the specified bitset type is initialized.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

/kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

/area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
