### PR TITLE
feat(rules): New `Windows Defender driver unloading` rule

### DIFF
--- a/rules/defense_evasion_windows_defender_driver_unloading.yml
+++ b/rules/defense_evasion_windows_defender_driver_unloading.yml
@@ -1,0 +1,28 @@
+name: Windows Defender driver unloading
+id: c9b93fbc-8845-4f39-a74b-26862615432c
+version: 1.0.0
+description: |
+  Detects the unloading of Windows Defender kernel-mode drivers, such as WdFilter.sys or WdBoot.sys,
+  which may indicate an attempt to impair or disable antivirus protections. 
+  Adversaries may unload these drivers to bypass or disable real-time scanning, file system filtering, 
+  or ELAM (Early Launch Anti-Malware) protections. Legitimate driver unloads are rare and should be 
+  investigated to rule out malicious tampering or post-exploitation activity.
+labels:
+  tactic.id: TA0005
+  tactic.name: Defense Evasion
+  tactic.ref: https://attack.mitre.org/tactics/TA0005/
+  technique.id: T1562
+  technique.name: Impair Defenses
+  technique.ref: https://attack.mitre.org/techniques/T1562/
+  subtechnique.id: T1562.001
+  subtechnique.name: Disable or Modify Tools
+  subtechnique.ref: https://attack.mitre.org/techniques/T1562/001
+
+condition: >
+  unload_driver and image.path imatches ('?:\\Windows\\System32\\drivers\\wd\\*.sys', '?:\\Windows\\System32\\drivers\\Wd*.sys')
+
+output: >
+  Windows Defender driver %image.path unloaded by process %ps.exe
+severity: high
+
+min-engine-version: 3.0.0

--- a/rules/macros/macros.yml
+++ b/rules/macros/macros.yml
@@ -135,7 +135,7 @@
     watching for driver objects being created.
 
 - macro: unload_driver
-  expr: unload_image and (image.name iendswith '.sys' or image.is_driver)
+  expr: unload_module and (image.name iendswith '.sys' or image.is_driver)
 
 - macro: load_unsigned_module
   expr: >


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Detects the unloading of Windows Defender kernel-mode drivers, such as WdFilter.sys or WdBoot.sys, which may indicate an attempt to impair or disable antivirus protections.

Adversaries may unload these drivers to bypass or disable real-time scanning, file system filtering, or ELAM (Early Launch Anti-Malware) protections. Legitimate driver unloads are rare and should be investigated to rule out malicious tampering or post-exploitation activity.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
