### PR TITLE
feat(config,rules): Add authors field in rule definition

### DIFF
--- a/pkg/config/_fixtures/filters/default.yml
+++ b/pkg/config/_fixtures/filters/default.yml
@@ -23,3 +23,6 @@ notes: |
   Lorem ipsum dolor sit amet, consectetur adipiscing elit.
   Ut ut ante id ligula molestie varius. Duis efficitur eros
   quis turpis accumsan, nec scelerisque libero euismod.
+authors:
+  - rabbitstack
+  - skynova

--- a/pkg/config/filters.go
+++ b/pkg/config/filters.go
@@ -55,6 +55,7 @@ type FilterConfig struct {
 	Notes            string            `json:"notes" yaml:"notes"`
 	MinEngineVersion string            `json:"min-engine-version" yaml:"min-engine-version"`
 	Enabled          *bool             `json:"enabled" yaml:"enabled"`
+	Authors          []string          `json:"authors" yaml:"authors"`
 }
 
 // FilterAction wraps all possible filter actions.

--- a/pkg/config/filters_test.go
+++ b/pkg/config/filters_test.go
@@ -58,6 +58,7 @@ func TestLoadRulesFromPaths(t *testing.T) {
 	assert.NotNil(t, f1.Action)
 	assert.Contains(t, f1.References, "ref2")
 	assert.NotEmpty(t, f1.Notes)
+	assert.Len(t, f1.Authors, 2)
 
 	acts, err := f1.DecodeActions()
 	require.NoError(t, err)

--- a/pkg/config/schema_windows.go
+++ b/pkg/config/schema_windows.go
@@ -524,6 +524,7 @@ var rulesSchema = `
 		},
 		"tags":						{"type": "array", "items": [{"type": "string", "minLength": 1}]},
 		"references":			{"type": "array", "items": [{"type": "string", "minLength": 1}]},
+		"authors":				{"type": "array", "items": [{"type": "string", "minLength": 1}]},
 		"action": 				{
 			"type": "array",
 			"items": {


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

The new `authors` field allows specifying one or more authors of the detection rule.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

/area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---

This PR adds the new `authors` field in the rule definition. Make sure to reflect this change in the docs.