### PR TITLE
feat(rule_engine): Validate event/category names

### DIFF
--- a/pkg/event/category.go
+++ b/pkg/event/category.go
@@ -122,3 +122,13 @@ func Categories() []string {
 		string(Threadpool),
 	}
 }
+
+// IsCategoryKnown indicates if the category is known given its name.
+func IsCategoryKnown(name string) bool {
+	for _, category := range Categories() {
+		if category == name {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/event/metainfo_windows.go
+++ b/pkg/event/metainfo_windows.go
@@ -314,6 +314,16 @@ outer:
 	return typs
 }
 
+// IsKnown indicates if the event type is known given the event name.
+func IsKnown(name string) bool {
+	for _, evt := range GetTypesMeta() {
+		if evt.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 // GetTypesMetaIndexed returns indexed event types metadata
 // that is guaranteed to always return the same event indices.
 func GetTypesMetaIndexed() []Info { return indexedEvents }

--- a/pkg/rules/_fixtures/field_values/correct_category_name_field.yml
+++ b/pkg/rules/_fixtures/field_values/correct_category_name_field.yml
@@ -1,0 +1,5 @@
+name: match https connections
+id: 8f36f8e0-a5c2-498f-9563-eea306daa586
+version: 1.0.0
+condition: evt.category = 'net' and net.dport = 443
+min-engine-version: 2.0.0

--- a/pkg/rules/_fixtures/field_values/correct_event_name_field.yml
+++ b/pkg/rules/_fixtures/field_values/correct_event_name_field.yml
@@ -1,0 +1,5 @@
+name: match https connections
+id: 8f36f8e0-a5c2-498f-9563-eea306daa586
+version: 1.0.0
+condition: evt.name = 'Recv' and net.dport = 443
+min-engine-version: 2.0.0

--- a/pkg/rules/_fixtures/field_values/incorrect_category_name_field.yml
+++ b/pkg/rules/_fixtures/field_values/incorrect_category_name_field.yml
@@ -1,0 +1,5 @@
+name: match https connections
+id: 8f36f8e0-a5c2-498f-9563-eea306daa586
+version: 1.0.0
+condition: evt.category = 'network' and net.dport = 443
+min-engine-version: 2.0.0

--- a/pkg/rules/_fixtures/field_values/incorrect_event_name_field.yml
+++ b/pkg/rules/_fixtures/field_values/incorrect_event_name_field.yml
@@ -1,0 +1,5 @@
+name: match https connections
+id: 8f36f8e0-a5c2-498f-9563-eea306daa586
+version: 1.0.0
+condition: evt.name = 'RecvTcp4' and net.dport = 443
+min-engine-version: 2.0.0

--- a/pkg/rules/_fixtures/field_values/incorrect_event_name_in_operator.yml
+++ b/pkg/rules/_fixtures/field_values/incorrect_event_name_in_operator.yml
@@ -1,0 +1,5 @@
+name: match https connections
+id: 8f36f8e0-a5c2-498f-9563-eea306daa586
+version: 1.0.0
+condition: evt.name in ('Recv', 'Accept', 'CreateProc') and net.dport = 443
+min-engine-version: 2.0.0

--- a/pkg/rules/compiler_test.go
+++ b/pkg/rules/compiler_test.go
@@ -70,3 +70,29 @@ func TestCompileMinEngineVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestCompileEventCategoryFieldNames(t *testing.T) {
+	var tests = []struct {
+		rules string
+		err   error
+	}{
+		{"_fixtures/field_values/correct_event_name_field.yml", nil},
+		{"_fixtures/field_values/incorrect_event_name_field.yml", ErrUnknownEventName("match https connections", "RecvTcp4")},
+		{"_fixtures/field_values/incorrect_event_name_in_operator.yml", ErrUnknownEventName("match https connections", "CreateProc")},
+		{"_fixtures/field_values/correct_category_name_field.yml", nil},
+		{"_fixtures/field_values/incorrect_category_name_field.yml", ErrUnknownCategoryName("match https connections", "network")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.rules, func(t *testing.T) {
+			c := newCompiler(new(ps.SnapshotterMock), newConfig(tt.rules))
+			_, _, err := c.compile()
+			if err != nil && tt.err != nil {
+				require.Error(t, err)
+			}
+			if err != nil {
+				require.EqualError(t, err, tt.err.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

The rule engine compiler ensures that the provided event or category names match the internal catalog nomenclature.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

/area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
