### PR TITLE
fix(filter): Provide accessor default value

### DIFF
--- a/pkg/filter/fields/fields_windows.go
+++ b/pkg/filter/fields/fields_windows.go
@@ -609,6 +609,9 @@ const (
 // String casts the field type to string.
 func (f Field) String() string { return string(f) }
 
+// Type returns the data type that this field contains.
+func (f Field) Type() params.Type { return fields[f].Type }
+
 func (f Field) IsPsField() bool         { return strings.HasPrefix(string(f), "ps.") }
 func (f Field) IsKevtField() bool       { return strings.HasPrefix(string(f), "evt.") }
 func (f Field) IsThreadField() bool     { return strings.HasPrefix(string(f), "thread.") }

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -423,14 +423,15 @@ func (f *filter) mapValuer(evt *event.Event) map[string]interface{} {
 				continue
 			}
 			v, err := accessor.Get(field, evt)
-			if err != nil && !errs.IsParamNotFound(err) {
-				accessorErrors.Add(err.Error(), 1)
+			if v == nil || err != nil {
+				valuer[field.Value] = defaultAccessorValue(field)
+				if err != nil && !errs.IsParamNotFound(err) {
+					accessorErrors.Add(err.Error(), 1)
+				}
 				continue
 			}
-			if v != nil {
-				valuer[field.Value] = v
-				break
-			}
+			valuer[field.Value] = v
+			break
 		}
 	}
 	return valuer

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -201,6 +201,16 @@ func TestProcFilter(t *testing.T) {
 		},
 	}
 
+	evt2 := &event.Event{
+		Type:     event.OpenProcess,
+		Category: event.Process,
+		Params: event.Params{
+			params.DesiredAccess: {Name: params.DesiredAccess, Type: params.Flags, Value: uint32(0x1400), Flags: event.PsAccessRightFlags},
+		},
+		Name: "OpenProcess",
+		PID:  1023,
+	}
+
 	var tests = []struct {
 		filter  string
 		matches bool
@@ -336,6 +346,26 @@ func TestProcFilter(t *testing.T) {
 			t.Fatal(err)
 		}
 		matches := f.Run(evt1)
+		if matches != tt.matches {
+			t.Errorf("%d. %q ps filter mismatch: exp=%t got=%t", i, tt.filter, tt.matches, matches)
+		}
+	}
+
+	var tests2 = []struct {
+		filter  string
+		matches bool
+	}{
+
+		{`ps.exe = ''`, true},
+	}
+
+	for i, tt := range tests2 {
+		f := New(tt.filter, cfg)
+		err := f.Compile()
+		if err != nil {
+			t.Fatal(err)
+		}
+		matches := f.Run(evt2)
 		if matches != tt.matches {
 			t.Errorf("%d. %q ps filter mismatch: exp=%t got=%t", i, tt.filter, tt.matches, matches)
 		}


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

When the accessor fails or returns a nil value , populate the valuer map with a default value. This is important to avoid rule-matching misbehaviours.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

/area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
