### PR TITLE
fix(ps): Assign UUID from internal process state

### DIFF
--- a/pkg/ps/snapshotter_windows.go
+++ b/pkg/ps/snapshotter_windows.go
@@ -20,14 +20,15 @@ package ps
 
 import (
 	"expvar"
-	"github.com/rabbitstack/fibratus/pkg/sys"
-	"github.com/rabbitstack/fibratus/pkg/util/va"
-	"golang.org/x/sys/windows"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/rabbitstack/fibratus/pkg/sys"
+	"github.com/rabbitstack/fibratus/pkg/util/va"
+	"golang.org/x/sys/windows"
 
 	"github.com/rabbitstack/fibratus/pkg/config"
 	"github.com/rabbitstack/fibratus/pkg/event"
@@ -184,6 +185,11 @@ func (s *snapshotter) Write(e *event.Event) error {
 			proc.Exe = ps.Exe
 			e.AppendParam(params.Exe, params.Path, ps.Exe)
 		}
+
+		// if the process UUID has been initialized when
+		// the internal event arrived, reassign it to the
+		// current process state
+		proc.AssignUUID(ps)
 
 		e.AppendParam(params.ProcessTokenIntegrityLevel, params.AnsiString, ps.TokenIntegrityLevel)
 		e.AppendParam(params.ProcessTokenElevationType, params.AnsiString, ps.TokenElevationType)

--- a/pkg/ps/types/types_windows.go
+++ b/pkg/ps/types/types_windows.go
@@ -21,20 +21,22 @@ package types
 import (
 	"encoding/binary"
 	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+
 	"github.com/rabbitstack/fibratus/pkg/sys"
 	"github.com/rabbitstack/fibratus/pkg/util/cmdline"
 	"github.com/rabbitstack/fibratus/pkg/util/va"
 	"golang.org/x/sys/windows"
-	"path/filepath"
-	"strings"
-	"sync"
 
 	"github.com/rabbitstack/fibratus/pkg/cap/section"
 	htypes "github.com/rabbitstack/fibratus/pkg/handle/types"
 	"github.com/rabbitstack/fibratus/pkg/pe"
 
-	"github.com/rabbitstack/fibratus/pkg/util/bootid"
 	"time"
+
+	"github.com/rabbitstack/fibratus/pkg/util/bootid"
 )
 
 // PS encapsulates process' state such as allocated resources and other metadata.
@@ -123,6 +125,14 @@ func (ps *PS) UUID() uint64 {
 		}
 	}
 	return ps.uuid
+}
+
+// AssignUUID assigns the UUID from the given
+// process if the UUID has been initialized.
+func (ps *PS) AssignUUID(proc *PS) {
+	if proc.uuid != 0 {
+		ps.uuid = proc.uuid
+	}
 }
 
 // ProcessSequenceNumber contains the unique process sequence number.


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

The internal process creation/rundown event typically arrives before the respective NT Kernel Logger event. If the process UUID is initialized as a result of internal event arrival, we want to reassign the same process UUID to events published by the Kernel Logger provider.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

/area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
