### PR TITLE
refactor(event): Remove delay event logic

### DIFF
--- a/pkg/event/event_windows.go
+++ b/pkg/event/event_windows.go
@@ -152,18 +152,6 @@ func (e *Event) IsDropped(capture bool) bool {
 // current process is dropped.
 func IsCurrentProcDropped(pid uint32) bool { return DropCurrentProc && pid == currentPid }
 
-// DelayKey returns the value that is used to
-// store and reference delayed events in the event
-// backlog state. The delayed event is indexed by
-// the sequence identifier.
-func (e *Event) DelayKey() uint64 {
-	switch e.Type {
-	case CreateHandle, CloseHandle:
-		return e.Params.MustGetUint64(params.HandleObject)
-	}
-	return 0
-}
-
 // IsNetworkTCP determines whether the event pertains to network TCP events.
 func (e *Event) IsNetworkTCP() bool {
 	return e.Category == Net && !e.IsNetworkUDP()
@@ -417,26 +405,6 @@ func (e *Event) PartialKey() uint64 {
 		return hashers.FnvUint64(b)
 	}
 	return 0
-}
-
-// BacklogKey represents the key used to index the events in the backlog store.
-func (e *Event) BacklogKey() uint64 {
-	switch e.Type {
-	case CreateHandle, CloseHandle:
-		return e.Params.MustGetUint64(params.HandleObject)
-	}
-	return 0
-}
-
-// CopyState adds parameters, tags, or process state from the provided event.
-func (e *Event) CopyState(evt *Event) {
-	switch evt.Type {
-	case CloseHandle:
-		if evt.Params.Contains(params.ImagePath) {
-			e.Params.Append(params.ImagePath, params.UnicodeString, evt.GetParamAsString(params.ImagePath))
-		}
-		_ = e.Params.SetValue(params.HandleObjectName, evt.GetParamAsString(params.HandleObjectName))
-	}
 }
 
 // Summary returns a brief summary of this event. Various important substrings

--- a/rules/macros/macros.yml
+++ b/rules/macros/macros.yml
@@ -123,13 +123,10 @@
 
 - macro: load_driver
   expr: >
-    (load_module and (image.name iendswith '.sys' or image.is_driver)) or
-    (create_handle and handle.type = 'Driver')
+    (load_module and (image.name iendswith '.sys' or image.is_driver))
   description: |
     Detects the loading of the kernel driver. Image load events are published when
-    executable images, DLLs, or driver PE objects are loaded. On the contrary, we can
-    also detect loading of kernel driver by observing the object manager events and
-    watching for driver objects being created.
+    executable images, DLLs, or driver PE objects are loaded.
 
 - macro: unload_driver
   expr: unload_module and (image.name iendswith '.sys' or image.is_driver)


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Delay key logic only applies to handle events, which are rarely enabled due to their immense volume. For the sake of codebase simplicity and maintainability, we are sunsetting this functionality.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

/kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

/area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
