### PR TITLE
fix(event): Dangling registry value data buffer

### DIFF
--- a/pkg/event/param_windows.go
+++ b/pkg/event/param_windows.go
@@ -29,6 +29,8 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/rabbitstack/fibratus/pkg/util/utf16"
+
 	"github.com/rabbitstack/fibratus/pkg/event/params"
 	"github.com/rabbitstack/fibratus/pkg/fs"
 	htypes "github.com/rabbitstack/fibratus/pkg/handle/types"
@@ -531,10 +533,10 @@ func (e *Event) produceParams(evt *etw.EventRecord) {
 		e.AppendParam(params.RegPath, params.Key, filepath.Join(keyName, valueName))
 		e.AppendEnum(params.RegValueType, valueType, key.RegistryValueTypes)
 
-		if len(capturedData) > 0 {
+		if len(b) > 0 {
 			switch valueType {
 			case registry.SZ, registry.MULTI_SZ, registry.EXPAND_SZ:
-				e.AppendParam(params.RegData, params.UnicodeString, string(capturedData))
+				e.AppendParam(params.RegData, params.UnicodeString, utf16.BytesToString(b, binary.LittleEndian))
 			case registry.BINARY:
 				e.AppendParam(params.RegData, params.Binary, b)
 			case registry.DWORD:

--- a/pkg/util/utf16/utf16.go
+++ b/pkg/util/utf16/utf16.go
@@ -22,6 +22,7 @@
 package utf16
 
 import (
+	"encoding/binary"
 	"unicode/utf8"
 )
 
@@ -57,4 +58,17 @@ func Decode(p []uint16) string {
 		s = utf8.AppendRune(s, r)
 	}
 	return string(s)
+}
+
+// BytesToString converts the UTF16-encoded byte buffer to string.
+func BytesToString(b []byte, o binary.ByteOrder) string {
+	utf := make([]uint16, 0, len(b)/2)
+	for i := 0; i+1 < len(b); i += 2 {
+		u := o.Uint16(b[i:])
+		if u == 0 {
+			break // stop at null terminator
+		}
+		utf = append(utf, u)
+	}
+	return Decode(utf)
 }


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

To prevent referencing a dangling buffer that is invalidated after the callback function returns, we make a copy of the buffer
and attach the copy to the event parameters. The string value parsing requires a function to convert UTF-16 code points to a UTF-8 string.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

/area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
