### PR TITLE
fix(rule_engine): Permit sequence link sets

### DIFF
--- a/pkg/rules/sequence.go
+++ b/pkg/rules/sequence.go
@@ -21,6 +21,11 @@ package rules
 import (
 	"context"
 	"expvar"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
 	fsm "github.com/qmuntal/stateless"
 	"github.com/rabbitstack/fibratus/pkg/config"
 	"github.com/rabbitstack/fibratus/pkg/event"
@@ -29,10 +34,6 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/filter/ql"
 	"github.com/rabbitstack/fibratus/pkg/ps"
 	log "github.com/sirupsen/logrus"
-	"sort"
-	"sync"
-	"sync/atomic"
-	"time"
 )
 
 const (
@@ -520,7 +521,7 @@ func (s *sequenceState) runSequence(e *event.Event) bool {
 			for seqID := 0; seqID < len(s.partials); seqID++ {
 				for _, outer := range s.partials[seqID] {
 					for _, inner := range s.partials[seqID+1] {
-						if filter.CompareSeqLink(outer.SequenceLink(), inner.SequenceLink()) {
+						if filter.CompareSeqLinks(outer.SequenceLinks(), inner.SequenceLinks()) {
 							setMatch(seqID, outer)
 							setMatch(seqID+1, inner)
 						}


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Events can end up decorated with more than one sequence value. For example, a freshly created process can be assigned the `ps.uuid` or `ps.name` join field, and the rule engine would effectively override the last matched event. For this reason, it is necessary to allow sequence value sets so that that sequence matching can consider multiple values extracted from the join field.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

/area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
