### PR TITLE
perf(rule_engine,filter): Improve bound sequences

### DIFF
--- a/pkg/filter/accessor.go
+++ b/pkg/filter/accessor.go
@@ -153,7 +153,7 @@ func (*evtAccessor) Get(f Field, evt *event.Event) (params.Value, error) {
 // referenced in the bound field.
 func (f *filter) narrowAccessors() {
 	var (
-		removeKevtAccessor       = true
+		removeEvtAccessor        = true
 		removePsAccessor         = true
 		removeThreadAccessor     = true
 		removeImageAccessor      = true
@@ -169,8 +169,8 @@ func (f *filter) narrowAccessors() {
 
 	for _, field := range f.fields {
 		switch {
-		case field.Name.IsKevtField():
-			removeKevtAccessor = false
+		case field.Name.IsKevtField(), field.Name.IsEvtField():
+			removeEvtAccessor = false
 		case field.Name.IsPsField():
 			removePsAccessor = false
 		case field.Name.IsThreadField():
@@ -196,7 +196,7 @@ func (f *filter) narrowAccessors() {
 		}
 	}
 
-	if removeKevtAccessor {
+	if removeEvtAccessor {
 		f.removeAccessor(&evtAccessor{})
 	}
 	if removePsAccessor {

--- a/pkg/filter/fields/fields_windows.go
+++ b/pkg/filter/fields/fields_windows.go
@@ -563,7 +563,8 @@ func (f Field) String() string { return string(f) }
 func (f Field) Type() params.Type { return fields[f].Type }
 
 func (f Field) IsPsField() bool         { return strings.HasPrefix(string(f), "ps.") }
-func (f Field) IsKevtField() bool       { return strings.HasPrefix(string(f), "evt.") }
+func (f Field) IsKevtField() bool       { return strings.HasPrefix(string(f), "kevt.") }
+func (f Field) IsEvtField() bool        { return strings.HasPrefix(string(f), "evt.") }
 func (f Field) IsThreadField() bool     { return strings.HasPrefix(string(f), "thread.") }
 func (f Field) IsImageField() bool      { return strings.HasPrefix(string(f), "image.") }
 func (f Field) IsFileField() bool       { return strings.HasPrefix(string(f), "file.") }


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Refactor bound sequence evaluation logic to speed it up, most notably by deferring the field hash calculation only when the
event matches. Furthermore, the accessor is tied to the bound field, avoiding iteration across the filter's registered accessors.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

/kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

/area rule-engine

/area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
