### PR TITLE
perf(rule_engine,filter): Preallocate default accessor values

### DIFF
--- a/pkg/filter/accessor.go
+++ b/pkg/filter/accessor.go
@@ -247,6 +247,13 @@ func (f *filter) removeAccessor(removed Accessor) {
 	}
 }
 
+var (
+	zeroTime  time.Time
+	zeroSlice []string
+	zeroIP    net.IP
+	zeroByte  []byte
+)
+
 // defaultAccessorValue provides the default value for the field.
 // This value is typically assigned when the accessor returns an
 // error or nil value, but the map valuer must contain the resolved
@@ -260,15 +267,15 @@ func defaultAccessorValue(field Field) any {
 	case params.Float, params.Double:
 		return 0.0
 	case params.Time:
-		return time.Now()
+		return zeroTime
 	case params.Bool:
 		return false
 	case params.IP, params.IPv4, params.IPv6:
-		return net.IP{}
+		return zeroIP
 	case params.Binary:
-		return []byte{}
+		return zeroByte
 	case params.Slice:
-		return []string{}
+		return zeroSlice
 	default:
 		return ""
 	}


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Preallocate default accessor values as they should remain static across the program lifetime.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

/area rule-engine

/area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
