### PR TITLE
perf(rule_engine): Move to iterative greedy wildcard matching

### DIFF
--- a/pkg/util/wildcard/wildcard_test.go
+++ b/pkg/util/wildcard/wildcard_test.go
@@ -1,5 +1,5 @@
 /*
- *	Copyright 2019-2020 by Nedim Sabic
+ *	Copyright 2019-present by Nedim Sabic
  *	http://rabbitstack.github.io
  *	All Rights Reserved.
  *
@@ -13,15 +13,31 @@
 package wildcard
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMatch(t *testing.T) {
-	assert.True(t, Match("C:\\*\\lsass?.dmp", "C:\\Windows\\System32\\lsass2.dmp"))
-	assert.True(t, Match("C:\\*\\ActionList.x?l", "C:\\Windows\\Setup\\LatentAcquisition\\ActionList.xml"))
-	assert.True(t, Match("C:\\ProgramData\\*.dll", "C:\\ProgramData\\Directory\\OneMoreDirectory\\mal.dll"))
-	assert.True(t, Match("C:\\ProgramData\\*.dll", "C:\\ProgramData\\Directory\\OneMoreDirectory\\mal.dll"))
-	assert.True(t, Match("HKEY_USERS\\*\\Environment\\windir", "HKEY_USERS\\S-1-5-21-2271034452-2606270099-984871569-1001\\Environment\\windir"))
-	assert.True(t, Match("C:\\Windows\\SoftwareDistribution\\*", "C:\\Windows\\SoftwareDistribution\\SLS\\7971F918-A847-4430-9279-4A52D1EFE18D\\sls.rar"))
+	var tests = []struct {
+		p     string
+		s     string
+		match bool
+	}{
+		{"C:\\*\\lsass?.dmp", "C:\\Windows\\System32\\lsass2.dmp", true},
+		{"?:\\*\\lsass?.dmp", "C:\\Windows\\System32\\lsass2.dmp", true},
+		{"?:\\*\\lsass?.dmp", "C:\\Windows\\System32\\cmd.exe", false},
+		{"C:\\*\\ActionList.x?l", "C:\\Windows\\Setup\\LatentAcquisition\\ActionList.xml", true},
+		{"C:\\ProgramData\\*.dll", "C:\\ProgramData\\Directory\\OneMoreDirectory\\mal.dll", true},
+		{"HKEY_USERS\\*\\Environment\\windir", "HKEY_USERS\\S-1-5-21-2271034452-2606270099-984871569-1001\\Environment\\windir", true},
+		{"C:\\Windows\\SoftwareDistribution\\*", "C:\\Windows\\SoftwareDistribution\\SLS\\7971F918-A847-4430-9279-4A52D1EFE18D\\sls.rar", true},
+		{"HKEY_USERS\\S-1-5-21-*_CLASSES\\MS-SETTINGS\\CURVER", "HKEY_USERS\\S-1-5-21-2271034452-1207270099-244871569-1021_CLASSES\\MS-SETTINGS\\CURVER", true},
+		{"ntdll.dll|KernelBase.dll|advapi32.dll|*", "ntdll.dll|KernelBase.dll|advapi32.dll|pe386.dll|com.dll|clr.dll|mmc.exe", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.p, func(t *testing.T) {
+			assert.Equal(t, tt.match, Match(tt.p, tt.s))
+		})
+	}
 }


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

By switching from recursive backtracking to an iterative greedy matcher, we've eliminated:

- all the recursion overhead.
- repeated slice copies for every recursive call.
- exponential branching when * appears in the pattern.

The matcher is now linear-time in the length of the pattern and the string, and introduces an ASCII-fast path with a UTF-8 fallback only when needed.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

/area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
