### PR TITLE
refactor(rules): Remove `write_minidump_file` macro

### DIFF
--- a/rules/credential_access_lsass_memory_dumping.yml
+++ b/rules/credential_access_lsass_memory_dumping.yml
@@ -1,6 +1,6 @@
 name: LSASS memory dumping via legitimate or offensive tools
 id: 335795af-246b-483e-8657-09a30c102e63
-version: 1.0.4
+version: 1.2.0
 description: |
   Detects an attempt to dump the LSAAS memory to the disk by employing legitimate
   tools such as procdump, Task Manager, Process Explorer or built-in Windows tools
@@ -23,7 +23,7 @@ condition: >
   sequence
   maxspan 2m
   by ps.uuid
-    |open_process and 
+    |open_process and
      ps.access.mask.names in ('ALL_ACCESS', 'CREATE_PROCESS', 'VM_READ', 'DUP_HANDLE') and
      evt.arg[exe] imatches '?:\\Windows\\System32\\lsass.exe' and
      ps.exe not imatches
@@ -32,7 +32,7 @@ condition: >
                   '?:\\ProgramData\\Microsoft\\Windows Defender\\*\\MsMpEng.exe'
                 )
     |
-    |write_minidump_file|
+    |create_file and (file.extension iin ('.dmp', '.mdmp', '.dump') or is_minidump(file.path))|
 
 output: >
   Detected an attempt by `%1.ps.name` process to access and read

--- a/rules/macros/macros.yml
+++ b/rules/macros/macros.yml
@@ -204,25 +204,6 @@
   description: >
     Detects when either unsigned or untrusted DLL is loaded into process address space.
 
-- macro: write_minidump_file
-  expr: >
-    create_file and
-    (
-      file.extension iin
-                    (
-                      '.dmp',
-                      '.mdmp',
-                      '.dump'
-                    ) or
-      is_minidump(file.path)
-    )
-  description: |
-    Detects a process writing the minidump file. Minidump files are used for crash
-    reporting as they contain a snapshot of the process' memory such as local variables
-    or heap objects. Processes can create minidump files by calling into the MiniDumpWriteDump()
-    function. This macro checks the well-known extensions of the minidump files as well as
-    the minidump signature.
-
 - macro: msoffice_binaries
   list: [EXCEL.EXE, WINWORD.EXE, MSACCESS.EXE, POWERPNT.EXE, visio.exe, mspub.exe, fltldr.exe, eqnedt32.exe]
 


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

The macro is only used in one rule so we can reduce the clutter.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

/kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
