### PR TITLE
perf(event): Defer event metadata initialization

### DIFF
--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -245,6 +245,9 @@ func NewFromCapture(buf []byte, ver capver.Version) (*Event, error) {
 func (e *Event) AddMeta(k MetadataKey, v any) {
 	e.mmux.Lock()
 	defer e.mmux.Unlock()
+	if e.Metadata == nil {
+		e.Metadata = make(map[MetadataKey]any)
+	}
 	e.Metadata[k] = v
 }
 
@@ -263,13 +266,18 @@ func (e *Event) AddOrAppendMetaSlice(k MetadataKey, s string) {
 func (e *Event) RemoveMeta(k MetadataKey) {
 	e.mmux.Lock()
 	defer e.mmux.Unlock()
-	delete(e.Metadata, k)
+	if e.Metadata != nil {
+		delete(e.Metadata, k)
+	}
 }
 
 // GetMetaAsString returns the metadata as a string value.
 func (e *Event) GetMetaAsString(k MetadataKey) string {
 	e.mmux.RLock()
 	defer e.mmux.RUnlock()
+	if e.Metadata == nil {
+		return ""
+	}
 	if v, ok := e.Metadata[k]; ok {
 		if s, ok := v.(string); ok {
 			return s
@@ -282,6 +290,9 @@ func (e *Event) GetMetaAsString(k MetadataKey) string {
 func (e *Event) GetMeta(k MetadataKey) any {
 	e.mmux.RLock()
 	defer e.mmux.RUnlock()
+	if e.Metadata == nil {
+		return ""
+	}
 	return e.Metadata[k]
 }
 
@@ -289,6 +300,9 @@ func (e *Event) GetMeta(k MetadataKey) any {
 func (e *Event) ContainsMeta(k MetadataKey) bool {
 	e.mmux.RLock()
 	defer e.mmux.RUnlock()
+	if e.Metadata == nil {
+		return false
+	}
 	return e.Metadata[k] != nil
 }
 

--- a/pkg/event/event_windows.go
+++ b/pkg/event/event_windows.go
@@ -58,18 +58,16 @@ func New(seq uint64, evt *etw.EventRecord) *Event {
 	)
 
 	e := &Event{
-		Seq:         seq,
-		PID:         pid,
-		Tid:         tid,
-		CPU:         cpu,
-		Type:        typ,
-		Category:    typ.Category(),
-		Name:        typ.String(),
-		Params:      make(map[string]*Param),
-		Description: typ.Description(),
-		Timestamp:   ts,
-		Metadata:    make(map[MetadataKey]any),
-		Host:        hostname.Get(),
+		Seq:       seq,
+		PID:       pid,
+		Tid:       tid,
+		CPU:       cpu,
+		Type:      typ,
+		Category:  typ.Category(),
+		Name:      typ.String(),
+		Params:    make(map[string]*Param),
+		Timestamp: ts,
+		Host:      hostname.Get(),
 	}
 
 	e.produceParams(evt)


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Initialize the event metadata map lazily, in fact, only when labels need to be pushed to the metadata.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

/area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
