### PR TITLE
feat(rules): New `Potential NTLM hash leak via MS Photos` rule

### DIFF
--- a/rules/credential_access_potential_ntlm_hash_leak_via_ms_photos.yml
+++ b/rules/credential_access_potential_ntlm_hash_leak_via_ms_photos.yml
@@ -1,0 +1,37 @@
+name: Potential NTLM hash leak via MS Photos
+id: b5b70c6d-e265-477e-bd62-b4d05089e2ab
+version: 1.0.0
+description: |
+  Detects a potential NTLM hash disclosure via abuse of the ms-photos: URI
+  scheme with a UNC path parameter. An attacker can craft a specially formatted
+  link that, when opened, launches Microsoft Photos directly from a browser and
+  triggers outbound authentication, potentially leaking NTLM credentials.
+labels:
+  tactic.id: TA0006
+  tactic.name: Credential Access
+  tactic.ref: https://attack.mitre.org/tactics/TA0006/
+  technique.id: T1187
+  technique.name: Forced Authentication
+  technique.ref: https://attack.mitre.org/techniques/T1187/
+references:
+  - https://github.com/rubenformation/ms-photos_NTLM_Leak
+
+condition: >
+  sequence
+  maxspan 1m
+    |spawn_process and
+     ps.parent.name ~= 'explorer.exe' and ps.name ~= 'Photos.exe' and
+     ps.cmdline imatches '*ms-photos:viewer?fileName=%5C%5C*%5C*%5C*'
+    |
+    |connect_socket and
+     evt.pid = 4 and net.dport = 445 and not cidr_contains(net.dip,
+                                                  '127.0.0.0/8',
+                                                  '10.0.0.0/8',
+                                                  '172.16.0.0/12', '192.168.0.0/16')
+    |
+
+output: >
+  Potential NTLM hash leak via MS Photos UNC path at address $2.net.dip
+severity: high
+
+min-engine-version: 3.0.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Identifies a potential NTLM hash leak via ms-photos URI scheme parameter which can be submitted with UNC path. Adversaries can craft a specially formatted link and coerce a victim into launching the Microsoft Photos directly from the browser.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
