### PR TITLE
fix(tests): Use parent process id for test assertion

### DIFF
--- a/internal/etw/source_test.go
+++ b/internal/etw/source_test.go
@@ -421,7 +421,7 @@ func TestEventSourceAllEvents(t *testing.T) {
 				return nil
 			},
 			func(e *event.Event) bool {
-				return e.IsCreateProcess() && e.CurrentPid() &&
+				return e.IsCreateProcess() && e.Params.MustGetUint32(params.ProcessParentID) == uint32(os.Getpid()) &&
 					strings.EqualFold(e.GetParamAsString(params.ProcessName), "notepad.exe")
 			},
 			false,
@@ -876,7 +876,7 @@ func testCallstackEnrichment(t *testing.T, hsnap handle.Snapshotter, psnap ps.Sn
 				return nil
 			},
 			func(e *event.Event) bool {
-				if e.IsCreateProcess() && e.CurrentPid() &&
+				if e.IsCreateProcess() && e.Params.MustGetUint32(params.ProcessParentID) == uint32(os.Getpid()) &&
 					strings.EqualFold(e.GetParamAsString(params.ProcessName), "notepad.exe") {
 					callstack := e.Callstack.String()
 					log.Infof("create process event %s: %s", e.String(), callstack)


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Event source tests are failing after process child filter field refactoring. Use the parent process id as a condition in test assertion.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

/area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
