### PR TITLE
feat(rules): New `Potential shellcode injection via Windows Debugging API` rule

### DIFF
--- a/rules/defense_evasion_potential_shellcode_injection_via_windows_debugging_api.yml
+++ b/rules/defense_evasion_potential_shellcode_injection_via_windows_debugging_api.yml
@@ -1,0 +1,39 @@
+name: Potential shellcode injection via Windows Debugging API
+id: 0100c5ce-3cdf-4701-8253-6c33bb48eabf
+version: 1.0.0
+description: |
+  Identifies shellcode injection using the Windows Debugging API and shared memory section.
+  Attackers avoid writing and reading remote memory directly, instead employ context manipulation
+  to force the target process to load and execute the payload itself via shared file mapping.
+labels:
+  tactic.id: TA0005
+  tactic.name: Defense Evasion
+  tactic.ref: https://attack.mitre.org/tactics/TA0005/
+  technique.id: T1055
+  technique.name: Process Injection
+  technique.ref: https://attack.mitre.org/techniques/T1055/
+references:
+  - https://github.com/dis0rder0x00/DbgNexum
+
+condition: >
+  sequence
+  maxspan 1m
+    |create_remote_thread and
+     thread.callstack.symbols imatches ('ntdll.dll!DbgUiDebugActiveProcess', 'ntdll.dll!DbgUiIssueRemoteBreakin', 'KernelBase.dll!DebugActiveProcess') and
+     ps.exe not imatches
+                (
+                  '?:\\Program Files\\*.exe',
+                  '?:\\Program Files(x86)\\*.exe',
+                  '?:\\Windows\\System32\\wermgr.exe',
+                  '?:\\Windows\\System32\\WerFault.exe'
+                )
+    | by thread.pid
+    |map_view_of_section and
+     file.view.protection = 'READONLY|EXECUTE' and file.view.size >= 4096
+    | by ps.pid
+action:
+  - name: kill
+
+severity: high
+
+min-engine-version: 3.0.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Identifies shellcode injection using the Windows Debugging API and shared memory section. Attackers avoid writing and reading remote memory directly, instead employ context manipulation to force the target process to load and execute the payload itself via shared file mapping.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
