### PR TITLE
feat(rules): New `Clickfix phishing via browser dialog box` rule

### DIFF
--- a/rules/initial_access_clickfix_phishing_via_browser_dialog_box.yml
+++ b/rules/initial_access_clickfix_phishing_via_browser_dialog_box.yml
@@ -1,0 +1,36 @@
+name: Clickfix phishing via browser dialog box
+id: 5fc4bf43-fbb6-4a78-a2cc-1fe9138bd3c2
+version: 1.0.0
+description: |
+  Identifies a ClickFix-style social-engineering phishing attempt and its FileFix evolution
+  where a web page coerces a user into interacting with a trusted File Explorer address bar so
+  that a clipboard-pasted value executes a command on the host. Attackers use convincing browser
+  lures (fake CAPTCHAs, shared-file prompts, account-suspension pages, etc.) to cause the browser
+  to open a native dialog or explorer window and simultaneously place a malicious command
+  on the clipboard. When the user pastes that content into the trusted UI it runs with
+  their privileges, often bypassing Mark-Of-The-Web checks and many automated protections.
+labels:
+  tactic.id: TA0001
+  tactic.name: Initial Access
+  tactic.ref: https://attack.mitre.org/tactics/TA0001/
+  technique.id: T1566
+  technique.name: Phishing
+  technique.ref: https://attack.mitre.org/techniques/T1566/
+references:
+  - https://thehackernews.com/2025/06/new-filefix-method-emerges-as-threat.html
+  - https://www.bridewell.com/insights/blogs/detail/filefix-the-evolved-clickfix
+  - https://blog.checkpoint.com/research/filefix-the-new-social-engineering-attack-building-on-clickfix-tested-in-the-wild/
+
+condition: >
+  spawn_process and ps.parent.name iin web_browser_binaries and
+  (ps.name iin script_interpreters or ps.name iin ('msiexec.exe', 'rundll32.exe', 'curl.exe', 'wget.exe', 'certutil.exe', 'certreq.exe', 'msbuild.exe') or
+   ps.exe imatches '?:\\Users\\*\\Downloads\\*') and
+  thread.callstack.summary imatches 'ntdll.dll|*|windows.storage.dll|shell32.dll|windows.storage.dll|SHCore.dll|*'
+action:
+  - name: kill
+
+output: >
+  Process %ps.exe execution via potential Clickfix phishing browser dialog box
+severity: high
+
+min-engine-version: 3.0.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Identifies a ClickFix-style social-engineering phishing attempt and its FileFix evolution where a web page coerces a user into interacting with a trusted File Explorer address bar so that a clipboard-pasted value executes a command on the host. Attackers use convincing browser lures (fake CAPTCHAs, shared-file prompts, account-suspension pages, etc.) to cause the browser to open a native dialog or explorer window and simultaneously place a malicious command on the clipboard. When the user pastes that content into the trusted UI it runs with their privileges, often bypassing Mark-Of-The-Web checks and many automated protections.


### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
