### PR TITLE
feat(rules): New `Potential NTLM hash leak via shortcut file` rule

### DIFF
--- a/rules/credential_access_potential_ntlm_hash_leak_via_shortcut_file.yml
+++ b/rules/credential_access_potential_ntlm_hash_leak_via_shortcut_file.yml
@@ -1,0 +1,42 @@
+name: Potential NTLM hash leak via shortcut file
+id: 2217339b-19d0-45ac-9ec5-26b0a968bdf1
+version: 1.0.0
+description: |
+  Identifies potential NTLM hash leakage via malicious shortcut (.lnk) file processing.
+  By crafting a .lnk file with a default icon from shell32.dll and the target path pointing
+  to a remote SMB-hosted binary file, the explorer.exe process will fetch the remote file to
+  extract the icon from the PE resource directory, leading to NTLM hash leak.
+labels:
+  tactic.id: TA0006
+  tactic.name: Credential Access
+  tactic.ref: https://attack.mitre.org/tactics/TA0006/
+  technique.id: T1187
+  technique.name: Forced Authentication
+  technique.ref: https://attack.mitre.org/techniques/T1187/
+references:
+  - https://github.com/rubenformation/CVE-2025-50154
+
+condition: >
+  sequence
+  maxspan 1m
+  by ps.uuid
+    |open_file and
+     ps.name ~= 'explorer.exe' and file.extension ~= '.lnk' and
+     thread.callstack.summary imatches 'ntdll.dll|KernelBase.dll|SHCore.dll|windows.storage.dll|shell32.dll|SHCore.dll|*' and
+     thread.callstack.symbols iin ('shell32.dll!SHELL32_CNetFolderUI_CreateInstance')
+    |
+    |open_file and
+     file.path istartswith '\\Device\\Mup\\' and
+     file.extension iin
+                    (
+                      '.exe',
+                      '.dll',
+                      '.ocx',
+                      '.cpl',
+                      '.sys'
+                    )
+    |
+
+severity: high
+
+min-engine-version: 3.0.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Identifies potential NTLM hash leakage via malicious shortcut (.lnk) file processing. By crafting a .lnk file with a default icon from `shell32.dll` and the target path pointing to a remote SMB-hosted binary file, the explorer.exe process will fetch the remote file to extract the icon from the PE resource directory, leading to NTLM hash leak.


### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
