### PR TITLE
fix(tests): Override the DOS device path in the cache

### DIFF
--- a/pkg/fs/dev_test.go
+++ b/pkg/fs/dev_test.go
@@ -23,9 +23,10 @@ package fs
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var drives = []string{
@@ -74,6 +75,7 @@ func TestConvertDosDevice(t *testing.T) {
 	assert.Contains(t, files, filename)
 
 	m.(*mapper).cache["\\Device\\HarddiskVolume1"] = "C:"
+	m.(*mapper).cache["\\Device\\HarddiskVolume5"] = "\\Device\\HarddiskVolume5"
 	m.(*mapper).sysroot = "C:\\Windows"
 
 	var tests = []struct {


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Override the DOS device path in the cache to make the test more predictable. 

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

/area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
