### PR TITLE
refactor(filter)!: Make `ps.modules` return full module paths

### DIFF
--- a/pkg/filter/accessor_windows.go
+++ b/pkg/filter/accessor_windows.go
@@ -192,7 +192,7 @@ func (ps *psAccessor) Get(f Field, e *event.Event) (params.Value, error) {
 		}
 		mods := make([]string, 0, len(ps.Modules))
 		for _, m := range ps.Modules {
-			mods = append(mods, filepath.Base(m.Name))
+			mods = append(mods, m.Name)
 		}
 		return mods, nil
 	case fields.PsUUID:

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -301,7 +301,7 @@ func TestProcFilter(t *testing.T) {
 
 		{`evt.name = 'CreateProcess' and ps.name contains 'svchost'`, true},
 
-		{`ps.modules IN ('kernel32.dll')`, true},
+		{`ps.modules IN ('C:\\Windows\\System32\\kernel32.dll')`, true},
 		{`evt.name = 'CreateProcess' and evt.pid != ps.ppid`, true},
 		{`ps.parent.name = 'svchost.exe'`, true},
 
@@ -328,7 +328,7 @@ func TestProcFilter(t *testing.T) {
 		{`ps.args iintersects ('-K', 'DComLaunch')`, true},
 		{`ps.args iintersects ('-W', 'DcomLaunch')`, false},
 
-		{`foreach(ps.modules, $mod, $mod imatches 'us?r32.dll')`, true},
+		{`foreach(ps.modules, $mod, $mod imatches '?:\\*\\us?r32.dll')`, true},
 		{`foreach(ps._modules, $mod, $mod.path imatches '?:\\Windows\\System32\\us?r32.dll')`, true},
 		{`foreach(ps._modules, $mod, $mod.name imatches 'USER32.*')`, true},
 		{`foreach(ps._modules, $mod, $mod.name imatches 'USER32.*' and $mod.size >= 212354)`, true},


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Make `ps.modules` filter field return full module paths instead of base module name.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

/kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

/kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

/area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
