### PR TITLE
feat(rules): New `Potential LSA secrets registry dumping` rule

### DIFF
--- a/rules/credential_access_potential_lsa_secrets_registry_dumping.yml
+++ b/rules/credential_access_potential_lsa_secrets_registry_dumping.yml
@@ -1,0 +1,54 @@
+name: Potential LSA secrets registry dumping
+id: e5e95cbe-c8ab-418c-abe3-539d70a0b0af
+version: 1.0.0
+description: |
+  Identifies potential dumping of LSA secrets by suspicious processes that access
+  sensitive SECURITY registry hives associated with cached credentials and LSA secret
+  storage.
+  This behavior is commonly observed in credential dumping utilities attempting to
+  extract plaintext secrets, service credentials, or cached domain credentials from
+  the Local Security Authority.
+labels:
+  tactic.id: TA0006
+  tactic.name: Credential Access
+  tactic.ref: https://attack.mitre.org/tactics/TA0006/
+  technique.id: T1003
+  technique.name: OS Credential Dumping
+  technique.ref: https://attack.mitre.org/techniques/T1003/
+  subtechnique.id: T1003.004
+  subtechnique.name: LSA secrets
+  subtechnique.ref: https://attack.mitre.org/techniques/T1003/004/
+references:
+  - https://github.com/almounah/silp
+
+condition: >
+  sequence
+  maxspan 10m
+  by ps.uuid
+    |spawn_process and
+     ps.token.integrity_level not in ('LOW', 'MEDIUM') and
+     ps.exe not imatches
+                (
+                  '?:\\Windows\\regedit.exe',
+                  '?:\\Program Files\\*',
+                  '?:\\Program Files (x86)\\*',
+                  '?:\\Windows\\System32\\lsass.exe'
+                )
+    |
+    |open_registry and
+     registry.path imatches
+                (
+                  'HKEY_LOCAL_MACHINE\\SECURITY\\CACHE\\*',
+                  'HKEY_LOCAL_MACHINE\\SECURITY\\Policy\\Secrets\\*'
+                ) and
+      registry.path not imatches
+                (
+                  'HKEY_LOCAL_MACHINE\\SECURITY\\Policy\\Secrets\\$MACHINE.ACC\\CupdTime\\*'
+                )
+    |
+action:
+  - name: kill
+
+severity: critical
+
+min-engine-version: 3.0.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Identifies potential dumping of LSA secrets by suspicious processes that access sensitive SECURITY registry hives associated with cached credentials and LSA secret storage. This behavior is commonly observed in credential dumping utilities attempting to extract plaintext secrets, service credentials, or cached domain credentials from the Local Security Authority.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
