### PR TITLE
feat(rules): New `Suspicious virtual path redirection` rule

### DIFF
--- a/rules/defense_evasion_suspicious_virtual_path_redirection.yml
+++ b/rules/defense_evasion_suspicious_virtual_path_redirection.yml
@@ -1,0 +1,54 @@
+name: Suspicious virtual path redirection
+id: 71a7ba01-a7a9-428a-8704-72b200f9b43c
+version: 1.0.0
+description: |
+  Detects attempts to create files in user-writable or system-temporary locations
+  where the thread call stack shows use of APIs commonly involved in virtual-path
+  redirection / bind filter registration.
+  Attackers sometimes abuse virtual-path redirection, filter drivers, or cloud-sync
+  registration to place malicious payloads in locations that are later resolved or
+  served via trusted paths to evade detection or gain persistence.
+labels:
+  tactic.id: TA0005
+  tactic.name: Defense Evasion
+  tactic.ref: https://attack.mitre.org/tactics/TA0005/
+  technique.id: T1562
+  technique.name: Impair Defenses
+  technique.ref: https://attack.mitre.org/techniques/T1562/
+  subtechnique.id: T1562.001
+  subtechnique.name: Disable or Modify Tools
+  subtechnique.ref: https://attack.mitre.org/techniques/T1562/001
+references:
+  - https://github.com/TwoSevenOneT/EDR-Redir
+  - https://www.zerosalarium.com/2025/10/DR-Redir-Break-EDR-Via-BindLink-Cloud-Filter.html
+
+condition: >
+  create_file and
+  evt.pid != 4 and thread.callstack.symbols imatches ('ntdll.dll!*DeviceIoControlFile') and
+  thread.callstack.symbols imatches ('bindfltapi.dll!BfSetupFilter', 'cldapi.dll!CfRegisterSyncRoot') and
+  file.path imatches
+            (
+              '?:\\Users\\*\\AppData\\Local\\Temp\\*',
+              '?:\\Users\\*\\AppData\\Local\\VirtualStore\\*',
+              '?:\\Users\\*\\AppData\\Roaming\\*',
+              '?:\\Users\\Public\\*',
+              '?:\\Users\\*\\Pictures\\*',
+              '?:\\Users\\*\\Music\\*',
+              '?:\\ProgramData\\*',
+              '?:\\Windows\\Tasks\\*',
+              '?:\\Windows\\System32\\Tasks\\*',
+              '?:\\Windows\\Temp\\*',
+              '?:\\Windows\\tracing\\*',
+              '?:\\Temp\\*',
+              '?:\\Tmp\\*',
+              '?:\\PerfLogs\\*',
+              '?:\\$Recycle.Bin\\*',
+              '?:\\Intel\\*',
+              '?:\\AMD\\Temp\\*'
+            )
+
+output: >
+  Suspicious virtual path redirection mapped to %file.path by process %ps.exe
+severity: high
+
+min-engine-version: 3.0.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Detects attempts to create files in user-writable or system-temporary locations where the thread call stack shows use of APIs commonly involved in virtual-path redirection / bind filter registration. Attackers sometimes abuse virtual-path redirection, filter drivers, or cloud-sync registration to place malicious payloads in locations that are later resolved or served via trusted paths to evade detection or gain persistence.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
