### PR TITLE
feat(rules): New `Process creation via direct syscall` rule

### DIFF
--- a/rules/defense_evasion_process_creation_via_direct_syscall.yml
+++ b/rules/defense_evasion_process_creation_via_direct_syscall.yml
@@ -1,0 +1,29 @@
+name: Process creation via direct syscall
+id: 79627d37-0796-4fe9-afc2-06b9b41563e3
+version: 1.0.0
+description: |
+  Identifies process creation initiated via direct system call, a technique
+  commonly used by malware to bypass user-mode API hooks and evade security
+  monitoring.
+labels:
+  tactic.id: TA0005
+  tactic.name: Defense Evasion
+  tactic.ref: https://attack.mitre.org/tactics/TA0005/
+  technique.id: T1055
+  technique.name: Process Injection
+  technique.ref: https://attack.mitre.org/techniques/T1055/
+references:
+  - https://github.com/jthuraisamy/SysWhispers
+  - https://github.com/klezVirus/SysWhispers3
+
+condition: >
+  spawn_process and
+  direct_syscall and
+  (thread.callstack.summary not imatches 'unbacked|embeddedbrowserwebview.dll|unbacked' and
+   thread.callstack.modules not imatches ('?:\\Program Files*\\Microsoft\\EdgeWebView\\*\\EmbeddedBrowserWebView.dll')))
+action:
+  - name: kill
+
+severity: high
+
+min-engine-version: 3.0.0

--- a/rules/macros/macros.yml
+++ b/rules/macros/macros.yml
@@ -106,6 +106,10 @@
 - macro: create_symbolic_link_object
   expr: evt.name = 'CreateSymbolicLinkObject' and evt.arg[status] = 'Success'
 
+- macro: direct_syscall
+  expr: evt.is_direct_syscall
+  description: Indicates if the event has been triggered via direct syscall.
+
 - macro: inbound_network
   expr: >
     (recv_socket or accept_socket) and


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Identifies process creation initiated via direct system call, a technique commonly used by malware to bypass user-mode API hooks and evade security monitoring.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
