### PR TITLE
fix(event): Registry data buffer bound checks

### DIFF
--- a/pkg/event/param_windows.go
+++ b/pkg/event/param_windows.go
@@ -540,11 +540,40 @@ func (e *Event) produceParams(evt *etw.EventRecord) {
 			case registry.BINARY:
 				e.AppendParam(params.RegData, params.Binary, b)
 			case registry.DWORD:
-				e.AppendParam(params.RegData, params.Uint32, binary.LittleEndian.Uint32(b))
+				var v uint32
+				switch len(b) {
+				case 4:
+					v = binary.LittleEndian.Uint32(b)
+				case 2:
+					v = uint32(binary.LittleEndian.Uint16(b))
+				case 1:
+					v = uint32(b[0])
+				}
+				e.AppendParam(params.RegData, params.Uint32, v)
 			case registry.DWORD_BIG_ENDIAN:
-				e.AppendParam(params.RegData, params.Uint32, binary.BigEndian.Uint32(b))
+				var v uint32
+				switch len(b) {
+				case 4:
+					v = binary.BigEndian.Uint32(b)
+				case 2:
+					v = uint32(binary.BigEndian.Uint16(b))
+				case 1:
+					v = uint32(b[0])
+				}
+				e.AppendParam(params.RegData, params.Uint32, v)
 			case registry.QWORD:
-				e.AppendParam(params.RegData, params.Uint64, binary.LittleEndian.Uint64(b))
+				var v uint64
+				switch len(b) {
+				case 8:
+					v = binary.LittleEndian.Uint64(b)
+				case 4:
+					v = uint64(binary.LittleEndian.Uint32(b))
+				case 2:
+					v = uint64(binary.LittleEndian.Uint16(b))
+				case 1:
+					v = uint64(b[0])
+				}
+				e.AppendParam(params.RegData, params.Uint64, v)
 			}
 		}
 	case CreateFile:


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

In some occasions, the registry data buffer is provided without enough length to satisfy the underlying value type. To prevent panics, when converting the buffer to an integer data type, incorporate bound checks.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

/area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
