### PR TITLE
fix(event,processors): Prevent slice capacity leak

### DIFF
--- a/internal/etw/processors/fs_windows.go
+++ b/internal/etw/processors/fs_windows.go
@@ -372,13 +372,17 @@ func (f *fsProcessor) purge() {
 
 			// evict unmatched stack traces
 			for id, q := range f.buckets {
-				s := q[:0]
+				s := make([]*event.Event, 0, len(q))
 				for _, evt := range q {
 					if time.Since(evt.Timestamp) <= time.Second*30 {
 						s = append(s, evt)
 					}
 				}
-				f.buckets[id] = s
+				if len(s) == 0 {
+					delete(f.buckets, id)
+				} else {
+					f.buckets[id] = s
+				}
 			}
 
 			f.mu.Unlock()

--- a/pkg/event/stackwalk.go
+++ b/pkg/event/stackwalk.go
@@ -210,7 +210,7 @@ func (s *StackwalkDecorator) flush() []error {
 	errs := make([]error, 0)
 
 	for id, q := range s.buckets {
-		n := q[:0]
+		n := make([]*Event, 0, len(q))
 		for _, evt := range q {
 			if time.Since(evt.Timestamp) < maxQueueTTLPeriod {
 				n = append(n, evt)
@@ -230,7 +230,11 @@ func (s *StackwalkDecorator) flush() []error {
 			}
 			stackwalkFlushesEvents.Add(evt.Name, 1)
 		}
-		s.buckets[id] = n
+		if len(n) == 0 {
+			delete(s.buckets, id)
+		} else {
+			s.buckets[id] = n
+		}
 	}
 
 	return errs


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Hard-free the event buffer to prevent slice leak when the capacity grows, and GC cannot reclaim the memory because the buffer still references it.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

/area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
