### PR TITLE
chore(rules): Exclude sysdir from Potential ClickFix infection chain rule

### DIFF
--- a/rules/initial_access_potential_clickfix_infection_chain.yml
+++ b/rules/initial_access_potential_clickfix_infection_chain.yml
@@ -1,6 +1,6 @@
 name: Potential ClickFix infection chain
 id: ffe1fc54-2893-4760-ab50-51a83bd71d13
-version: 2.0.0
+version: 2.0.1
 description: |
   Identifies the execution of the process via the Run command dialog box, Windows Console shortuct, or Explorer address bar
   followed by spawning of the potential infostealer process.
@@ -36,8 +36,7 @@ condition: >
     |spawn_process and ps.exe not imatches
                               (
                                 '?:\\Program Files\\*.exe',
-                                '?:\\Program Files (x86)\\*.exe',
-                                '?:\\Windows\\System32\\*.exe'
+                                '?:\\Program Files (x86)\\*.exe'
                               )
     | by ps.parent.uuid
 action:


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Exclude `System32` directory exception in Potential ClickFix infection chain rule.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
