### PR TITLE
feat(rules):  New `Potential privilege escalation via DeadPotato exploit` rule

### DIFF
--- a/rules/privilege_escalation_potential_privilege_escalation_via_deadpotato_exploit.yml
+++ b/rules/privilege_escalation_potential_privilege_escalation_via_deadpotato_exploit.yml
@@ -1,0 +1,33 @@
+name: Potential privilege escalation via DeadPotato exploit
+id: 3911130a-b71c-4994-a7c3-5ae07dc0abe0
+version: 1.0.0
+description: |
+  Detects potential privilege escalation activity consistent with the DeadPotato
+  exploit. Attackers can abuse the DCOM RPCSS service flaw to start an elevated
+  process allowing unrestricted access over the machine for critical operations to
+  be freely performed.
+labels:
+  tactic.id: TA0004
+  tactic.name: Privilege Escalation
+  tactic.ref: https://attack.mitre.org/tactics/TA0004/
+  technique.id: T1068
+  technique.name: Exploitation for Privilege Escalation
+  technique.ref: https://attack.mitre.org/techniques/T1068/
+references:
+  - https://github.com/lypd0/DeadPotato
+
+condition: >
+  sequence
+  maxspan 1m
+    |connect_socket and
+     ps.name = 'svchost.exe' and ps.args intersects ('-k', 'RPCSS') and
+     net.dport = 135 and (net.dip = 127.0.0.1 or net.dip = '::1')
+    |
+    |spawn_process and
+     ps.token.integrity_level = 'SYSTEM' and
+     ps.exe not imatches '?:\\WINDOWS\\system32\\conhost.exe'
+    |
+
+severity: high
+
+min-engine-version: 3.0.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Detects potential privilege escalation activity consistent with the DeadPotato exploit. Attackers can abuse the `DCOM RPCSS ` service flaw to start an elevated process allowing unrestricted access over the machine for critical operations to be freely performed.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
