### PR TITLE
feat(rules): New `UAC bypass via assembly Native Image Cache hijack` rule

### DIFF
--- a/rules/privilege_escalation_uac_bypass_via_assembly_native_image_cache_hijack.yml
+++ b/rules/privilege_escalation_uac_bypass_via_assembly_native_image_cache_hijack.yml
@@ -1,0 +1,43 @@
+name: UAC bypass via assembly Native Image Cache hijack
+id: d10685d9-675c-4888-a246-85758e4c4515
+version: 1.0.0
+description: |
+  Detects attempts to bypass User Account Control (UAC) by hijacking the
+  .NET Native Image Cache (NativeImages) through unauthorized assembly
+  creation followed by execution of a high-integrity process.
+labels:
+  tactic.id: TA0004
+  tactic.name: Privilege Escalation
+  tactic.ref: https://attack.mitre.org/tactics/TA0004/
+  technique.id: T1548
+  technique.name: Abuse Elevation Control Mechanism
+  technique.ref: https://attack.mitre.org/techniques/T1548/
+  subtechnique.id: T1548.002
+  subtechnique.name: Bypass User Account Control
+  subtechnique.ref: https://attack.mitre.org/techniques/T1548/002/
+references:
+  - https://github.com/hfiref0x/UACME
+
+condition: >
+  sequence
+  maxspan 1m
+    |create_file and
+     evt.pid != 4 and ps.sid != 'S-1-5-18' and
+     file.path imatches '?:\\WINDOWS\\assembly\\NativeImages_*\\*.dll' and
+     ps.exe not imatches
+                (
+                  '?:\\Windows\\Microsoft.NET\\Framework\\*\\ngen.exe',
+                  '?:\\Windows\\Microsoft.NET\\Framework64\\*\\ngen.exe',
+                  '?:\\Windows\\Microsoft.NET\\Framework\\*\\mscorsvw.exe',
+                  '?:\\Windows\\Microsoft.NET\\Framework64\\*\\mscorsvw.exe',
+                  '?:\\Windows\\servicing\\TrustedInstaller.exe'
+                )
+    | as e1
+    |spawn_process and
+     ps.token.integrity_level = 'HIGH' and
+     thread.callstack.summary imatches concat('ntdll.dll|KernelBase.dll|*', $e1.file.name, '|*')
+    |
+
+severity: high
+
+min-engine-version: 3.0.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Detects attempts to bypass User Account Control (UAC) by hijacking the .NET Native Image Cache (NativeImages) through unauthorized DLL creation followed by execution in a high-integrity process, a technique commonly abused to achieve local privilege escalation.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
