### PR TITLE
feat(rules): New `UAC bypass via CDSSync scheduled task hijack` rule

### DIFF
--- a/rules/privilege_escalation_uac_bypass_via_cdssync_scheduled_task_hijack.yml
+++ b/rules/privilege_escalation_uac_bypass_via_cdssync_scheduled_task_hijack.yml
@@ -1,0 +1,43 @@
+name: UAC bypass via CDSSync scheduled task hijack
+id: 7de08df3-c2ab-4632-ab26-37e617815edb
+version: 1.0.0
+description: |
+  Identifies attempts to bypass User Account Control (UAC) by hijacking the CDSSync
+  scheduled task through a malicious npmproxy.dll. Such behavior is indicative of a
+  UAC bypass technique where attackers abuse auto-elevated scheduled tasks to execute
+  code with elevated privileges.
+labels:
+  tactic.id: TA0004
+  tactic.name: Privilege Escalation
+  tactic.ref: https://attack.mitre.org/tactics/TA0004/
+  technique.id: T1548
+  technique.name: Abuse Elevation Control Mechanism
+  technique.ref: https://attack.mitre.org/techniques/T1548/
+  subtechnique.id: T1548.002
+  subtechnique.name: Bypass User Account Control
+  subtechnique.ref: https://attack.mitre.org/techniques/T1548/002/
+references:
+  - https://www.elastic.co/de/security-labs/exploring-windows-uac-bypasses-techniques-and-detection-strategies
+
+condition: >
+  sequence
+  maxspan 1m
+    |create_file and
+     file.path imatches '?:\\*\\System32\\npmproxy.dll' and
+     file.path not imatches
+                (
+                  '?:\\Windows\\System32\\npmproxy.dll',
+                  '?:\\Windows\\SysWOW64\\npmproxy.dll'
+                )
+    | as e1
+    |spawn_process and
+     ps.name ~= 'taskhostw.exe' and ps.token.integrity_level = 'HIGH' and
+     thread.callstack.summary imatches concat('ntdll.dll|KernelBase.dll|kernel32.dll|npmproxy.dll|*', base($e1.file.path), '|*') and
+     ps.exe not imatches '?:\\Windows\\System32\\WinSAT.exe'
+    |
+action:
+  - name: kill
+
+severity: high
+
+min-engine-version: 3.0.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Identifies attempts to bypass User Account Control (UAC) by hijacking the CDSSync scheduled task through a malicious `npmproxy.dll`. Such behavior is indicative of a UAC bypass technique where attackers abuse auto-elevated scheduled tasks to execute code with elevated privileges.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
