### PR TITLE
feat(rules): New `UAC bypass via Control Panel applet execution hijack` rule

### DIFF
--- a/rules/privilege_escalation_uac_bypass_via_control_panel_applet_execution_hijack.yml
+++ b/rules/privilege_escalation_uac_bypass_via_control_panel_applet_execution_hijack.yml
@@ -1,0 +1,41 @@
+name: UAC bypass via Control Panel applet execution hijack
+id: daddbf61-c391-4875-988a-a385b38c397d
+version: 1.0.0
+description: |
+  Identifies attempts to bypass User Account Control (UAC) by abusing trusted Control Panel
+  execution paths to achieve unauthorized privilege escalation.
+  Attackers leverage the implicit trust and auto-elevation behavior of Control Panel components
+  to execute arbitrary code with elevated privileges. By manipulating how Control Panel applets
+  or associated shell handlers are resolved, adversaries can cause privileged system processes to
+  launch attacker-controlled payloads without triggering a UAC prompt.
+labels:
+  tactic.id: TA0004
+  tactic.name: Privilege Escalation
+  tactic.ref: https://attack.mitre.org/tactics/TA0004/
+  technique.id: T1548
+  technique.name: Abuse Elevation Control Mechanism
+  technique.ref: https://attack.mitre.org/techniques/T1548/
+  subtechnique.id: T1548.002
+  subtechnique.name: Bypass User Account Control
+  subtechnique.ref: https://attack.mitre.org/techniques/T1548/002/
+references:
+  - https://github.com/hfiref0x/UACME
+
+condition: >
+  sequence
+  maxspan 1m
+    |set_value and
+     registry.path imatches
+                  (
+                    'HKEY_CURRENT_USER\\Environment\\Path',
+                    'HKEY_USERS\\S-1-5-21*_Classes\\Folder\\Shell\\Open\\Command*'
+                  )
+    |
+    |spawn_process and
+     ps.token.integrity_level = 'HIGH' and
+     ((ps.parent.name ~= 'control.exe' and length(ps.args) >= 2) or thread.callstack.symbols imatches ('shell32.dll!Control_RunDLL*'))
+    |
+
+severity: high
+
+min-engine-version: 3.0.0


### PR DESCRIPTION
Identifies attempts to bypass User Account Control (UAC) by abusing trusted Control Panel execution paths to achieve unauthorized privilege escalation. Attackers leverage the implicit trust and auto-elevation behavior of Control Panel components to execute arbitrary code with elevated privileges. By manipulating how Control Panel applets or associated shell handlers are resolved, adversaries can cause privileged system processes to launch attacker-controlled payloads without triggering a UAC prompt.

### What is the purpose of this PR / why it is needed?


### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
