### PR TITLE
fix(tests): Add real ppid in symbolizer tests

### DIFF
--- a/pkg/symbolize/symbolizer_test.go
+++ b/pkg/symbolize/symbolizer_test.go
@@ -270,8 +270,9 @@ func TestProcessCallstack(t *testing.T) {
 		Category:  event.Process,
 		Host:      "archrabbit",
 		Params: event.Params{
-			params.ProcessParentID: {Name: params.ProcessParentID, Type: params.PID, Value: (uint32(os.Getpid()))},
-			params.Callstack:       {Name: params.Callstack, Type: params.Slice, Value: []va.Address{0x7ffb5c1d0396, 0x7ffb5d8e61f4, 0x7ffb3138592e, 0x7ffb313853b2, 0x2638e59e0a5}},
+			params.ProcessParentID:     {Name: params.ProcessParentID, Type: params.PID, Value: (uint32(os.Getpid()))},
+			params.ProcessRealParentID: {Name: params.ProcessRealParentID, Type: params.PID, Value: (uint32(os.Getpid()))},
+			params.Callstack:           {Name: params.Callstack, Type: params.Slice, Value: []va.Address{0x7ffb5c1d0396, 0x7ffb5d8e61f4, 0x7ffb3138592e, 0x7ffb313853b2, 0x2638e59e0a5}},
 		},
 		PS: proc,
 	}
@@ -443,8 +444,9 @@ func TestProcessCallstackProcsTTL(t *testing.T) {
 			Category:  event.Process,
 			Host:      "archrabbit",
 			Params: event.Params{
-				params.ProcessParentID: {Name: params.ProcessParentID, Type: params.PID, Value: (uint32(os.Getpid()))},
-				params.Callstack:       {Name: params.Callstack, Type: params.Slice, Value: []va.Address{0x7ffb5c1d0396, 0x7ffb5d8e61f4, 0x7ffb3138592e, 0x7ffb313853b2, 0x2638e59e0a5}},
+				params.ProcessParentID:     {Name: params.ProcessParentID, Type: params.PID, Value: (uint32(os.Getpid()))},
+				params.ProcessRealParentID: {Name: params.ProcessRealParentID, Type: params.PID, Value: (uint32(os.Getpid()))},
+				params.Callstack:           {Name: params.Callstack, Type: params.Slice, Value: []va.Address{0x7ffb5c1d0396, 0x7ffb5d8e61f4, 0x7ffb3138592e, 0x7ffb313853b2, 0x2638e59e0a5}},
 			},
 		}
 		_, _ = s.ProcessEvent(e)


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

The event in the symbolizer tests is missing the real parent pid, which leads to a panic because the parameter is not found.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

/area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
