### PR TITLE
refactor(rules): Remove inbound/outbound network macros

### DIFF
--- a/rules/persistence_network_connection_via_startup_folder_executable_or_script.yml
+++ b/rules/persistence_network_connection_via_startup_folder_executable_or_script.yml
@@ -1,6 +1,6 @@
 name: Network connection via startup folder executable or script
 id: 09b7278d-42e3-4792-9f00-dee38baecfad
-version: 1.0.5
+version: 1.1.0
 description: |
   Identifies the execution of unsigned binary or script from the
   Startup folder followed by network inbound or outbound connection.
@@ -22,6 +22,10 @@ condition: >
     |(load_untrusted_executable and module.path imatches startup_locations) or
      (load_executable and ps.name in script_interpreters and ps.cmdline imatches startup_locations)
     |
-    |((inbound_network) or (outbound_network)) and ps.cmdline imatches startup_locations|
+    |connect_socket and
+     ps.cmdline imatches startup_locations and
+     net.dip != 0.0.0.0 and net.dip not in ('0:0:0:0:0:0:0:1', '::1') and
+     not cidr_contains(net.dip, '127.0.0.0/8', '10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16')
+    |
 
 min-engine-version: 3.0.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Removes inbound/outbound network macros from the rule and switches to using only the connect socket event.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

/kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
