### PR TITLE
fix(rule_engine): Enforce temporal monotonicity

### DIFF
--- a/pkg/rules/engine_test.go
+++ b/pkg/rules/engine_test.go
@@ -299,7 +299,7 @@ func TestRunSequenceRuleWithPsUUIDLink(t *testing.T) {
 	e2 := &event.Event{
 		Seq:       2,
 		Type:      event.CreateFile,
-		Timestamp: time.Now(),
+		Timestamp: time.Now().Add(time.Second),
 		Name:      "CreateFile",
 		Tid:       2484,
 		PID:       uint32(os.Getpid()),


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Enforces temporal monotonicity by comparing the timestamp of the last matched partial in the previous slot.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

/area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
