### PR TITLE
fix(processor): Correct unbounded registry values slice growth

### DIFF
--- a/internal/etw/processors/registry_windows_test.go
+++ b/internal/etw/processors/registry_windows_test.go
@@ -19,6 +19,9 @@
 package processors
 
 import (
+	"testing"
+	"time"
+
 	"github.com/rabbitstack/fibratus/pkg/event"
 	"github.com/rabbitstack/fibratus/pkg/event/params"
 	"github.com/rabbitstack/fibratus/pkg/handle"
@@ -26,8 +29,6 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/util/key"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
 )
 
 func init() {
@@ -183,8 +184,8 @@ func TestRegistryProcessor(t *testing.T) {
 				},
 			},
 			func(p Processor) {
-				p.(*registryProcessor).values[23234] = []*event.Event{
-					{
+				p.(*registryProcessor).values[23234] = map[string]*event.Event{
+					"SessionId": {
 						Type:      event.RegSetValueInternal,
 						Timestamp: time.Now(),
 						Params: event.Params{
@@ -193,7 +194,7 @@ func TestRegistryProcessor(t *testing.T) {
 							params.RegValueType: {Name: params.RegValueType, Type: params.Enum, Value: uint32(1), Enum: key.RegistryValueTypes},
 							params.RegKeyHandle: {Name: params.RegKeyHandle, Type: params.Uint64, Value: uint64(0)}},
 					},
-					{
+					"Directory": {
 						Type:      event.RegSetValueInternal,
 						Timestamp: time.Now(),
 						Params: event.Params{


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Refactors the registry data stitching to prevent unbounded slice growth.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

/kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

/area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
