### PR TITLE
perf(etw): Increase default max buffers

### DIFF
--- a/pkg/config/eventsource.go
+++ b/pkg/config/eventsource.go
@@ -22,10 +22,11 @@
 package config
 
 import (
-	"github.com/rabbitstack/fibratus/pkg/event"
-	"github.com/rabbitstack/fibratus/pkg/util/bitmask"
 	"runtime"
 	"time"
+
+	"github.com/rabbitstack/fibratus/pkg/event"
+	"github.com/rabbitstack/fibratus/pkg/util/bitmask"
 
 	pstypes "github.com/rabbitstack/fibratus/pkg/ps/types"
 	"github.com/spf13/viper"
@@ -57,7 +58,7 @@ const (
 
 var (
 	defaultMinBuffers    = uint32(runtime.NumCPU() * 2)
-	defaultMaxBuffers    = defaultMinBuffers + 20
+	defaultMaxBuffers    = uint32(runtime.NumCPU() * 8)
 	defaultFlushInterval = time.Second
 )
 


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Increase ETW session default max buffers to the number of CPUs * 8.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

/area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
