### PR TITLE
fix(systray): Distinguish between behaviour and YARA notifications

### DIFF
--- a/cmd/systray/main_windows.go
+++ b/cmd/systray/main_windows.go
@@ -35,6 +35,7 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/sys"
 	"github.com/rabbitstack/fibratus/pkg/util/log"
 	"github.com/rabbitstack/fibratus/pkg/util/signals"
+	yconfig "github.com/rabbitstack/fibratus/pkg/yara/config"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
 )
@@ -49,8 +50,8 @@ const (
 )
 
 var (
-	className  = windows.StringToUTF16Ptr("fibratus")
-	alertTitle = "Malicious Activity Detected"
+	className           = windows.StringToUTF16Ptr("fibratus")
+	defaultSystrayTitle = "Malicious Activity Detected"
 )
 
 // Msg represents the data exchanged between systray client/server.
@@ -75,6 +76,24 @@ func (m Msg) decode(output any) error {
 		return err
 	}
 	return decoder.Decode(m.Data)
+}
+
+func systrayTitle(alert alertsender.Alert) string {
+	switch alert.Title {
+	case yconfig.MemoryThreatAlertTitle, yconfig.FileThreatAlertTitle:
+		return alert.Title
+	default:
+		return defaultSystrayTitle
+	}
+}
+
+func systrayText(alert alertsender.Alert) string {
+	switch alert.Title {
+	case yconfig.MemoryThreatAlertTitle, yconfig.FileThreatAlertTitle:
+		return alert.Text
+	default:
+		return alert.Title
+	}
 }
 
 type Systray struct {
@@ -222,7 +241,7 @@ func (s *Systray) handleMessage(m Msg) error {
 			logrus.Errorf("unable to decode alert: %v", err)
 			return err
 		}
-		return s.systrayIcon.ShowBalloonNotification(alertTitle, alert.Title, s.config.Sound, s.config.QuietMode)
+		return s.systrayIcon.ShowBalloonNotification(systrayTitle(alert), systrayText(alert), s.config.Sound, s.config.QuietMode)
 	}
 	return nil
 }


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

The notification area text and title are rendered depending on whether the alert is generated by the behaviour or the YARA rule engine.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

/kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

/area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
