### PR TITLE
fix(accessor): Ignore System process PE parsing

### DIFF
--- a/pkg/filter/accessor_windows.go
+++ b/pkg/filter/accessor_windows.go
@@ -1078,6 +1078,11 @@ func newPEAccessor() Accessor {
 }
 
 func (pa *peAccessor) Get(f Field, e *event.Event) (params.Value, error) {
+	// ignore System process
+	if e.PID == psnap.SystemPID {
+		return nil, nil
+	}
+
 	var p *pe.PE
 	if e.PS != nil && e.PS.PE != nil {
 		p = e.PS.PE


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Ignore the `System` process PE parsing to reduce file open operations. In general, System process PE is not very useful.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

/area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
