### PR TITLE
fix(yara):  Address ADS scanning leftovers

### DIFF
--- a/pkg/yara/scanner.go
+++ b/pkg/yara/scanner.go
@@ -262,8 +262,7 @@ func (s scanner) Scan(e *event.Event) (bool, error) {
 		if err != nil {
 			return false, nil
 		}
-		if n > 0 {
-			data = data[:n]
+		if len(data) > 0 {
 			log.Debugf("scanning ADS %s. pid: %d", filename, e.PID)
 			matches, err = s.scan(data)
 			streamScans.Add(1)


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

After moving from NTFS parser to overlapped I/O, the code for scanning the ADS content was not adapted accordingly.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

/area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
