### PR TITLE
perf(symbolizer): Cache unsuccessful debug help resolutions

### DIFF
--- a/pkg/symbolize/symbolizer.go
+++ b/pkg/symbolize/symbolizer.go
@@ -535,12 +535,16 @@ func (s *Symbolizer) produceFrame(addr va.Address, e *event.Event) callstack.Fra
 	if !ok {
 		handle, err := windows.OpenProcess(windows.SYNCHRONIZE|windows.PROCESS_QUERY_INFORMATION, false, pid)
 		if err != nil {
+			// symbol handler initalization fails, cache
+			// the symbol for future lookups
+			s.cacheSymbolUnbacked(pid, addr, &frame)
 			return frame
 		}
 		// initialize symbol handler
 		opts := uint32(sys.SymUndname | sys.SymCaseInsensitive | sys.SymAutoPublics | sys.SymOmapFindNearest | sys.SymDeferredLoads)
 		err = s.r.Initialize(handle, opts)
 		if err != nil {
+			s.cacheSymbolUnbacked(pid, addr, &frame)
 			return frame
 		}
 		proc = &process{pid, handle, time.Now(), 1}
@@ -652,6 +656,13 @@ func (s *Symbolizer) cacheSymbol(pid uint32, addr va.Address, frame *callstack.F
 		symCachedSymbols.Add(1)
 		s.symbols[pid] = map[va.Address]syminfo{addr: {module: frame.Module, symbol: frame.Symbol, moduleAddress: frame.ModuleAddress}}
 	}
+}
+
+func (s *Symbolizer) cacheSymbolUnbacked(pid uint32, addr va.Address, frame *callstack.Frame) {
+	if frame.Module == "?" {
+		frame.Module = "unbacked"
+	}
+	s.cacheSymbol(pid, addr, frame)
 }
 
 func (s *Symbolizer) cleanSym() {


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

If the process handle can't be acquired or the symbol handler initialization fails, we cache the symbol info to avoid hammering the OpenProcess API indefinitely.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

/area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
