### PR TITLE
fix(filter): Include field argument in valuer

### DIFF
--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -71,6 +71,19 @@ type Field struct {
 	Arg   string
 }
 
+func (f *Field) String() string {
+	if f.Arg != "" {
+		var b strings.Builder
+		b.Grow(len(f.Value) + len(f.Arg) + 2)
+		b.WriteString(f.Value)
+		b.WriteByte('[')
+		b.WriteString(f.Arg)
+		b.WriteByte(']')
+		return b.String()
+	}
+	return f.Value
+}
+
 // BoundField contains the field meta attributes in addition to bound field specific fields.
 type BoundField struct {
 	Field    Field
@@ -489,15 +502,15 @@ func (f *filter) mapValuer(evt *event.Event) map[string]any {
 			v, err := accessor.Get(field, evt)
 			if v == nil || err != nil {
 				if v == nil {
-					valuer[field.Value] = defaultAccessorValue(field)
+					valuer[field.String()] = defaultAccessorValue(field)
 				}
 				if err != nil && !errs.IsParamNotFound(err) {
-					valuer[field.Value] = defaultAccessorValue(field)
+					valuer[field.String()] = defaultAccessorValue(field)
 					accessorErrors.Add(err.Error(), 1)
 				}
 				continue
 			}
-			valuer[field.Value] = v
+			valuer[field.String()] = v
 			break
 		}
 	}
@@ -507,7 +520,7 @@ func (f *filter) mapValuer(evt *event.Event) map[string]any {
 // addField appends a new field to the filter fields list.
 func (f *filter) addField(field *ql.FieldLiteral) {
 	for _, f := range f.fields {
-		if f.Value == field.Value {
+		if f.String() == field.String() {
 			return
 		}
 	}

--- a/pkg/filter/ql/ast.go
+++ b/pkg/filter/ql/ast.go
@@ -21,12 +21,13 @@
 package ql
 
 import (
-	fuzzysearch "github.com/lithammer/fuzzysearch/fuzzy"
-	"github.com/rabbitstack/fibratus/pkg/util/sets"
-	"github.com/rabbitstack/fibratus/pkg/util/wildcard"
 	"net"
 	"strconv"
 	"strings"
+
+	fuzzysearch "github.com/lithammer/fuzzysearch/fuzzy"
+	"github.com/rabbitstack/fibratus/pkg/util/sets"
+	"github.com/rabbitstack/fibratus/pkg/util/wildcard"
 )
 
 // Eval evaluates expr against a map that contains the field values.
@@ -198,7 +199,7 @@ func (v *ValuerEval) Eval(expr Expr) interface{} {
 	case *BoolLiteral:
 		return expr.Value
 	case *FieldLiteral:
-		val, ok := v.Valuer.Value(expr.Value)
+		val, ok := v.Valuer.Value(expr.String())
 		if !ok {
 			return nil
 		}

--- a/pkg/filter/ql/literal.go
+++ b/pkg/filter/ql/literal.go
@@ -98,7 +98,16 @@ func (s StringLiteral) String() string {
 	return s.Value
 }
 
-func (f FieldLiteral) String() string {
+func (f *FieldLiteral) String() string {
+	if f.Arg != "" {
+		var b strings.Builder
+		b.Grow(len(f.Value) + len(f.Arg) + 2)
+		b.WriteString(f.Value)
+		b.WriteByte('[')
+		b.WriteString(f.Arg)
+		b.WriteByte(']')
+		return b.String()
+	}
 	return f.Value
 }
 


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

This PR corrects the argument-based field naming. If the field supports arguments, the name of the field passed to the valuer must include the argument as well.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

/area rule-engine

/area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
