### PR TITLE
fix(filament): Rename comm dict key

### DIFF
--- a/pkg/filament/dict.go
+++ b/pkg/filament/dict.go
@@ -23,6 +23,7 @@ package filament
 
 import (
 	"errors"
+
 	"github.com/rabbitstack/fibratus/pkg/event"
 	"github.com/rabbitstack/fibratus/pkg/event/params"
 	"github.com/rabbitstack/fibratus/pkg/filament/cpython"
@@ -34,7 +35,7 @@ var (
 	ppid       = cpython.PyUnicodeFromString("ppid")
 	cwd        = cpython.PyUnicodeFromString("cwd")
 	exec       = cpython.PyUnicodeFromString("exe")
-	comm       = cpython.PyUnicodeFromString("comm")
+	cmdline    = cpython.PyUnicodeFromString("cmdline")
 	sid        = cpython.PyUnicodeFromString("sid")
 	tid        = cpython.PyUnicodeFromString("tid")
 	cpu        = cpython.PyUnicodeFromString("cpu")
@@ -73,7 +74,7 @@ func newEventDict(evt *event.Event) (*cpython.Dict, error) {
 		dict.Insert(ppid, cpython.NewPyObjectFromValue(ps.Ppid))
 		dict.Insert(cwd, cpython.NewPyObjectFromValue(ps.Cwd))
 		dict.Insert(exec, cpython.NewPyObjectFromValue(ps.Name))
-		dict.Insert(comm, cpython.NewPyObjectFromValue(ps.Cmdline))
+		dict.Insert(cmdline, cpython.NewPyObjectFromValue(ps.Cmdline))
 		dict.Insert(sid, cpython.NewPyObjectFromValue(ps.SID))
 	}
 


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Rename the `comm` Python dictionary key to `cmdline`.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

/kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

/area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
