### PR TITLE
fix(stackwalk): Mitigate deadlock on full input queue

### DIFF
--- a/pkg/event/stackwalk.go
+++ b/pkg/event/stackwalk.go
@@ -201,13 +201,13 @@ func (s *StackwalkDecorator) doFlush() {
 // TTL period.
 func (s *StackwalkDecorator) flush() []error {
 	s.mux.Lock()
-	defer s.mux.Unlock()
 
 	if len(s.buckets) == 0 {
+		s.mux.Unlock()
 		return nil
 	}
 
-	errs := make([]error, 0)
+	expired := make([]*Event, 0)
 
 	for id, q := range s.buckets {
 		n := make([]*Event, 0, len(q))
@@ -216,25 +216,34 @@ func (s *StackwalkDecorator) flush() []error {
 				n = append(n, evt)
 				continue
 			}
-
-			stackwalkFlushes.Add(1)
-			err := s.q.push(evt)
-			if err != nil {
-				errs = append(errs, err)
-			}
-			if stackwalkEnqueued.Value() > 0 {
-				stackwalkEnqueued.Add(-1)
-			}
-			if evt.PS != nil {
-				stackwalkFlushesProcs.Add(evt.PS.Name, 1)
-			}
-			stackwalkFlushesEvents.Add(evt.Name, 1)
+			expired = append(expired, evt)
 		}
 		if len(n) == 0 {
 			delete(s.buckets, id)
 		} else {
 			s.buckets[id] = n
 		}
+	}
+
+	s.mux.Unlock()
+	errs := make([]error, 0)
+
+	// push expired events without holding the mutex.
+	// This allows incoming Push()/Pop() calls to proceed
+	// while the channel send may block briefly
+	for _, evt := range expired {
+		stackwalkFlushes.Add(1)
+		err := s.q.push(evt)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		if stackwalkEnqueued.Value() > 0 {
+			stackwalkEnqueued.Add(-1)
+		}
+		if evt.PS != nil {
+			stackwalkFlushesProcs.Add(evt.PS.Name, 1)
+		}
+		stackwalkFlushesEvents.Add(evt.Name, 1)
 	}
 
 	return errs


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

The flush() method held the mutex while calling q.push() which does a blocking channel send. When the event channel fills up the sequence is:

1. Flusher acquires mutex, calls q.push(evt)
2. q.push() blocks on channel send (channel full)
3. Incoming StackWalk events call Pop()  blocks on the mutex
4. ETW consumer goroutine blocks waiting for Pop()
5. Consumer can't drain the channel, leading to permanent deadlock

Fix: split flush() into two phases:
 1: collect expired events under the lock, then release it
 2: push events without holding the mutex

This allows Push()/Pop() to proceed while the flusher pushes events, breaking the deadlock cycle.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

/area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
