### PR TITLE
refactor(processors): Remove unused rate limiter

### DIFF
--- a/internal/etw/processors/fs_windows.go
+++ b/internal/etw/processors/fs_windows.go
@@ -33,7 +33,6 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/sys"
 	"github.com/rabbitstack/fibratus/pkg/util/va"
 	"golang.org/x/sys/windows"
-	"golang.org/x/time/rate"
 )
 
 var (
@@ -65,8 +64,6 @@ type fsProcessor struct {
 	purger  *time.Ticker
 
 	quit chan struct{}
-	// lim throttles the parsing of image characteristics
-	lim *rate.Limiter
 }
 
 // FileInfo stores file information obtained from event state.
@@ -91,7 +88,6 @@ func newFsProcessor(
 		buckets:   make(map[uint64][]*event.Event),
 		purger:    time.NewTicker(time.Second * 5),
 		quit:      make(chan struct{}, 1),
-		lim:       rate.NewLimiter(30, 40), // allow 30 parse ops per second or bursts of 40 ops
 	}
 
 	go f.purge()


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Remove unused rate limiter `fsProcessor` structure's variable declaration and initialization.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

/kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

/area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
