### PR TITLE
perf(filter): Pre-lowercase LHS for imatches/icontains operators

### DIFF
--- a/pkg/filter/ql/ast.go
+++ b/pkg/filter/ql/ast.go
@@ -854,12 +854,13 @@ func (v *ValuerEval) evalBinaryExpr(expr *BinaryExpr) interface{} {
 				return false
 			}
 		case IContains:
+			v := strings.ToLower(lhs)
 			switch rhs := rhs.(type) {
 			case string:
-				return strings.Contains(strings.ToLower(lhs), strings.ToLower(rhs))
+				return strings.Contains(v, strings.ToLower(rhs))
 			case []string:
 				for _, s := range rhs {
-					if strings.Contains(strings.ToLower(lhs), strings.ToLower(s)) {
+					if strings.Contains(v, strings.ToLower(s)) {
 						return true
 					}
 				}
@@ -960,12 +961,13 @@ func (v *ValuerEval) evalBinaryExpr(expr *BinaryExpr) interface{} {
 				return false
 			}
 		case IMatches:
+			v := strings.ToLower(lhs)
 			switch rhs := rhs.(type) {
 			case string:
-				return wildcard.Match(strings.ToLower(rhs), strings.ToLower(lhs))
+				return wildcard.Match(strings.ToLower(rhs), v)
 			case []string:
 				for _, pat := range rhs {
-					if wildcard.Match(strings.ToLower(pat), strings.ToLower(lhs)) {
+					if wildcard.Match(strings.ToLower(pat), v) {
 						return true
 					}
 				}


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

`ToLower` the event value once per comparison block instead of once per pattern in the list. For a rule with 10 `imatches` patterns, this eliminates 9 redundant string allocations and saves additional CPU cycles.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

/area rule-engine

/area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
