### PR TITLE
fix(ps): Avoid returning module temporary copy on stack under released lock

### DIFF
--- a/pkg/ps/types/types_windows.go
+++ b/pkg/ps/types/types_windows.go
@@ -497,7 +497,9 @@ func (ps *PS) RemoveHandle(handle windows.Handle) {
 
 // AddModule adds a new module to this process state.
 func (ps *PS) AddModule(mod Module) {
+	ps.RLock()
 	m := ps.FindModuleByAddr(mod.BaseAddress)
+	ps.RUnlock()
 	if m != nil {
 		return
 	}
@@ -522,9 +524,9 @@ func (ps *PS) RemoveModule(addr va.Address) {
 func (ps *PS) FindModule(path string) *Module {
 	ps.RLock()
 	defer ps.RUnlock()
-	for _, mod := range ps.Modules {
-		if filepath.Base(mod.Name) == filepath.Base(path) {
-			return &mod
+	for i := range ps.Modules {
+		if filepath.Base(ps.Modules[i].Name) == filepath.Base(path) {
+			return &ps.Modules[i]
 		}
 	}
 	return nil
@@ -532,11 +534,9 @@ func (ps *PS) FindModule(path string) *Module {
 
 // FindModuleByAddr finds the module by its base address.
 func (ps *PS) FindModuleByAddr(addr va.Address) *Module {
-	ps.RLock()
-	defer ps.RUnlock()
-	for _, mod := range ps.Modules {
-		if mod.BaseAddress == addr {
-			return &mod
+	for i := range ps.Modules {
+		if ps.Modules[i].BaseAddress == addr {
+			return &ps.Modules[i]
 		}
 	}
 	return nil
@@ -549,7 +549,9 @@ var queryLiveModules = func(pid uint32) []sys.ProcessModule {
 // FindModuleByVa finds the module name by
 // probing the range of the given virtual address.
 func (ps *PS) FindModuleByVa(addr va.Address) *Module {
+	ps.RLock()
 	mod := ps.findModuleByVa(addr)
+	ps.RUnlock()
 	if mod != nil {
 		return mod
 	}
@@ -569,8 +571,7 @@ func (ps *PS) FindModuleByVa(addr va.Address) *Module {
 		if addr < b || addr >= b.Inc(size) {
 			continue
 		}
-
-		mod := Module{
+		mod := &Module{
 			Name:               m.Name,
 			BaseAddress:        b,
 			Size:               size,
@@ -578,22 +579,21 @@ func (ps *PS) FindModuleByVa(addr va.Address) *Module {
 		}
 
 		ps.Lock()
-		ps.Modules = append(ps.Modules, mod)
+		ps.Modules = append(ps.Modules, *mod)
 		ps.Unlock()
 
-		return &mod
+		return mod
 	}
 
 	return nil
 }
 
 func (ps *PS) findModuleByVa(addr va.Address) *Module {
-	ps.RLock()
-	defer ps.RUnlock()
-	for _, mod := range ps.Modules {
-		end := mod.BaseAddress.Inc(mod.Size)
-		if addr >= mod.BaseAddress && addr < end {
-			return &mod
+	for i := range ps.Modules {
+		end := ps.Modules[i].BaseAddress.Inc(ps.Modules[i].Size)
+		if addr >= ps.Modules[i].BaseAddress && addr < end {
+			mod := &ps.Modules[i]
+			return mod
 		}
 	}
 	return nil


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Module is a copy of the slice element, re-used on each iteration. Returning &mod gives the caller a pointer to that temporary copy on the stack. Once the function returns, that memory is either stale or (if the compiler escapes it to the heap) points to a value that is disconnected from the original slice. Any mutation through the pointer won't affect `ps.Modules`, and the pointed-to value may be unexpected if the compiler reuses the variable.

Secondly, returning a pointer under a released lock, the caller receives a module pointer, but the `RUnlock` runs before the caller uses it. If another goroutine mutates or removes that module from the slice concurrently, the caller is reading (or writing through) the pointer without any lock held.


### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

/area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
