### PR TITLE
refactor(filter): Deprecate file.share.mask field

### DIFF
--- a/pkg/event/flags.go
+++ b/pkg/event/flags.go
@@ -19,9 +19,10 @@
 package event
 
 import (
+	"strings"
+
 	"github.com/rabbitstack/fibratus/pkg/sys"
 	"golang.org/x/sys/windows"
-	"strings"
 )
 
 // ParamFlag defines the mapping between the flag value and its symbolical name.
@@ -178,6 +179,7 @@ var FileCreateOptionsFlags = []ParamFlag{
 
 // FileShareModeFlags describes file share mask flags
 var FileShareModeFlags = []ParamFlag{
+	{"DENY", 0},
 	{"READ", windows.FILE_SHARE_READ},
 	{"WRITE", windows.FILE_SHARE_WRITE},
 	{"DELETE", windows.FILE_SHARE_DELETE},

--- a/pkg/filter/accessor_windows.go
+++ b/pkg/filter/accessor_windows.go
@@ -691,7 +691,7 @@ func (l *fileAccessor) Get(f Field, e *event.Event) (params.Value, error) {
 		return e.Params.GetUint64(params.FileOffset)
 	case fields.FileIOSize:
 		return e.Params.GetUint32(params.FileIoSize)
-	case fields.FileShareMask:
+	case fields.FileShareMode, fields.FileShareMask:
 		return e.GetParamAsString(params.FileShareMask), nil
 	case fields.FileOperation:
 		return e.GetParamAsString(params.FileOperation), nil

--- a/pkg/filter/fields/fields_windows.go
+++ b/pkg/filter/fields/fields_windows.go
@@ -457,6 +457,8 @@ const (
 	FileOperation Field = "file.operation"
 	// FileShareMask represents the file share mask
 	FileShareMask Field = "file.share.mask"
+	// FileShareMode represents the file share mode field
+	FileShareMode Field = "file.share_mode"
 	// FileIOSize represents the number of read/written bytes
 	FileIOSize Field = "file.io.size"
 	// FileOffset represents the read/write offset
@@ -1177,7 +1179,8 @@ var fields = map[Field]FieldInfo{
 	FilePathStem:                    {FilePathStem, "full file path without extension", params.UnicodeString, []string{"file.path.stem = 'C:\\Windows\\System32\\cmd'"}, nil, nil},
 	FileName:                        {FileName, "full file name", params.UnicodeString, []string{"file.name contains 'mimikatz'"}, nil, nil},
 	FileOperation:                   {FileOperation, "file operation", params.AnsiString, []string{"file.operation = 'open'"}, nil, nil},
-	FileShareMask:                   {FileShareMask, "file share mask", params.AnsiString, []string{"file.share.mask = 'rw-'"}, nil, nil},
+	FileShareMask:                   {FileShareMask, "file share mask", params.AnsiString, []string{"file.share.mask = 'READ'"}, &Deprecation{Since: "3.1.0", Fields: []Field{FileShareMode}}, nil},
+	FileShareMode:                   {FileShareMask, "file share mode", params.AnsiString, []string{"file.share_mode = 'DENY'"}, nil, nil},
 	FileIOSize:                      {FileIOSize, "file I/O size", params.Uint32, []string{"file.io.size > 512"}, nil, nil},
 	FileOffset:                      {FileOffset, "file offset", params.Uint64, []string{"file.offset = 1024"}, nil, nil},
 	FileType:                        {FileType, "file type", params.AnsiString, []string{"file.type = 'directory'"}, nil, nil},

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -630,6 +630,7 @@ func TestFileFilter(t *testing.T) {
 			params.FilePath:      {Name: params.FilePath, Type: params.UnicodeString, Value: "C:\\Windows\\system32\\user32.dll"},
 			params.FileType:      {Name: params.FileType, Type: params.AnsiString, Value: "file"},
 			params.FileOperation: {Name: params.FileOperation, Type: params.AnsiString, Value: "open"},
+			params.FileShareMask: {Name: params.FileShareMask, Type: params.Flags, Value: uint32(1), Flags: event.FileShareModeFlags},
 		},
 		Metadata: map[event.MetadataKey]any{"foo": "bar", "fooz": "barzz"},
 	}
@@ -641,7 +642,7 @@ func TestFileFilter(t *testing.T) {
 
 		{`file.name = 'user32.dll'`, true},
 		{`file.path = 'C:\\Windows\\system32\\user32.dll'`, true},
-		{`file.extension  = '.dll'`, true},
+		{`file.extension = '.dll'`, true},
 		{`file.extension not contains '.exe'`, true},
 		{`file.extension contains '.exe' or (file.extension contains '.dll' and file.name endswith 'user32.dll')`, true},
 		{`file.extension = '.dll' or (file.extension contains '.exe' and file.name endswith 'kernel32.dll')`, true},
@@ -670,6 +671,7 @@ func TestFileFilter(t *testing.T) {
 		{`file.path fuzzy ('C:\\Windows\\system32\\kernel', 'C:\\Windows\\system32\\ser3ll')`, true},
 		{`file.path ifuzzynorm 'C:\\WINDOWS\\sÝS\\32dll'`, true},
 		{`file.path.stem = 'C:\\Windows\\system32\\user32'`, true},
+		{`file.share_mode = 'READ'`, true},
 		{`base(file.path) = 'user32.dll'`, true},
 		{`ext(base(file.path)) = '.dll'`, true},
 		{`base(file.path, false) = 'user32'`, true},


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Deprecate the `file.share.mask` and introduce the `file.share_mode` field instead. Additionally, modify the share mode flags to treat absent share mode as `DENY`.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

/kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

/area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
