### PR TITLE
fix(rules): Add HKEY_USERS windir/systemroot wildcard matches

### DIFF
--- a/rules/privilege_escalation_fake_system_root_environment_variable_manipulation.yml
+++ b/rules/privilege_escalation_fake_system_root_environment_variable_manipulation.yml
@@ -1,6 +1,6 @@
 name: Fake system root environment variable manipulation
 id: 15613558-14cc-4d00-b13e-392df61e29c4
-version: 1.0.0
+version: 1.0.1
 description: |
   Identifies attempts to manipulate user-scoped Windows directory registry values
   to point to non-standard locations, a technique commonly abused to fake the system
@@ -20,6 +20,8 @@ condition: >
   ps.sid != 'S-1-5-18' and
   registry.path imatches
                 (
+                  'HKEY_USERS\\*\\windir',
+                  'HKEY_USERS\\*\\systemroot',
                   'HKEY_CURRENT_USER\\*\\windir',
                   'HKEY_CURRENT_USER\\*\\systemroot'
                 ) and
@@ -29,7 +31,10 @@ condition: >
                   '?SystemRoot?'
                 ) and
    registry.path not imatches 'HKEY_CURRENT_USER\\*\\SOFTWARE\\*'
-
+action:
+  - name: kill
+  
 severity: high
+
 
 min-engine-version: 3.0.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Add HKEY_USERS windir/systemroot wildcard matches to cover global user registry paths.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
