### PR TITLE
fix(ci):  Make the vcvars64.bat path dynamic

### DIFF
--- a/internal/etw/_fixtures/Taskfile.yml
+++ b/internal/etw/_fixtures/Taskfile.yml
@@ -2,8 +2,6 @@ version: '3'
 
 vars:
   SYSWHISPERS3_REPO: https://github.com/klezVirus/SysWhispers3.git
-  VISUAL_STUDIO_EDITION: Enterprise
-  VISUAL_STUDIO_VERSION: 2022
 
 tasks:
   direct-syscall:
@@ -12,7 +10,7 @@ tasks:
     cmds:
       - git clone {{ .SYSWHISPERS3_REPO }}
       - python SysWhispers3/syswhispers.py -a x64 -c msvc -p common -o syscalls
-      - cmd.exe /c 'C:\"Program Files"\"Microsoft Visual Studio"\{{ .VISUAL_STUDIO_VERSION }}\{{ .VISUAL_STUDIO_EDITION }}\VC\Auxiliary\Build\vcvars64.bat && nmake -f Makefile.msvc'
+      - cmd.exe /c "{{.ROOT_DIR}}\build.bat Makefile.msvc"
     silent: true
 
   indirect-syscall:
@@ -21,7 +19,7 @@ tasks:
     cmds:
       - git clone {{ .SYSWHISPERS3_REPO }}
       - python SysWhispers3/syswhispers.py -a x64 -c msvc -p common -m jumper_randomized -o syscalls
-      - cmd.exe /c 'C:\"Program Files"\"Microsoft Visual Studio"\{{ .VISUAL_STUDIO_VERSION }}\{{ .VISUAL_STUDIO_EDITION }}\VC\Auxiliary\Build\vcvars64.bat && nmake -f Makefile.msvc'
+      - cmd.exe /c "{{.ROOT_DIR}}\build.bat Makefile.msvc"
     silent: true
 
   all:

--- a/internal/etw/_fixtures/build.bat
+++ b/internal/etw/_fixtures/build.bat
@@ -1,0 +1,12 @@
+@echo off
+
+for /f "usebackq delims=" %%i in (
+    `"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`
+) do set "VSINSTALLDIR=%%i\"
+
+echo [INFO] VS install path: %VSINSTALLDIR%
+
+call "%VSINSTALLDIR%VC\Auxiliary\Build\vcvars64.bat"
+if errorlevel 1 exit /b 1
+
+nmake -f %1


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Replace the hardcoded VS path with ` vswhere.exe`, which is always available on GitHub runners and resolves the correct installation regardless of edition or version.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

/area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
