### PR TITLE
feat(rules): New `Activation Context memory section hijacking` rule

### DIFF
--- a/rules/defense_evasion_activation_context_memory_section_hijacking.yml
+++ b/rules/defense_evasion_activation_context_memory_section_hijacking.yml
@@ -1,0 +1,41 @@
+name: Activation Context memory section hijacking
+id: 3d56281e-9608-4a70-b7b7-7651ccd3752b
+version: 1.0.0
+description: |
+  Detects abuses of a legitimate Windows feature present in most processes
+  called Activation Contexts with the objective of loading an arbitrary DLL
+  into signed executables.
+  Adversaries can unmap the legitimate read-only memory section view backing
+  the process Activation Context, then map a new pagefile-backed section at
+  the exact same base address containing a malicious Activation Context.
+labels:
+  tactic.id: TA0005
+  tactic.name: Defense Evasion
+  tactic.ref: https://attack.mitre.org/tactics/TA0005/
+  technique.id: T1055
+  technique.name: Process Injection
+  technique.ref: https://attack.mitre.org/techniques/T1055/
+references:
+  - https://github.com/r3xmax/PhantomCtx
+  - https://learn.microsoft.com/en-us/windows/win32/sbscs/activation-contexts
+
+condition: >
+  sequence
+  maxspan 40s
+  by ps.uuid, file.view.base
+    |unmap_view_file and
+     file.view.type = 'PAGEFILE' and file.view.protection = 'READONLY' and
+     (file.view.size = 12288 or (file.view.size = 4096 and
+      not (ps.parent.exe imatches '?:\\Windows\\System32\\svchost.exe' and ps.exe imatches '?:\\Windows\\System32\\taskhostw.exe') and
+      not (ps.parent.exe imatches '?:\\Windows\\explorer.exe' and ps.exe imatches '?:\\Program Files\\WindowsApps\\*.exe') and
+      not (ps.parent.exe imatches '?:\\Windows\\System32\\winlogon.exe' and ps.exe imatches '?:\\Windows\\System32\\dwm.exe') and
+      not (ps.parent.exe imatches '?:\\Windows\\System32\\winlogon.exe' and ps.exe imatches '?:\\Windows\\System32\\csrss.exe') and
+      not (ps.parent.exe imatches '?:\\Windows\\System32\\svchost.exe' and ps.exe imatches '?:\\Program Files\\Microsoft Office\\*\\ActionsServer\\ActionsServer.exe') and
+      not (ps.parent.exe imatches '?:\\Program Files\\Mozilla Firefox\\firefox.exe' and ps.exe imatches '?:\\Program Files\\Mozilla Firefox\\firefox.exe' and ps.cmdline imatches concat('*-contentproc -parentBuildID* -parentPid ', ps.ppid)))
+     )
+    |
+    |map_view_file and file.view.size = 12288 and file.view.type = 'PAGEFILE' and file.view.protection = 'READWRITE'|
+
+severity: high
+
+min-engine-version: 3.0.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Detects abuses of a legitimate Windows feature present in most processes called Activation Contexts with the objective of loading an arbitrary DLL into signed executables. Adversaries can unmap the legitimate read-only memory section view backing the process Activation Context, then map a new pagefile-backed section at the exact same base address containing a malicious Activation Context.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
