### PR TITLE
feat(rules): New `Untrusted DLL loaded from masqueraded Windows directory` rule

### DIFF
--- a/rules/privilege_escalation_untrusted_dll_loaded_from_masqueraded_windows_directory.yml
+++ b/rules/privilege_escalation_untrusted_dll_loaded_from_masqueraded_windows_directory.yml
@@ -1,0 +1,58 @@
+name: Untrusted DLL loaded from masqueraded Windows directory
+id: a3899290-dc2e-405b-a6ea-cb1eb40c4769
+version: 1.0.0
+description: |
+  Identifies trusted process executables loading unsigned or untrusted
+  Dynamic Link Libraries (DLLs) from filesystem paths that masquerade as
+  legitimate Windows system directories.
+  Attackers frequently create lookalike directory structures to disguise
+  malicious payloads as legitimate operating system components.
+labels:
+  tactic.id: TA0004
+  tactic.name: Privilege Escalation
+  tactic.ref: https://attack.mitre.org/tactics/TA0004/
+  technique.id: T1574
+  technique.name: Hijack Execution Flow
+  technique.ref: https://attack.mitre.org/techniques/T1574/
+references:
+  - https://github.com/r3xmax/PhantomCtx
+  - https://www.crowdstrike.com/en-us/blog/4-ways-adversaries-hijack-dlls/
+
+condition: >
+  load_dll and
+  ps.exe imatches ('?:\\Windows\\System32\\*.exe', '?:\\Windows\\SysWOW64\\*.exe', '?:\\Program Files*') and
+  (dll.signature.exists = false or dll.signature.trusted = false) and
+  dll.path imatches
+          (
+            '?:\\*\\Windows\\System32\\*',
+            '?:\\*\\Windows\\SysWOW64\\*',
+            '?:\\*\\Windows\\WinSxS\\*',
+            '?:\\*\\Windows\\assembly\\*',
+            '?:\\*\\Windows\\Microsoft.NET\\*',
+            '*:\\Windows \\System32\\*',
+            '*:\\Windows \\SysWOW64\\*',
+            '*:\\ Windows*\\System32\\*',
+            '*:\\ Windows*\\SysWOW64\\*',
+            '*:\\Windows*\\assembly\\*',
+            '*:\\Windows*\\WinSxS\\*',
+            '*:\\ Windows*\\WinSxS\\*',
+            '*:\\ Windows*\\assembly\\*'
+          ) and
+  dll.path not imatches
+          (
+            '?:\\Windows\\System32\\*',
+            '?:\\Windows\\SysWOW64\\*',
+            '?:\\Windows\\WinSxS\\*',
+            '?:\\Windows\\assembly\\*',
+            '?:\\Windows\\Microsoft.NET\\*',
+            '?:\\$WINDOWS.~BT\\*\\Windows\\System32\\migration\\*.dll',
+            '?:\\$WINDOWS.~BT\\*\\Windows\\SysWOW64\\migration\\*.dll',
+            '?:\\Windows.old\\WINDOWS\\System32\\DriverStore\\*.dll',
+            '?:\\$WinREAgent\\Scratch\\Mount\\Windows\\*.dll',
+            '?:\\ProgramData\\docker\\windowsfilter\\*\\Files\\Windows\\System32\\*.dll',
+            '?:\\ProgramData\\docker\\windowsfilter\\*\\Files\\Windows\\SysWOW64\\*.dll'
+          )
+
+severity: high
+
+min-engine-version: 3.0.0


### PR DESCRIPTION
Identifies trusted process executables loading unsigned or untrusted Dynamic Link Libraries (DLLs) from filesystem paths that masquerade as legitimate Windows system directories. Attackers frequently create lookalike directory structures to disguise malicious payloads as legitimate operating system components.

### What is the purpose of this PR / why it is needed?


### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
