### PR TITLE
perf(processor): Remove costly mmaped file queries

### DIFF
--- a/internal/etw/processors/fs_windows.go
+++ b/internal/etw/processors/fs_windows.go
@@ -28,9 +28,7 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/handle"
 	htypes "github.com/rabbitstack/fibratus/pkg/handle/types"
 	"github.com/rabbitstack/fibratus/pkg/ps"
-	"github.com/rabbitstack/fibratus/pkg/sys"
 	"github.com/rabbitstack/fibratus/pkg/util/signature"
-	"github.com/rabbitstack/fibratus/pkg/util/va"
 	"golang.org/x/sys/windows"
 )
 
@@ -110,16 +108,6 @@ func (f *fsProcessor) processEvent(e *event.Event) (*event.Event, error) {
 		if fileinfo != nil {
 			totalMapRundownFiles.Add(1)
 			e.AppendParam(params.FilePath, params.Path, fileinfo.Name)
-		} else {
-			// if the view of section is backed by the data/image file
-			// try to get the mapped file name and append it to params
-			sec := e.Params.MustGetUint32(params.FileViewSectionType)
-			isMapped := sec != va.SectionPagefile && sec != va.SectionPhysical
-			if isMapped {
-				totalMapRundownFiles.Add(1)
-				addr := e.Params.MustGetUint64(params.FileViewBase) + (e.Params.MustGetUint64(params.FileOffset))
-				e.AppendParam(params.FilePath, params.Path, f.getMappedFile(e.PID, addr))
-			}
 		}
 
 		return e, f.psnap.AddMmap(e)
@@ -179,17 +167,6 @@ func (f *fsProcessor) processEvent(e *event.Event) (*event.Event, error) {
 		// references fails, we search in the file handles for such file
 		fileinfo := f.findFile(fileKey, fileObject)
 
-		// try to resolve mapped file name if not found in internal state
-		if fileinfo == nil && e.IsMapViewFile() {
-			sec := e.Params.MustGetUint32(params.FileViewSectionType)
-			isMapped := sec != va.SectionPagefile && sec != va.SectionPhysical
-			if isMapped {
-				totalMapRundownFiles.Add(1)
-				addr := e.Params.MustGetUint64(params.FileViewBase) + (e.Params.MustGetUint64(params.FileOffset))
-				e.AppendParam(params.FilePath, params.Path, f.getMappedFile(e.PID, addr))
-			}
-		}
-
 		// ignore object misses that are produced by CloseFile
 		if fileinfo == nil && !e.IsCloseFile() {
 			fileObjectMisses.Add(1)
@@ -248,13 +225,4 @@ func (f *fsProcessor) findFile(fileKey, fileObject uint64) *FileInfo {
 		return &FileInfo{Name: file.Name, Type: fs.GetFileType(file.Name, 0)}
 	}
 	return nil
-}
-
-func (f *fsProcessor) getMappedFile(pid uint32, addr uint64) string {
-	process, err := windows.OpenProcess(windows.PROCESS_QUERY_INFORMATION, false, pid)
-	if err != nil {
-		return ""
-	}
-	defer windows.Close(process)
-	return fs.GetDevMapper().Convert(sys.GetMappedFile(process, uintptr(addr)))
 }


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Trying to fetch the memory-mapped file path for every MapViewFile event can degrade the performance. Since there is no detection value in the file path, we can safely drop the resolution logic.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

/area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
