### PR TITLE
fix(rules): Make resistant against evasions

### DIFF
--- a/rules/defense_evasion_potential_process_injection_via_tainted_memory_section.yml
+++ b/rules/defense_evasion_potential_process_injection_via_tainted_memory_section.yml
@@ -1,6 +1,6 @@
 name: Potential process injection via tainted memory section
 id: 8e4182f3-02e7-4e95-afc3-93d18c9a9c09
-version: 1.0.5
+version: 1.0.6
 description: |
   Identifies potential process injection when the adversary creates and maps a memory
   section with RW protection rights followed by mapping of the same memory section in
@@ -16,6 +16,7 @@ labels:
   technique.name: Process Injection
   technique.ref: https://attack.mitre.org/techniques/T1055/
 references:
+  - https://github.com/MazX0p/LACUNA-Chain
   - https://www.elastic.co/security-labs/dissecting-remcos-rat-part-four
   - https://www.ired.team/offensive-security/code-injection-process-injection/ntcreatesection-+-ntmapviewofsection-code-injection
 
@@ -36,17 +37,11 @@ condition: >
                   '?:\\WINDOWS\\System32\\svchost.exe',
                   '?:\\WINDOWS\\System32\\lsass.exe',
                   '?:\\WINDOWS\\System32\\SecurityHealthService.exe',
-                  '?:\\WINDOWS\\System32\\services.exe'
+                  '?:\\WINDOWS\\System32\\services.exe',
+                  '?:\\WINDOWS\\System32\\RuntimeBroker.exe'
                 )
     | as e1
-    |map_view_of_section and
-     file.view.protection = 'READONLY|EXECUTE' and file.key = $e1.file.key and evt.pid != $e1.evt.pid and
-     ps.exe not imatches
-                (
-                  '?:\\Program Files\\Mozilla Firefox\\firefox.exe',
-                  '?:\\Program Files (x86)\\Mozilla Firefox\\firefox.exe'
-                )
-    |
+    |map_view_of_section and file.view.protection = 'READONLY|EXECUTE' and file.key = $e1.file.key and evt.pid != $e1.evt.pid|
 action:
   - name: kill
 


### PR DESCRIPTION
Remove the process executable exclusion in the remote section and add the `RuntimeBroker` process executable path in the initiating mmap operation.

### What is the purpose of this PR / why it is needed?


### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

/kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
