### PR TITLE
refactor(rules): Define full paths in the share

### DIFF
--- a/rules/credential_access_potential_ntlm_hash_leak_via_shortcut_file.yml
+++ b/rules/credential_access_potential_ntlm_hash_leak_via_shortcut_file.yml
@@ -1,6 +1,6 @@
 name: Potential NTLM hash leak via shortcut file
 id: 2217339b-19d0-45ac-9ec5-26b0a968bdf1
-version: 1.0.0
+version: 1.0.1
 description: |
   Identifies potential NTLM hash leakage via malicious shortcut (.lnk) file processing.
   By crafting a .lnk file with a default icon from shell32.dll and the target path pointing
@@ -25,17 +25,7 @@ condition: >
      thread.callstack.summary imatches 'ntdll.dll|KernelBase.dll|SHCore.dll|windows.storage.dll|shell32.dll|SHCore.dll|*' and
      thread.callstack.symbols iin ('shell32.dll!SHELL32_CNetFolderUI_CreateInstance')
     |
-    |open_file and
-     file.path istartswith '\\Device\\Mup\\' and
-     file.extension iin
-                    (
-                      '.exe',
-                      '.dll',
-                      '.ocx',
-                      '.cpl',
-                      '.sys'
-                    )
-    |
+    |open_file and file.path imatches ('\\Device\\Mup\\*.exe', '\\Device\\Mup\\*.dll', '\\Device\\Mup\\*.ocx', '\\Device\\Mup\\*.cpl', '\\Device\\Mup\\*.sys')|
 
 severity: high
 


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Potential NTLM hash leak via shortcut file defined a list of extensions to be matched against the share. This can negatively impact
the approver as opening executable, DLLs, and other file formats can be quite noisy. Make it more approver-friendly to discard those events early in the processing pipeline.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
