### PR TITLE
feat(rules): New `Sensitive registry hive dump` rule

### DIFF
--- a/rules/credential_access_sensitive_registry_hive_dump.yml
+++ b/rules/credential_access_sensitive_registry_hive_dump.yml
@@ -1,0 +1,50 @@
+name: Sensitive registry hive dump
+id: 466fae85-e319-490e-9989-a5850ebf7c33
+version: 1.0.0
+description: |
+  Identifies an attempt to dump a sensitive registry hive (SAM, SECURITY, or SYSTEM).
+  Adversaries dump these hives to extract cached credentials, LSA secrets, and the SAM
+  database offline, commonly as a precursor to tools like secretsdump.py or mimikatz's
+  lsadump module.
+labels:
+  tactic.id: TA0006
+  tactic.name: Credential Access
+  tactic.ref: https://attack.mitre.org/tactics/TA0006/
+  technique.id: T1003
+  technique.name: OS Credential Dumping
+  technique.ref: https://attack.mitre.org/techniques/T1003/
+  subtechnique.id: T1003.002
+  subtechnique.name: Security Account Manager
+  subtechnique.ref: https://attack.mitre.org/techniques/T1003/002/
+references:
+  - https://github.com/gentilkiwi/mimikatz/wiki/module-~-lsadump
+
+condition: >
+  sequence
+  maxspan 1m
+  by ps.uuid
+    |open_registry and
+     evt.pid != 4 and registry.path iin ('HKEY_LOCAL_MACHINE\\SYSTEM', 'HKEY_LOCAL_MACHINE\\SAM', 'HKEY_LOCAL_MACHINE\\SECURITY', 'HKEY_LOCAL_MACHINE\\SECURITY\\Policy\\Secrets') and
+     ps.exe not imatches ('?:\\Windows\\System32\\svchost.exe', '?:\\Windows\\System32\\lsass.exe')
+    |
+    |create_file and
+     thread.callstack.symbols imatches ('KernelBase.dll!RegSaveKey*', 'advapi32.dll!RegSaveKey*') and
+     ps.exe not imatches
+                (
+                  '?:\\Windows\\System32\\wbengine.exe',
+                  '?:\\Windows\\System32\\wbadmin.exe',
+                  '?:\\Windows\\System32\\vssvc.exe',
+                  '?:\\Windows\\System32\\ntdsutil.exe',
+                  '?:\\Windows\\CCM\\CcmExec.exe',
+                  '?:\\Windows\\CCM\\CIAgent.exe',
+                  '?:\\Windows\\CCM\\SMSAgentHost.exe',
+                  '?:\\Program Files\\Veeam\\*\\*.exe',
+                  '?:\\Program Files\\Veritas\\Backup Exec\\*.exe',
+                  '?:\\Program Files\\Common Files\\Acronis\\*\\*.exe',
+                  '?:\\Program Files (x86)\\Common Files\\Acronis\\*\\*.exe'
+                )
+    |
+
+severity: high
+
+min-engine-version: 3.0.0


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Identifies an attempt to dump a sensitive registry hive (SAM, SECURITY, or SYSTEM). Adversaries dump these hives to extract cached credentials, LSA secrets, and the SAM database offline, commonly as a precursor to tools like secretsdump.py or mimikatz's lsadump module.


### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

/kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
