### PR TITLE
fix(test): Remove view of section backing file condition

### DIFF
--- a/internal/etw/source_test.go
+++ b/internal/etw/source_test.go
@@ -537,8 +537,7 @@ func TestEventSourceAllEvents(t *testing.T) {
 			func(e *event.Event) bool {
 				return e.CurrentPid() && e.Type == event.MapViewFile &&
 					e.GetParamAsString(params.MemProtect) == "EXECUTE_READWRITE|READONLY" &&
-					e.GetParamAsString(params.FileViewSectionType) == "IMAGE" &&
-					strings.Contains(e.GetParamAsString(params.FilePath), "_fixtures\\yara-test.dll")
+					e.GetParamAsString(params.FileViewSectionType) == "IMAGE"
 			},
 			false,
 		},


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

FS processor is no longer tracking/resolving memory-mapped file paths, so we can remove the condition from the test assertion.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

/area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
