### PR TITLE
perf(rules,approvers): Precompile patterns to lowercase

### DIFF
--- a/internal/etw/approvers/approver.go
+++ b/internal/etw/approvers/approver.go
@@ -123,37 +123,21 @@ func (*approver) matchPredicate(m map[string][]string, v string) bool {
 		for _, pattern := range patterns {
 			switch op {
 			case ql.IMatches.String():
-				if wildcard.Match(strings.ToLower(pattern), s) {
-					return true
-				}
-			case ql.Matches.String():
-				if wildcard.Match(pattern, v) {
+				if wildcard.Match(pattern, s) {
 					return true
 				}
 			case ql.IContains.String():
-				if strings.Contains(s, strings.ToLower(pattern)) {
-					return true
-				}
-			case ql.Contains.String():
-				if strings.Contains(v, pattern) {
-					return true
-				}
-			case ql.IEq.String(), ql.IIn.String():
-				if s == strings.ToLower(pattern) {
+				if strings.Contains(s, pattern) {
 					return true
 				}
 			case ql.Eq.String(), ql.In.String():
-				if v == pattern {
-					return true
-				}
+				return v == pattern
+			case ql.IEq.String(), ql.IIn.String():
+				return s == pattern
 			case ql.IStartswith.String():
 				return strings.HasPrefix(s, pattern)
-			case ql.Startswith.String():
-				return strings.HasPrefix(v, pattern)
 			case ql.IEndswith.String():
 				return strings.HasSuffix(s, pattern)
-			case ql.Endswith.String():
-				return strings.HasSuffix(v, pattern)
 			}
 		}
 	}

--- a/internal/etw/approvers/approver_test.go
+++ b/internal/etw/approvers/approver_test.go
@@ -131,7 +131,7 @@ func TestApproversFileEventWithRulesApproved(t *testing.T) {
 	rules := &config.RulesCompileResult{
 		Approvers: config.Approvers{
 			Paths: map[string][]string{
-				"ICONTAINS": {`Windows\AppCompat`},
+				"ICONTAINS": {`windows\appcompat`},
 			},
 		},
 	}
@@ -193,7 +193,7 @@ func TestApproversRegistryEventWithRulesApproved(t *testing.T) {
 	rules := &config.RulesCompileResult{
 		Approvers: config.Approvers{
 			Keys: map[string][]string{
-				"IMATCHES": {`HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\*`},
+				"IMATCHES": {`hkey_local_machine\software\microsoft\windows\*`},
 			},
 		},
 	}
@@ -251,7 +251,7 @@ func TestApproversProcEventWithRulesApproved(t *testing.T) {
 	rules := &config.RulesCompileResult{
 		Approvers: config.Approvers{
 			Executables: map[string][]string{
-				"IMATCHES": {`?:\Windows\System32\*`},
+				"IMATCHES": {`?:\windows\system32\*`},
 			},
 		},
 	}
@@ -307,13 +307,13 @@ func TestApproversMatchPredicate(t *testing.T) {
 	}{
 		{
 			name: "imatches wildcard hit",
-			m:    map[string][]string{"IMATCHES": {`C:\Windows\*`}},
+			m:    map[string][]string{"IMATCHES": {`c:\windows\*`}},
 			val:  `C:\Windows\System32\ntdll.dll`,
 			want: true,
 		},
 		{
 			name: "imatches wildcard miss",
-			m:    map[string][]string{"IMATCHES": {`C:\Windows\*`}},
+			m:    map[string][]string{"IMATCHES": {`c:\windows\*`}},
 			val:  `C:\Users\Administrator\cmd.exe`,
 			want: false,
 		},
@@ -326,12 +326,6 @@ func TestApproversMatchPredicate(t *testing.T) {
 		{
 			name: "icontains hit",
 			m:    map[string][]string{"ICONTAINS": {"svchost"}},
-			val:  `C:\Windows\System32\svchost.exe`,
-			want: true,
-		},
-		{
-			name: "icontains case insensitive",
-			m:    map[string][]string{"ICONTAINS": {"SVCHOST"}},
 			val:  `C:\Windows\System32\svchost.exe`,
 			want: true,
 		},
@@ -355,14 +349,14 @@ func TestApproversMatchPredicate(t *testing.T) {
 		},
 		{
 			name: "ieq hit",
-			m:    map[string][]string{"~=": {`C:\Windows\System32\svchost.exe`}},
-			val:  `C:\Windows\System32\svchost.exe`,
+			m:    map[string][]string{"~=": {`c:\windows\system32\svchost.exe`}},
+			val:  `c:\windows\system32\svchost.exe`,
 			want: true,
 		},
 		{
 			name: "multiple patterns first hits",
 			m: map[string][]string{
-				"IMATCHES": {`C:\Windows\*`, `C:\System32\*`},
+				"IMATCHES": {`c:\windows\*`, `C:\System32\*`},
 			},
 			val:  `C:\Windows\notepad.exe`,
 			want: true,

--- a/internal/etw/approvers/fs_test.go
+++ b/internal/etw/approvers/fs_test.go
@@ -259,7 +259,7 @@ func TestFSApproverFileOpEndPathApproverApproved(t *testing.T) {
 	rules := &config.RulesCompileResult{
 		Approvers: config.Approvers{
 			Paths: map[string][]string{
-				"ICONTAINS": {`Windows\AppCompat`},
+				"ICONTAINS": {`windows\appcompat`},
 			},
 		},
 	}

--- a/internal/etw/approvers/process_test.go
+++ b/internal/etw/approvers/process_test.go
@@ -145,7 +145,7 @@ func TestProcApproverOpenProcessExeApproved(t *testing.T) {
 	rules := &config.RulesCompileResult{
 		Approvers: config.Approvers{
 			Executables: map[string][]string{
-				"IMATCHES": {`C:\Windows\System32\*`},
+				"IMATCHES": {`c:\windows\system32\*`},
 			},
 		},
 	}
@@ -208,7 +208,7 @@ func TestProcApproverOpenThreadSameProcessExeApproved(t *testing.T) {
 	rules := &config.RulesCompileResult{
 		Approvers: config.Approvers{
 			Executables: map[string][]string{
-				"IMATCHES": {`C:\Windows\*`},
+				"IMATCHES": {`c:\windows\*`},
 			},
 		},
 	}

--- a/internal/etw/approvers/registry_test.go
+++ b/internal/etw/approvers/registry_test.go
@@ -208,7 +208,7 @@ func TestRegistryApproverRegOpenKeyApproved(t *testing.T) {
 	rules := &config.RulesCompileResult{
 		Approvers: config.Approvers{
 			Keys: map[string][]string{
-				"IMATCHES": {`HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\*`},
+				"IMATCHES": {`hkey_local_machine\software\microsoft\windows\currentversion\capabilityaccessmanager\*`},
 			},
 		},
 	}
@@ -250,7 +250,7 @@ func TestRegistryApproverRegOpenKeyKCBPathPrepended(t *testing.T) {
 	rules := &config.RulesCompileResult{
 		Approvers: config.Approvers{
 			Keys: map[string][]string{
-				"IMATCHES": {`HKEY_LOCAL_MACHINE\SYSTEM\*`},
+				"IMATCHES": {`hkey_local_machine\system\*`},
 			},
 		},
 	}
@@ -273,7 +273,7 @@ func TestRegistryApproverRegOpenKeyZeroKCBUsesPathDirectly(t *testing.T) {
 	rules := &config.RulesCompileResult{
 		Approvers: config.Approvers{
 			Keys: map[string][]string{
-				"IMATCHES": {`HKEY_LOCAL_MACHINE\SOFTWARE\*`},
+				"IMATCHES": {`hkey_local_machine\software\*`},
 			},
 		},
 	}

--- a/pkg/config/filters.go
+++ b/pkg/config/filters.go
@@ -214,38 +214,43 @@ type Approvers struct {
 }
 
 func (p *Approvers) AppendKey(op, path string) {
-	if slices.Contains(p.Keys[op], path) {
+	n := strings.ToLower(path)
+	if slices.Contains(p.Keys[op], n) {
 		return
 	}
-	p.Keys[op] = append(p.Keys[op], path)
+	p.Keys[op] = append(p.Keys[op], n)
 }
 
 func (p *Approvers) AppendPath(op, path string) {
-	if slices.Contains(p.Paths[op], path) {
+	n := strings.ToLower(path)
+	if slices.Contains(p.Paths[op], n) {
 		return
 	}
-	p.Paths[op] = append(p.Paths[op], path)
+	p.Paths[op] = append(p.Paths[op], n)
 }
 
 func (p *Approvers) AppendExtension(op, ext string) {
-	if slices.Contains(p.Extensions[op], ext) {
+	n := strings.ToLower(ext)
+	if slices.Contains(p.Extensions[op], n) {
 		return
 	}
-	p.Extensions[op] = append(p.Extensions[op], ext)
+	p.Extensions[op] = append(p.Extensions[op], n)
 }
 
 func (p *Approvers) AppendBase(op, base string) {
-	if slices.Contains(p.Bases[op], base) {
+	n := strings.ToLower(base)
+	if slices.Contains(p.Bases[op], n) {
 		return
 	}
-	p.Bases[op] = append(p.Bases[op], base)
+	p.Bases[op] = append(p.Bases[op], n)
 }
 
 func (p *Approvers) AppendExecutable(op, exe string) {
-	if slices.Contains(p.Executables[op], exe) {
+	n := strings.ToLower(exe)
+	if slices.Contains(p.Executables[op], n) {
 		return
 	}
-	p.Executables[op] = append(p.Executables[op], exe)
+	p.Executables[op] = append(p.Executables[op], n)
 }
 
 func (p Approvers) String() string {

--- a/pkg/filter/ql/ast.go
+++ b/pkg/filter/ql/ast.go
@@ -30,6 +30,18 @@ import (
 	"github.com/rabbitstack/fibratus/pkg/util/wildcard"
 )
 
+// loweredWildcards contains a mapping between original and lower-case wildcard patterns
+var loweredWildcards = map[string]string{}
+
+func toLowerWildcard(p string) string {
+	if s, ok := loweredWildcards[p]; ok {
+		return s
+	}
+	s := strings.ToLower(p)
+	loweredWildcards[p] = s
+	return s
+}
+
 // Eval evaluates expr against a map that contains the field values.
 func Eval(expr Expr, m map[string]interface{}, useFuncValuer bool) bool {
 	var eval ValuerEval
@@ -964,10 +976,10 @@ func (v *ValuerEval) evalBinaryExpr(expr *BinaryExpr) interface{} {
 			v := strings.ToLower(lhs)
 			switch rhs := rhs.(type) {
 			case string:
-				return wildcard.Match(strings.ToLower(rhs), v)
+				return wildcard.Match(toLowerWildcard(rhs), v)
 			case []string:
 				for _, pat := range rhs {
-					if wildcard.Match(strings.ToLower(pat), v) {
+					if wildcard.Match(toLowerWildcard(pat), v) {
 						return true
 					}
 				}
@@ -1232,7 +1244,7 @@ func (v *ValuerEval) evalBinaryExpr(expr *BinaryExpr) interface{} {
 			}
 			for _, pat := range rhs {
 				for _, val := range lhs {
-					if wildcard.Match(strings.ToLower(pat), strings.ToLower(val)) {
+					if wildcard.Match(toLowerWildcard(pat), strings.ToLower(val)) {
 						return true
 					}
 				}

--- a/pkg/rules/compiler_test.go
+++ b/pkg/rules/compiler_test.go
@@ -219,14 +219,14 @@ func TestAccumulatedApproverPredicates(t *testing.T) {
 			name: "extracts registry key path with imatches",
 			expr: "evt.name = 'RegOpenKey' and registry.path imatches 'HKEY_LOCAL_MACHINE\\\\SYSTEM\\\\*'",
 			wantKeys: map[string][]string{
-				"IMATCHES": {`HKEY_LOCAL_MACHINE\SYSTEM\*`},
+				"IMATCHES": {`hkey_local_machine\system\*`},
 			},
 		},
 		{
 			name: "extracts file path with imatches",
 			expr: "evt.name = 'CreateFile' and file.operation = 'OPEN' and file.path imatches 'C:\\\\Windows\\\\*'",
 			wantPaths: map[string][]string{
-				"IMATCHES": {`C:\Windows\*`},
+				"IMATCHES": {`c:\windows\*`},
 			},
 		},
 		{


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Imatches operator patterns are constantly lowercased during AST evaluation. The same happens for approver lower-case patterns. To speed up the processing pipeline, we can lowercase all patterns upfront and reduce the runtime cost.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

/area rule-engine

/area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
