### PR TITLE
fix(signature): Pin worker goroutine

### DIFF
--- a/pkg/sys/trust.go
+++ b/pkg/sys/trust.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"os"
 	"reflect"
-	"runtime"
 	"sync"
 	"time"
 	"unsafe"
@@ -310,8 +309,6 @@ func NewCatalog() Cat {
 // Open opens the catalog and acquires the hash for the given file. If the
 // file is catalog-signed, a valid catalog handle is stored internally.
 func (c *Cat) Open(filename string) error {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
 	// acquire handle to a catalog administrator context
 	err := CryptCatalogAdminAcquireContext(&c.admin, nil, nil, 0, 0)
 	if err != nil {
@@ -350,8 +347,6 @@ func (c *Cat) IsCatalogSigned() bool {
 
 // Verify verifies the signature of the given file against the catalog.
 func (c *Cat) Verify(filename string) (SignatureStatus, error) {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
 	trust := NewWintrustData(WtdChoiceCatalog)
 	defer trust.Close()
 	if c.file == nil {
@@ -428,8 +423,6 @@ func (c *Cat) ParseCertificate() (*Cert, error) {
 }
 
 func (c *Cat) Close() error {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
 	if c.admin != 0 {
 		defer CryptCatalogAdminReleaseContext(c.admin, 0)
 	}

--- a/pkg/util/signature/signature.go
+++ b/pkg/util/signature/signature.go
@@ -318,6 +318,11 @@ func (s *Signatures) getOrCheck(key Key) *Signature {
 }
 
 func (s *Signatures) runWorker() {
+	// pin this goroutine to its OS thread for the lifetime of the worker.
+	// WinVerifyTrust has COM STA thread affinity and all calls must happen
+	// on a thread where CoInitializeEx has been called.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	for {
 		select {
 		case req := <-s.requests:

--- a/pkg/util/signature/types.go
+++ b/pkg/util/signature/types.go
@@ -21,7 +21,6 @@ package signature
 import (
 	"errors"
 	"fmt"
-	"runtime"
 	"sync/atomic"
 	"time"
 
@@ -262,8 +261,6 @@ func (s *Signature) HasCertificate() bool {
 // by passing the inquiry to a trust provider that supports the action
 // identifier.
 func (s *Signature) verifyFile() error {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
 	trust := sys.NewWintrustData(sys.WtdChoiceFile)
 	defer trust.Close()
 	status, err := trust.VerifyFile(s.Path)


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Lock the worker goroutine to its OS thread for the lifetime of the worker. WinVerifyTrust has COM STA thread affinity and all calls must happen on a thread where `CoInitializeEx` has been called.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

/area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
