### PR TITLE
fix(symbolizer): Device driver misattribution

### DIFF
--- a/pkg/symbolize/driver.go
+++ b/pkg/symbolize/driver.go
@@ -47,9 +47,31 @@ func (d *driverStore) resolve(addr va.Address) *sys.Driver {
 	// driver already cached?
 	d.mux.RLock()
 	dev, isCached := d.drivers[addr]
-	d.mux.RUnlock()
+	var (
+		base va.Address
+		size uint64
+	)
 	if isCached {
-		return dev
+		base = va.Address(dev.Base)
+		size = uint64(dev.Size)
+	}
+	d.mux.RUnlock()
+
+	if isCached {
+		if addr >= base && addr < base.Inc(size) {
+			// entry is still valid
+			return dev
+		}
+		// evict the stale cache entry so that subsequent calls for
+		// the same address do not keep hitting the validation path
+		d.mux.Lock()
+		// recheck under write lock in case if another goroutine may
+		// have already evicted or refreshed the entry while we were
+		// upgrading the lock
+		if current, still := d.drivers[addr]; still && current == dev {
+			delete(d.drivers, addr)
+		}
+		d.mux.Unlock()
 	}
 
 	d.mux.Lock()
@@ -67,15 +89,12 @@ func (d *driverStore) resolve(addr va.Address) *sys.Driver {
 }
 
 func (d *driverStore) addDriver(base va.Address, size uint64, path string) {
-	d.mux.Lock()
-	defer d.mux.Unlock()
-
 	dev := sys.Driver{
 		Path: path,
 		Base: base.Uintptr(),
 		Size: uint32(size),
 	}
-	d.devs = append(d.devs, dev)
+	d.addDev(dev)
 }
 
 func (d *driverStore) removeDriver(base va.Address, size uint64) {
@@ -93,5 +112,40 @@ func (d *driverStore) removeDriver(base va.Address, size uint64) {
 		if addr >= base && addr < base.Inc(size) {
 			delete(d.drivers, addr)
 		}
+	}
+}
+
+func (d *driverStore) addDev(drv sys.Driver) {
+	d.mux.Lock()
+	defer d.mux.Unlock()
+
+	var (
+		exists = false
+		base   = va.Address(drv.Base)
+		size   = uint64(drv.Size)
+	)
+
+	for i, dev := range d.devs {
+		switch {
+		case dev.Base == drv.Base && dev.Path != drv.Path:
+			// different driver has reloaded at the same base address.
+			// Evict all cached addresses that still point at the old
+			// driver so that resolve() cannot return a stale pointer
+			// for the new occupant.
+			for addr := range d.drivers {
+				if addr >= base && addr < base.Inc(size) {
+					delete(d.drivers, addr)
+				}
+			}
+			d.devs = append(d.devs[:i], d.devs[i+1:]...)
+		case dev.Base == drv.Base && dev.Path == drv.Path:
+			// driver exists at identical base address and
+			// device path. Nothing to do
+			exists = true
+		}
+	}
+
+	if !exists {
+		d.devs = append(d.devs, drv)
 	}
 }

--- a/pkg/symbolize/driver_test.go
+++ b/pkg/symbolize/driver_test.go
@@ -256,3 +256,25 @@ func TestAddRemoveRoundTrip(t *testing.T) {
 		t.Error("driver must be gone after round-trip removal")
 	}
 }
+
+func TestAddNewDriverSameBase(t *testing.T) {
+	ds := makeStore(realDrivers())
+
+	const base va.Address = 0xFFFFF80010000000
+	const size uint64 = 0x50000
+
+	ds.addDriver(base, size, `\Driver\fileinfo.sys`)
+	if len(ds.devs) != 3 {
+		t.Error("must be 3 drivers in the store")
+	}
+
+	ds.addDriver(base, size, `\Driver\FLTMGR.SYS.sys`)
+	if len(ds.devs) != 3 {
+		t.Error("must be 3 drivers in the store")
+	}
+
+	drv := ds.resolve(base)
+	if drv.Path != `\Driver\FLTMGR.SYS.sys` {
+		t.Error("unexpected driver resolved")
+	}
+}


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

`EnumDevices()` captures driver base/size at startup. If between enumeration and and the first call stack capture, any driver shifted or reloaded, the base addresses in devs are stale. The address range check could match the wrong driver if two drivers happen to have overlapping or adjacent ranges in your stale snapshot vs. reality.

Mitigation steps:

- Validate cache hits against current devs
- Remove a stale driver if the new driver lives at the same base but a different device path

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

/area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
