### PR TITLE
perf(rules): Optimize allocation_size evaluation

### DIFF
--- a/rules/defense_evasion_process_creation_from_stomped_module.yml
+++ b/rules/defense_evasion_process_creation_from_stomped_module.yml
@@ -1,6 +1,6 @@
 name: Process creation from a stomped module
 id: f85d1e80-49ec-4bbe-9bf5-7e2a3a8a7319
-version: 1.0.1
+version: 1.1.0
 description: |
   Identifies the creation of the process from the parent where the call stack
   exhibits suspicious memory properties. The pattern is typical of stomped module
@@ -24,8 +24,9 @@ condition: >
                                         '?:\\Program Files\\*.exe',
                                         '?:\\Program Files(x86)\\*.exe'
                                       ) and
-  foreach(thread._callstack, $frame, $frame.module imatches ('?:\\Windows\\System32\\*.dll', '?:\\Windows\\SysWOW64\\*.dll') and $frame.allocation_size >= 10000) and
-  not foreach(thread._callstack, $frame, $frame.module imatches
+  foreach(thread._callstack, $frame,
+                          $frame.module imatches ('?:\\Windows\\System32\\*.dll', '?:\\Windows\\SysWOW64\\*.dll') and
+                          $frame.module not imatches
                                 (
                                   '?:\\Program Files\\*.dll',
                                   '?:\\Program Files (x86)\\*.dll',
@@ -44,7 +45,8 @@ condition: >
                                   '?:\\Windows\\System32\\spool\\drivers\\*',
                                   '?:\\Windows\\assembly\\NativeImages_*',
                                   '?:\\Windows\\System32\\DriverStore\\FileRepository\\*'
-                                ))
+                                ) and
+                          $frame.allocation_size >= 10000)
 action:
   - name: kill
 


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Optimize the rule to defer the evaluation of the `allocation_size` only when the module paths are matched.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

/area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
