### PR TITLE
fix(fs,signature): Eagerly initialize metadata stores

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -142,6 +142,9 @@ func NewApp(cfg *config.Config, options ...Option) (*App, error) {
 	var engine *rules.Engine
 	var rs *config.RulesCompileResult
 
+	signature.InitStore()
+	fs.InitMetadataStore()
+
 	if cfg.Filters.Rules.Enabled && !cfg.ForwardMode && !cfg.IsCaptureSet() && !cfg.IsFilamentSet() {
 		engine = rules.NewEngine(psnap, cfg)
 		var err error

--- a/pkg/fs/file.go
+++ b/pkg/fs/file.go
@@ -155,6 +155,12 @@ func GetMetadataStore() *FileMetadataStore {
 	return metadataStore
 }
 
+func InitMetadataStore() {
+	onceMetadataStore.Do(func() {
+		metadataStore = newFileMetadataStore()
+	})
+}
+
 // FileMetadataStore contains metainfo of PE files derived
 // from file creation or DLL loading. Metadata store is
 // invalidated on various signals such as file overwriting

--- a/pkg/util/signature/signature.go
+++ b/pkg/util/signature/signature.go
@@ -140,6 +140,13 @@ func GetSignatures() *Signatures {
 	return sigs
 }
 
+// InitStore eagerly initializes the signature store and its worker pool.
+func InitStore() {
+	once.Do(func() {
+		sigs = newSignatures()
+	})
+}
+
 func newSignatures() *Signatures {
 	sigs = &Signatures{
 		signatures: make(map[Key]*Signature, 512),


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Eagerly initialise the signature/fs metadata worker pool before opening the ETW session. Rundown events fire immediately on session open and must find workers already running to avoid any fallback path executing on the ETW callback goroutine.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

/kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

/area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
