### PR TITLE
chore(build): Bump Go to 1.27.x

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,7 +10,7 @@ on:
       - "docs/**"
 
 env:
-  GO_VERSION: 1.26.x
+  GO_VERSION: 1.27.x
   WIX_VERSION: 5.0.0
   PYTHON_VERSION: 3.7.9
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.26.x
+  GO_VERSION: 1.27.x
   WIX_VERSION: 5.0.0
   PYTHON_VERSION: 3.7.9
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 env:
-  GO_VERSION: 1.26.x
+  GO_VERSION: 1.27.x
   WIX_VERSION: 5.0.0
   PYTHON_VERSION: 3.7.9
 


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

Bumps the Go toolchain to 1.27.x

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

> /kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

> /kind cleanup

/kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

> /area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

/area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
