### PR TITLE
refactor(telemetry): Retire threadpool telemetry

### DIFF
--- a/configs/fibratus.yml
+++ b/configs/fibratus.yml
@@ -252,9 +252,6 @@ eventsource:
   # Determines whether DNS client events are collected
   #enable-dns: true
 
-  # Determines whether thread pool events are collected
-  #enable-threadpool: true
-
   # Indicates if stack enrichment is enabled for eligible events
   #stack-enrichment: true
 

--- a/internal/etw/source.go
+++ b/internal/etw/source.go
@@ -138,7 +138,6 @@ func (e *EventSource) Open(config *config.Config) error {
 		config.EventSource.EnableMemEvents = config.EventSource.EnableMemEvents && (e.r.HasMemEvents || (config.Yara.Enabled && !config.Yara.SkipAllocs))
 		config.EventSource.EnableDNSEvents = config.EventSource.EnableDNSEvents && e.r.HasDNSEvents
 		config.EventSource.EnableAuditAPIEvents = config.EventSource.EnableAuditAPIEvents && e.r.HasAuditAPIEvents
-		config.EventSource.EnableThreadpoolEvents = config.EventSource.EnableThreadpoolEvents && e.r.HasThreadpoolEvents
 		for _, typ := range event.All() {
 			if typ == event.CreateProcess || typ == event.TerminateProcess ||
 				typ == event.LoadModule || typ == event.UnloadModule {
@@ -195,17 +194,6 @@ func (e *EventSource) Open(config *config.Config) error {
 
 	if config.EventSource.EnableAuditAPIEvents {
 		trace.AddProvider(etw.KernelAuditAPICallsGUID, config.EventSource.StackEnrichment)
-	}
-
-	if config.EventSource.EnableThreadpoolEvents {
-		// thread pool provider must be configured with
-		// stack extensions to activate stack walks events
-		var stackexts *StackExtensions
-		if e.config.EventSource.StackEnrichment {
-			stackexts = NewStackExtensions(config.EventSource)
-			stackexts.EnableThreadpoolCallstack()
-		}
-		trace.AddProvider(etw.ThreadpoolGUID, config.EventSource.StackEnrichment, WithStackExts(stackexts))
 	}
 
 	// add security telemetry trace

--- a/internal/etw/stackext.go
+++ b/internal/etw/stackext.go
@@ -103,12 +103,3 @@ func (s *StackExtensions) EnableMemoryCallstack() {
 		s.AddStackTracing(event.VirtualAlloc)
 	}
 }
-
-// EnableThreadpoolCallstack enables stack tracing for thread pool events.
-func (s *StackExtensions) EnableThreadpoolCallstack() {
-	if s.config.EnableThreadpoolEvents {
-		s.AddStackTracing(event.SubmitThreadpoolWork)
-		s.AddStackTracing(event.SubmitThreadpoolCallback)
-		s.AddStackTracing(event.SetThreadpoolTimer)
-	}
-}

--- a/internal/etw/trace.go
+++ b/internal/etw/trace.go
@@ -50,16 +50,8 @@ type ProviderInfo struct {
 	// CaptureState requests that the provider log its state
 	// information, such as rundown events.
 	CaptureState bool
-	// stackExtensions manager stack tracing enablement.
-	// For each event present in the stack identifiers,
-	// the StackWalk event is published by the provider.
-	stackExtensions *StackExtensions
 	//eventFilterDescriptors stores the provider-specific filters.
 	eventFilterDescriptors []etw.EventFilterDescriptor
-}
-
-func (p *ProviderInfo) HasStackExtensions() bool {
-	return p.stackExtensions != nil && !p.stackExtensions.Empty()
 }
 
 func (p *ProviderInfo) HasEventFilterDescriptors() bool {
@@ -137,11 +129,6 @@ type trace struct {
 
 	// name represents the unique tracing session name.
 	name string
-
-	// stackExtensions manages stack tracing enablement.
-	// For each event present in the stack identifiers,
-	// the StackWalk event is published by the provider.
-	stackExtensions *StackExtensions
 
 	// controlHandle is the session handle returned by the
 	// etw.StartTrace function. This handle is
@@ -228,6 +215,10 @@ func (t *trace) Close() error {
 // events from the global NT Kernel Logger session.
 type KernelTrace struct {
 	trace
+	// stackExtensions manages stack tracing enablement.
+	// For each event present in the stack identifiers,
+	// the StackWalk event is published by the provider.
+	stackExtensions *StackExtensions
 }
 
 // UserTrace is responsible for starting a private tracing
@@ -242,7 +233,6 @@ type UserTrace struct {
 	Providers []ProviderInfo
 }
 type opts struct {
-	stackexts              *StackExtensions
 	keywords               uint64
 	captureState           bool
 	eventFilterDescriptors []etw.EventFilterDescriptor
@@ -250,13 +240,6 @@ type opts struct {
 
 // Option represents the option for the trace.
 type Option func(o *opts)
-
-// WithStackExts sets the stack extensions.
-func WithStackExts(stackexts *StackExtensions) Option {
-	return func(o *opts) {
-		o.stackexts = stackexts
-	}
-}
 
 // WithKeywords sets the bitmask of keywords that determine
 // the categories of events for the provider to emit.
@@ -284,7 +267,7 @@ func WithEventFilterDescriptors(descriptors ...etw.EventFilterDescriptor) Option
 
 // NewKernelTrace creates a new NT Kernel Logger trace.
 func NewKernelTrace(config *config.Config) *KernelTrace {
-	t := &KernelTrace{trace: trace{guid: etw.KernelTraceControlGUID, name: etw.KernelLoggerSession, stackExtensions: NewStackExtensions(config.EventSource), config: config}}
+	t := &KernelTrace{trace: trace{guid: etw.KernelTraceControlGUID, name: etw.KernelLoggerSession, config: config}, stackExtensions: NewStackExtensions(config.EventSource)}
 
 	t.stackExtensions.EnableProcessCallstack()
 	t.stackExtensions.EnableRegistryCallstack()
@@ -314,7 +297,7 @@ func (t *UserTrace) AddProvider(guid windows.GUID, enableStacks bool, options ..
 
 	t.Providers = append(
 		t.Providers,
-		ProviderInfo{GUID: guid, Keywords: opts.keywords, EnableStacks: enableStacks, CaptureState: opts.captureState, stackExtensions: opts.stackexts, eventFilterDescriptors: opts.eventFilterDescriptors},
+		ProviderInfo{GUID: guid, Keywords: opts.keywords, EnableStacks: enableStacks, CaptureState: opts.captureState, eventFilterDescriptors: opts.eventFilterDescriptors},
 	)
 }
 
@@ -400,13 +383,6 @@ func (t *UserTrace) Start() error {
 	// data item section when writing events to the session buffers
 	for _, provider := range t.Providers {
 		switch {
-		case provider.EnableStacks && provider.HasStackExtensions():
-			if err := etw.EnableStackTracing(t.controlHandle, provider.stackExtensions.EventIds()); err != nil {
-				return fmt.Errorf("fail to enable provider callstack tracing: %v", err)
-			}
-			if err := etw.EnableTrace(provider.GUID, t.controlHandle, provider.Keywords); err != nil {
-				return err
-			}
 		case provider.EnableStacks || provider.HasEventFilterDescriptors():
 			opts := etw.EnableTraceOpts{
 				WithStacktrace:         provider.EnableStacks,

--- a/pkg/config/config.schema.json
+++ b/pkg/config/config.schema.json
@@ -362,9 +362,6 @@
         "enable-dns": {
           "type": "boolean"
         },
-        "enable-threadpool": {
-          "type": "boolean"
-        },
         "stack-enrichment": {
           "type": "boolean"
         },
@@ -428,10 +425,7 @@
                   "ReplyDns",
                   "VirtualAlloc",
                   "VirtualFree",
-                  "CreateSymbolicLinkObject",
-                  "SubmitThreadpoolWork",
-                  "SubmitThreadpoolCallback",
-                  "SetThreadpoolTimer"
+                  "CreateSymbolicLinkObject"
                 ]
               }
             },

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -428,7 +428,6 @@ func (c *Config) addFlags() {
 		c.flags.Bool(enableMemEvents, true, "Determines whether memory manager events are collected by Kernel Logger provider")
 		c.flags.Bool(enableAuditAPIEvents, true, "Determines whether kernel audit API calls events are published")
 		c.flags.Bool(enableDNSEvents, true, "Determines whether DNS client events are enabled")
-		c.flags.Bool(enableThreadpoolEvents, true, "Determines whether thread pool events are published")
 		c.flags.Bool(stackEnrichment, true, "Indicates if stack enrichment is enabled for eligible events")
 		c.flags.Int(bufferSize, int(maxBufferSize), "Represents the amount of memory allocated for each event tracing session buffer, in kilobytes. The buffer size affects the rate at which buffers fill and must be flushed (small buffer size requires less memory but it increases the rate at which buffers must be flushed)")
 		c.flags.Int(minBuffers, int(defaultMinBuffers), "Determines the minimum number of buffers allocated for the event tracing session's buffer pool")

--- a/pkg/config/eventsource.go
+++ b/pkg/config/eventsource.go
@@ -33,21 +33,20 @@ import (
 )
 
 const (
-	enableThreadEvents     = "eventsource.enable-thread"
-	enableRegistryEvents   = "eventsource.enable-registry"
-	enableNetEvents        = "eventsource.enable-net"
-	enableFileIOEvents     = "eventsource.enable-fileio"
-	enableVAMapEvents      = "eventsource.enable-vamap"
-	enableModuleEvents     = "eventsource.enable-module"
-	enableMemEvents        = "eventsource.enable-mem"
-	enableAuditAPIEvents   = "eventsource.enable-audit-api"
-	enableDNSEvents        = "eventsource.enable-dns"
-	enableThreadpoolEvents = "eventsource.enable-threadpool"
-	stackEnrichment        = "eventsource.stack-enrichment"
-	bufferSize             = "eventsource.buffer-size"
-	minBuffers             = "eventsource.min-buffers"
-	maxBuffers             = "eventsource.max-buffers"
-	flushInterval          = "eventsource.flush-interval"
+	enableThreadEvents   = "eventsource.enable-thread"
+	enableRegistryEvents = "eventsource.enable-registry"
+	enableNetEvents      = "eventsource.enable-net"
+	enableFileIOEvents   = "eventsource.enable-fileio"
+	enableVAMapEvents    = "eventsource.enable-vamap"
+	enableModuleEvents   = "eventsource.enable-module"
+	enableMemEvents      = "eventsource.enable-mem"
+	enableAuditAPIEvents = "eventsource.enable-audit-api"
+	enableDNSEvents      = "eventsource.enable-dns"
+	stackEnrichment      = "eventsource.stack-enrichment"
+	bufferSize           = "eventsource.buffer-size"
+	minBuffers           = "eventsource.min-buffers"
+	maxBuffers           = "eventsource.max-buffers"
+	flushInterval        = "eventsource.flush-interval"
 
 	excludedEvents = "eventsource.blacklist.events"
 	excludedImages = "eventsource.blacklist.images"
@@ -81,8 +80,6 @@ type EventSourceConfig struct {
 	EnableAuditAPIEvents bool `json:"enable-audit-api" yaml:"enable-audit-api"`
 	// EnableDNSEvents indicates if DNS client events are enabled
 	EnableDNSEvents bool `json:"enable-dns" yaml:"enable-dns"`
-	// EnableThreadpoolEvents indicates if thread pool events are enabled
-	EnableThreadpoolEvents bool `json:"enable-threadpool" yaml:"enable-threadpool"`
 	// StackEnrichment indicates if stack enrichment is enabled for eligible events.
 	StackEnrichment bool `json:"stack-enrichment" yaml:"stack-enrichment"`
 	// BufferSize represents the amount of memory allocated for each event tracing session buffer, in kilobytes.
@@ -116,7 +113,6 @@ func (c *EventSourceConfig) initFromViper(v *viper.Viper) {
 	c.EnableMemEvents = v.GetBool(enableMemEvents)
 	c.EnableAuditAPIEvents = v.GetBool(enableAuditAPIEvents)
 	c.EnableDNSEvents = v.GetBool(enableDNSEvents)
-	c.EnableThreadpoolEvents = v.GetBool(enableThreadpoolEvents)
 	c.StackEnrichment = v.GetBool(stackEnrichment)
 	c.BufferSize = uint32(v.GetInt(bufferSize))
 	c.MinBuffers = uint32(v.GetInt(minBuffers))

--- a/pkg/config/filters.go
+++ b/pkg/config/filters.go
@@ -188,20 +188,19 @@ func (ctx *ActionContext) UniquePids() []uint32 {
 // enabling/disabling event providers/types
 // dynamically.
 type RulesCompileResult struct {
-	HasProcEvents       bool
-	HasThreadEvents     bool
-	HasModuleEvents     bool
-	HasFileEvents       bool
-	HasNetworkEvents    bool
-	HasRegistryEvents   bool
-	HasMemEvents        bool
-	HasVAMapEvents      bool
-	HasDNSEvents        bool
-	HasAuditAPIEvents   bool
-	HasThreadpoolEvents bool
-	UsedEvents          []event.Type
-	NumberRules         int
-	Approvers           Approvers
+	HasProcEvents     bool
+	HasThreadEvents   bool
+	HasModuleEvents   bool
+	HasFileEvents     bool
+	HasNetworkEvents  bool
+	HasRegistryEvents bool
+	HasMemEvents      bool
+	HasVAMapEvents    bool
+	HasDNSEvents      bool
+	HasAuditAPIEvents bool
+	UsedEvents        []event.Type
+	NumberRules       int
+	Approvers         Approvers
 }
 
 type Approvers struct {
@@ -287,7 +286,6 @@ func (r RulesCompileResult) String() string {
 		HasVAMapEvents: %t
 		HasAuditAPIEvents: %t
 		HasDNSEvents: %t
-		HasThreadpoolEvents: %t
 		Events: %s
 		Approvers: %s`,
 		r.HasProcEvents,
@@ -300,7 +298,6 @@ func (r RulesCompileResult) String() string {
 		r.HasVAMapEvents,
 		r.HasAuditAPIEvents,
 		r.HasDNSEvents,
-		r.HasThreadpoolEvents,
 		strings.Join(events, ", "),
 		r.Approvers,
 	)

--- a/pkg/event/category.go
+++ b/pkg/event/category.go
@@ -47,8 +47,6 @@ const (
 	Mem Category = "mem"
 	// Object the category for object manager events
 	Object Category = "object"
-	// Threadpool is the category for thread pool events
-	Threadpool Category = "threadpool"
 	// Other is the category for uncategorized events
 	Other Category = "other"
 	// Unknown is the category for events that couldn't match any of the previous categories
@@ -68,7 +66,7 @@ func (c Category) Hash() uint32 {
 }
 
 // MaxCategoryIndex designates the maximum category index.
-const MaxCategoryIndex = 12
+const MaxCategoryIndex = 11
 
 // Index returns a numerical category index.
 func (c Category) Index() uint8 {
@@ -86,15 +84,13 @@ func (c Category) Index() uint8 {
 	case Module:
 		return 6
 	case Driver:
-		return 8
+		return 7
 	case Mem:
-		return 9
+		return 8
 	case Object:
-		return 10
-	case Threadpool:
-		return 11
+		return 9
 	case Other:
-		return 12
+		return 10
 	default:
 		return MaxCategoryIndex
 	}
@@ -114,7 +110,6 @@ func Categories() []string {
 		string(Other),
 		string(Unknown),
 		string(Object),
-		string(Threadpool),
 	}
 }
 

--- a/pkg/event/event_windows.go
+++ b/pkg/event/event_windows.go
@@ -565,12 +565,6 @@ func (e *Event) Summary() string {
 		src := e.GetParamAsString(params.LinkSource)
 		target := e.GetParamAsString(params.LinkTarget)
 		return printSummary(e, fmt.Sprintf("created symbolic link from %s to %s", src, target))
-	case SubmitThreadpoolWork:
-		return printSummary(e, "enqueued the work item to the thread pool")
-	case SubmitThreadpoolCallback:
-		return printSummary(e, "Submitted the thread pool callback for execution within the work item")
-	case SetThreadpoolTimer:
-		return printSummary(e, "set thread pool timer object")
 	}
 	return ""
 }

--- a/pkg/event/metainfo_windows.go
+++ b/pkg/event/metainfo_windows.go
@@ -84,9 +84,6 @@ var events = map[Type]Info{
 	QueryDNS:                 {"QueryDns", Net, "Sends a DNS query to the name server"},
 	ReplyDNS:                 {"ReplyDNS", Net, "Receives the response from the DNS server"},
 	CreateSymbolicLinkObject: {"CreateSymbolicLinkObject", Object, "Creates the symbolic link within the object manager directory"},
-	SubmitThreadpoolWork:     {"SubmitThreadpoolWork", Threadpool, "Enqueues the work item to the thread pool"},
-	SubmitThreadpoolCallback: {"SubmitThreadpoolCallback", Threadpool, "Submits the thread pool callback for execution within the work item"},
-	SetThreadpoolTimer:       {"SetThreadpoolTimer", Threadpool, "Sets the thread pool timer object"},
 }
 
 var types = map[string]Type{
@@ -140,9 +137,6 @@ var types = map[string]Type{
 	"QueryDns":                 QueryDNS,
 	"ReplyDns":                 ReplyDNS,
 	"CreateSymbolicLinkObject": CreateSymbolicLinkObject,
-	"SubmitThreadpoolWork":     SubmitThreadpoolWork,
-	"SubmitThreadpoolCallback": SubmitThreadpoolCallback,
-	"SetThreadpoolTimer":       SetThreadpoolTimer,
 }
 
 // indexedEvents keeps the slice of event infos. When the
@@ -199,9 +193,6 @@ var indexedEvents = []Info{
 	events[QueryDNS],
 	events[ReplyDNS],
 	events[CreateSymbolicLinkObject],
-	events[SubmitThreadpoolWork],
-	events[SubmitThreadpoolCallback],
-	events[SetThreadpoolTimer],
 }
 
 // All returns all event types.

--- a/pkg/event/param_decoder_windows.go
+++ b/pkg/event/param_decoder_windows.go
@@ -451,40 +451,6 @@ func (d *ParamDecoder) DecodeSetThreadContext(r *etw.EventRecord, e *Event) {
 	e.AppendParam(params.Callstack, params.Slice, r.Callstack())
 }
 
-// DecodeThreadpool decodes payloads for thread pool events.
-func (d *ParamDecoder) DecodeThreadpool(r *etw.EventRecord, e *Event) {
-	switch r.Header.EventDescriptor.Opcode {
-	case SubmitThreadpoolWorkID, SubmitThreadpoolCallbackID:
-		// typedef struct _ETW_TP_EVENT_CALLBACK_ENQUEUE {
-		//     PVOID PoolId;                   // Pool Identifier
-		//     PVOID TaskId;                   // Task Identifier
-		//     PVOID Callback;                 // Callback Function
-		//     PVOID Context;                  // Callback Context
-		//     PVOID SubProcessTag;            // Sub-components in a process
-		// } ETW_TP_EVENT_CALLBACK_ENQUEUE, *PETW_TP_EVENT_CALLBACK_ENQUEUE
-		e.AppendParam(params.ThreadpoolPoolID, params.Address, r.ReadUint64(0))
-		e.AppendParam(params.ThreadpoolTaskID, params.Address, r.ReadUint64(8))
-		e.AppendParam(params.ThreadpoolCallback, params.Address, r.ReadUint64(16))
-		e.AppendParam(params.ThreadpoolContext, params.Address, r.ReadUint64(24))
-		e.AppendParam(params.ThreadpoolSubprocessTag, params.Address, r.ReadUint64(32))
-	case SetThreadpoolTimerID:
-		// typedef struct _ETW_TP_EVENT_TIMER_SET {
-		//     LONG64 DueTime;                 // Due time
-		//     PVOID SubQueue;                 // Sub Queue to be inserted
-		//     PVOID Timer;                    // Timer to be set
-		//     ULONG Period;                   // period of the timer
-		//     ULONG WindowLength;             // Tolerate period
-		//     ULONG Absolute;                 // An absolute timer or relative timer
-		// } ETW_TP_EVENT_TIMER_SET, *PETW_TP_EVENT_TIMER_SET;
-		e.AppendParam(params.ThreadpoolTimerDuetime, params.Uint64, r.ReadUint64(0))
-		e.AppendParam(params.ThreadpoolTimerSubqueue, params.Address, r.ReadUint64(8))
-		e.AppendParam(params.ThreadpoolTimer, params.Address, r.ReadUint64(16))
-		e.AppendParam(params.ThreadpoolTimerPeriod, params.Uint32, r.ReadUint32(24))
-		e.AppendParam(params.ThreadpoolTimerWindow, params.Uint32, r.ReadUint32(28))
-		e.AppendParam(params.ThreadpoolTimerAbsolute, params.Bool, r.ReadUint32(32) > 0)
-	}
-}
-
 // DecodeCreateSymbolicLinkObject decodes the payload for the CreateSymbolicLinkObject event.
 func (d *ParamDecoder) DecodeCreateSymbolicLinkObject(r *etw.EventRecord, e *Event) {
 	source, offset := r.ReadUTF16String(0)

--- a/pkg/event/param_windows.go
+++ b/pkg/event/param_windows.go
@@ -243,8 +243,6 @@ func (e *Event) decodeParams(r *etw.EventRecord) {
 		paramDecoder.DecodeModule(r, e)
 	case ThreadEventGUID:
 		paramDecoder.DecodeThread(r, e)
-	case ThreadpoolEventGUID:
-		paramDecoder.DecodeThreadpool(r, e)
 	case RegistryKernelEventGUID:
 		paramDecoder.DecodeRegSetValueInternal(r, e)
 	case ProcessKernelEventGUID:

--- a/pkg/event/params/params_windows.go
+++ b/pkg/event/params/params_windows.go
@@ -255,37 +255,4 @@ const (
 	LinkSource = "source"
 	// LinkTarget identifies the parameter that represents the target symbolic link object or other kernel object
 	LinkTarget = "target"
-
-	// ThreadpoolPoolID represents the thread pool identifier.
-	ThreadpoolPoolID = "pool_id"
-	// ThreadpoolTaskID represents the thread pool task identifier.
-	ThreadpoolTaskID = "task_id"
-	// ThreadpoolCallback represents the address of the callback function.
-	ThreadpoolCallback = "callback"
-	// ThreadpoolCallbackSymbol represents the callback symbol.
-	ThreadpoolCallbackSymbol = "callback_symbol"
-	// ThreadpoolCallbackModule represents the module containing the callback symbol.
-	ThreadpoolCallbackModule = "callback_module"
-	// ThreadpoolContext represents the address of the callback context.
-	ThreadpoolContext = "context"
-	// ThreadpoolContextRip represents the value of instruction pointer contained in the callback context.
-	ThreadpoolContextRip = "context_rip"
-	// ThreadpoolContextRipSymbol represents the symbol name associated with the instruction pointer in callback context.
-	ThreadpoolContextRipSymbol = "context_rip_symbol"
-	// ThreadpoolContextRipModule represents the module name associated with the instruction pointer in callback context.
-	ThreadpoolContextRipModule = "context_rip_module"
-	// ThreadpoolSubprocessTag represents the service identifier associated with the thread pool.
-	ThreadpoolSubprocessTag = "subprocess_tag"
-	// ThreadpoolTimerDuetime represents the timer due time.
-	ThreadpoolTimerDuetime = "duetime"
-	// ThreadpoolTimerSubqueue represents the memory address of the timer subqueue.
-	ThreadpoolTimerSubqueue = "subqueue"
-	// ThreadpoolTimer represents the memory address of the timer object.
-	ThreadpoolTimer = "timer"
-	// ThreadpoolTimerPeriod represents the period of the timer
-	ThreadpoolTimerPeriod = "period"
-	// ThreadpoolTimerWindow represents the timer tolerate period.
-	ThreadpoolTimerWindow = "window"
-	// ThreadpoolTimerAbsolute indicates if the timer is absolute or relative.
-	ThreadpoolTimerAbsolute = "absolute"
 )

--- a/pkg/event/types_windows.go
+++ b/pkg/event/types_windows.go
@@ -63,8 +63,6 @@ var (
 	AuditAPIEventGUID = windows.GUID{Data1: 0xe02a841c, Data2: 0x75a3, Data3: 0x4fa7, Data4: [8]byte{0xaf, 0xc8, 0xae, 0x09, 0xcf, 0x9b, 0x7f, 0x23}}
 	// DNSEventGUID represents DNS provider event GUID
 	DNSEventGUID = windows.GUID{Data1: 0x1c95126e, Data2: 0x7eea, Data3: 0x49a9, Data4: [8]byte{0xa3, 0xfe, 0xa3, 0x78, 0xb0, 0x3d, 0xdb, 0x4d}}
-	// ThreadpoolEventGUID represents the thread pool event GUID
-	ThreadpoolEventGUID = windows.GUID{Data1: 0xc861d0e2, Data2: 0xa2c1, Data3: 0x4d36, Data4: [8]byte{0x9f, 0x9c, 0x97, 0x0b, 0xab, 0x94, 0x3a, 0x12}}
 	// ProcessKernelEventGUID represents the Process Kernel event GUID
 	ProcessKernelEventGUID = windows.GUID{Data1: 0x22fb2cd6, Data2: 0x0e7b, Data3: 0x422b, Data4: [8]byte{0xa0, 0xc7, 0x2f, 0xad, 0x1f, 0xd0, 0xe7, 0x16}}
 	// RegistryKernelEventGUID represents the Registry Kernel event GUID
@@ -144,10 +142,6 @@ const (
 	CreateSymbolicLinkObjectID uint16 = 3
 
 	StackWalkID uint8 = 32
-
-	SubmitThreadpoolWorkID     uint8 = 32
-	SubmitThreadpoolCallbackID uint8 = 34
-	SetThreadpoolTimerID       uint8 = 44
 )
 
 var (
@@ -297,13 +291,6 @@ var (
 	// CreateSymbolicLinkObject represents the event emitted by the object manager when the new symbolic link is created within the object manager directory
 	CreateSymbolicLinkObject = pack(AuditAPIEventGUID, CreateSymbolicLinkObjectID)
 
-	// SubmitThreadpoolWork represents the event that enqueues the work item to the thread pool
-	SubmitThreadpoolWork = pack(ThreadpoolEventGUID, uint16(SubmitThreadpoolWorkID))
-	//SubmitThreadpoolCallback represents the event that submits the thread pool callback for execution within the work item
-	SubmitThreadpoolCallback = pack(ThreadpoolEventGUID, uint16(SubmitThreadpoolCallbackID))
-	// SetThreadpoolTimer represents the event that sets the thread pool timer object
-	SetThreadpoolTimer = pack(ThreadpoolEventGUID, uint16(SetThreadpoolTimerID))
-
 	// UnknownType designates unknown event type
 	UnknownType = pack(windows.GUID{}, 0)
 )
@@ -415,12 +402,6 @@ func (t Type) String() string {
 		return "StackWalk"
 	case CreateSymbolicLinkObject:
 		return "CreateSymbolicLinkObject"
-	case SubmitThreadpoolWork:
-		return "SubmitThreadpoolWork"
-	case SubmitThreadpoolCallback:
-		return "SubmitThreadpoolCallback"
-	case SetThreadpoolTimer:
-		return "SetThreadpoolTimer"
 	default:
 		return ""
 	}
@@ -454,8 +435,6 @@ func (t Type) Category() Category {
 		return Mem
 	case CreateSymbolicLinkObject:
 		return Object
-	case SubmitThreadpoolWork, SubmitThreadpoolCallback, SetThreadpoolTimer:
-		return Threadpool
 	default:
 		return Unknown
 	}
@@ -552,12 +531,6 @@ func (t Type) Description() string {
 		return "Receives the response from the DNS server"
 	case CreateSymbolicLinkObject:
 		return "Creates the symbolic link within the object manager directory"
-	case SubmitThreadpoolWork:
-		return "Enqueues the work item to the thread pool"
-	case SubmitThreadpoolCallback:
-		return "Submits the thread pool callback for execution within the work item"
-	case SetThreadpoolTimer:
-		return "Sets the thread pool timer object"
 	default:
 		return ""
 	}
@@ -612,10 +585,7 @@ func (t Type) CanEnrichStack() bool {
 		RegDeleteValue,
 		DeleteFile,
 		RenameFile,
-		VirtualAlloc,
-		SubmitThreadpoolWork,
-		SubmitThreadpoolCallback,
-		SetThreadpoolTimer:
+		VirtualAlloc:
 		return true
 	default:
 		return false
@@ -665,7 +635,7 @@ func (t Type) ID() uint {
 // Source designates the provenance of this event type.
 func (t Type) Source() Source {
 	switch t.GUID() {
-	case AuditAPIEventGUID, DNSEventGUID, ThreadpoolEventGUID, ProcessKernelEventGUID, RegistryKernelEventGUID:
+	case AuditAPIEventGUID, DNSEventGUID, ProcessKernelEventGUID, RegistryKernelEventGUID:
 		return SecurityTelemetryLogger
 	default:
 		return SystemLogger
@@ -737,8 +707,6 @@ func (t Type) color() string {
 	case VirtualAlloc, VirtualFree:
 		return colorizer.SpanBold(colorizer.Magenta, t.String())
 	case CreateSymbolicLinkObject:
-		return colorizer.SpanBold(colorizer.Lavender, t.String())
-	case SubmitThreadpoolCallback, SubmitThreadpoolWork, SetThreadpoolTimer:
 		return colorizer.SpanBold(colorizer.Lavender, t.String())
 	default:
 		return colorizer.SpanBold(colorizer.White, t.String())

--- a/pkg/event/types_windows_test.go
+++ b/pkg/event/types_windows_test.go
@@ -104,10 +104,6 @@ func TestEventTypeExists(t *testing.T) {
 	require.True(t, AcceptTCPv6.Exists())
 }
 
-func TestTypeID(t *testing.T) {
-	assert.Equal(t, uint(14439051552138264620), SetThreadpoolTimer.ID())
-}
-
 func TestGUIDAndHookIDFromEventType(t *testing.T) {
 	var tests = []struct {
 		Type   Type

--- a/pkg/filter/accessor.go
+++ b/pkg/filter/accessor.go
@@ -153,17 +153,16 @@ func (*evtAccessor) Get(f Field, evt *event.Event) (params.Value, error) {
 // referenced in the bound field.
 func (f *filter) narrowAccessors() {
 	var (
-		removeEvtAccessor        = true
-		removePsAccessor         = true
-		removeThreadAccessor     = true
-		removeModuleAccessor     = true
-		removeFileAccessor       = true
-		removeRegistryAccessor   = true
-		removeNetworkAccessor    = true
-		removePEAccessor         = true
-		removeMemAccessor        = true
-		removeDNSAccessor        = true
-		removeThreadpoolAccessor = true
+		removeEvtAccessor      = true
+		removePsAccessor       = true
+		removeThreadAccessor   = true
+		removeModuleAccessor   = true
+		removeFileAccessor     = true
+		removeRegistryAccessor = true
+		removeNetworkAccessor  = true
+		removePEAccessor       = true
+		removeMemAccessor      = true
+		removeDNSAccessor      = true
 	)
 
 	for _, field := range f.fields {
@@ -188,8 +187,6 @@ func (f *filter) narrowAccessors() {
 			removeMemAccessor = false
 		case field.Name.IsDNSField():
 			removeDNSAccessor = false
-		case field.Name.IsThreadpoolField():
-			removeThreadpoolAccessor = false
 		}
 	}
 
@@ -222,9 +219,6 @@ func (f *filter) narrowAccessors() {
 	}
 	if removeDNSAccessor {
 		f.removeAccessor(&dnsAccessor{})
-	}
-	if removeThreadpoolAccessor {
-		f.removeAccessor(&threadpoolAccessor{})
 	}
 
 	for _, accessor := range f.accessors {

--- a/pkg/filter/accessor_windows.go
+++ b/pkg/filter/accessor_windows.go
@@ -58,7 +58,6 @@ func GetAccessors() []Accessor {
 		newThreadAccessor(),
 		newNetworkAccessor(),
 		newRegistryAccessor(),
-		newThreadpoolAccessor(),
 	}
 }
 
@@ -1256,58 +1255,6 @@ func (*dnsAccessor) Get(f Field, e *event.Event) (params.Value, error) {
 		return e.GetFlagsAsSlice(params.DNSOpts), nil
 	case fields.DNSAnswers:
 		return e.Params.GetSlice(params.DNSAnswers)
-	}
-
-	return nil, nil
-}
-
-// threadpoolAccessor extracts values from thread pool events
-type threadpoolAccessor struct{}
-
-func (threadpoolAccessor) SetFields([]Field)            {}
-func (threadpoolAccessor) SetSegments([]fields.Segment) {}
-func (threadpoolAccessor) IsFieldAccessible(e *event.Event) bool {
-	return e.Category == event.Threadpool
-}
-
-func newThreadpoolAccessor() Accessor {
-	return &threadpoolAccessor{}
-}
-
-func (*threadpoolAccessor) Get(f Field, e *event.Event) (params.Value, error) {
-	switch f.Name {
-	case fields.ThreadpoolPoolID:
-		return e.GetParamAsString(params.ThreadpoolPoolID), nil
-	case fields.ThreadpoolTaskID:
-		return e.GetParamAsString(params.ThreadpoolTaskID), nil
-	case fields.ThreadpoolCallbackAddress:
-		return e.GetParamAsString(params.ThreadpoolCallback), nil
-	case fields.ThreadpoolCallbackSymbol:
-		return e.GetParamAsString(params.ThreadpoolCallbackSymbol), nil
-	case fields.ThreadpoolCallbackModule:
-		return e.GetParamAsString(params.ThreadpoolCallbackModule), nil
-	case fields.ThreadpoolCallbackContext:
-		return e.GetParamAsString(params.ThreadpoolContext), nil
-	case fields.ThreadpoolCallbackContextRip:
-		return e.GetParamAsString(params.ThreadpoolContextRip), nil
-	case fields.ThreadpoolCallbackContextRipSymbol:
-		return e.GetParamAsString(params.ThreadpoolContextRipSymbol), nil
-	case fields.ThreadpoolCallbackContextRipModule:
-		return e.GetParamAsString(params.ThreadpoolContextRipModule), nil
-	case fields.ThreadpoolSubprocessTag:
-		return e.GetParamAsString(params.ThreadpoolSubprocessTag), nil
-	case fields.ThreadpoolTimer:
-		return e.GetParamAsString(params.ThreadpoolTimer), nil
-	case fields.ThreadpoolTimerSubqueue:
-		return e.GetParamAsString(params.ThreadpoolTimerSubqueue), nil
-	case fields.ThreadpoolTimerDuetime:
-		return e.Params.GetUint64(params.ThreadpoolTimerDuetime)
-	case fields.ThreadpoolTimerPeriod:
-		return e.Params.GetUint32(params.ThreadpoolTimerPeriod)
-	case fields.ThreadpoolTimerWindow:
-		return e.Params.GetUint32(params.ThreadpoolTimerWindow)
-	case fields.ThreadpoolTimerAbsolute:
-		return e.Params.GetBool(params.ThreadpoolTimerAbsolute)
 	}
 
 	return nil, nil

--- a/pkg/filter/fields/fields_windows.go
+++ b/pkg/filter/fields/fields_windows.go
@@ -641,39 +641,6 @@ const (
 	DNSAnswers Field = "dns.answers"
 	// DNSRcode identifies the field that represents the DNS response code
 	DNSRcode Field = "dns.rcode"
-
-	// ThreadpoolPoolID identifies the field that represents the thread pool identifier
-	ThreadpoolPoolID = "threadpool.id"
-	// ThreadpoolTaskID identifies the field that represents the thread pool task identifier
-	ThreadpoolTaskID = "threadpool.task.id"
-	// ThreadpoolCallbackAddress identifies the field that represents the address of the callback function
-	ThreadpoolCallbackAddress = "threadpool.callback.address"
-	// ThreadpoolCallbackSymbol identifies the field that represents the callback symbol
-	ThreadpoolCallbackSymbol = "threadpool.callback.symbol"
-	// ThreadpoolCallbackModule identifies the field that represents the module containing the callback symbol
-	ThreadpoolCallbackModule = "threadpool.callback.module"
-	// ThreadpoolCallbackContext identifies the field that represents the address of the callback context
-	ThreadpoolCallbackContext = "threadpool.callback.context"
-	// ThreadpoolCallbackContextRip identifies the field that represents the value of instruction pointer contained in the callback context
-	ThreadpoolCallbackContextRip = "threadpool.callback.context.rip"
-	// ThreadpoolCallbackContextRipSymbol identifies the field that represents the symbol name associated with the instruction pointer in callback context
-	ThreadpoolCallbackContextRipSymbol = "threadpool.callback.context.rip.symbol"
-	// ThreadpoolCallbackContextRipModule identifies the field that represents the module name associated with the instruction pointer in callback context
-	ThreadpoolCallbackContextRipModule = "threadpool.callback.context.rip.module"
-	// ThreadpoolSubprocessTag identifies the field that represents the service identifier associated with the thread pool
-	ThreadpoolSubprocessTag = "threadpool.subprocess_tag"
-	// ThreadpoolTimerDuetime identifies the field that represents the timer due time
-	ThreadpoolTimerDuetime = "threadpool.timer.duetime"
-	// ThreadpoolTimerSubqueue identifies the field that represents the memory address of the timer subqueue
-	ThreadpoolTimerSubqueue = "threadpool.timer.subqueue"
-	// ThreadpoolTimer identifies the field that represents the memory address of the timer object
-	ThreadpoolTimer = "threadpool.timer.address"
-	// ThreadpoolTimerPeriod identifies the field that represents the period of the timer
-	ThreadpoolTimerPeriod = "threadpool.timer.period"
-	// ThreadpoolTimerWindow identifies the field that represents the timer tolerate period
-	ThreadpoolTimerWindow = "threadpool.timer.window"
-	// ThreadpoolTimerAbsolute identifies the field that indicates if the timer is absolute or relative
-	ThreadpoolTimerAbsolute = "threadpool.timer.is_absolute"
 )
 
 // String casts the field type to string.
@@ -696,9 +663,8 @@ func (f Field) IsPeField() bool {
 func (f Field) IsModuleField() bool {
 	return strings.HasPrefix(string(f), "module.") || strings.HasPrefix(string(f), "dll.")
 }
-func (f Field) IsMemField() bool        { return strings.HasPrefix(string(f), "mem.") }
-func (f Field) IsDNSField() bool        { return strings.HasPrefix(string(f), "dns.") }
-func (f Field) IsThreadpoolField() bool { return strings.HasPrefix(string(f), "threadpool.") }
+func (f Field) IsMemField() bool { return strings.HasPrefix(string(f), "mem.") }
+func (f Field) IsDNSField() bool { return strings.HasPrefix(string(f), "dns.") }
 
 func (f Field) IsPeSection() bool { return f == PeNumSections || f == PsPeNumSections }
 func (f Field) IsPeSymbol() bool {
@@ -1249,23 +1215,6 @@ var fields = map[Field]FieldInfo{
 	DNSOptions: {DNSOptions, "dns query options", params.Flags64, []string{"dns.options in ('ADDRCONFIG', 'DUAL_ADDR')"}, nil, nil},
 	DNSRcode:   {DNSRR, "dns response status", params.AnsiString, []string{"dns.rcode = 'NXDOMAIN'"}, nil, nil},
 	DNSAnswers: {DNSAnswers, "dns response answers", params.Slice, []string{"dns.answers in ('o.lencr.edgesuite.net', 'a1887.dscq.akamai.net')"}, nil, nil},
-
-	ThreadpoolPoolID:                   {ThreadpoolPoolID, "thread pool identifier", params.Address, []string{"threadpool.id = '20f5fc02440'"}, nil, nil},
-	ThreadpoolTaskID:                   {ThreadpoolTaskID, "thread pool task identifier", params.Address, []string{"threadpool.task.id = '20f7ecd21f8'"}, nil, nil},
-	ThreadpoolCallbackAddress:          {ThreadpoolCallbackAddress, "thread pool callback address", params.Address, []string{"threadpool.callback.address = '7ff868739ed0'"}, nil, nil},
-	ThreadpoolCallbackSymbol:           {ThreadpoolCallbackSymbol, "thread pool callback symbol", params.UnicodeString, []string{"threadpool.callback.symbol = 'RtlDestroyQueryDebugBuffer'"}, nil, nil},
-	ThreadpoolCallbackModule:           {ThreadpoolCallbackModule, "thread pool module containing the callback symbol", params.UnicodeString, []string{"threadpool.callback.module contains 'ntdll.dll'"}, nil, nil},
-	ThreadpoolCallbackContext:          {ThreadpoolCallbackContext, "thread pool callback context address", params.Address, []string{"threadpool.callback.context = '1df41e07bd0'"}, nil, nil},
-	ThreadpoolCallbackContextRip:       {ThreadpoolCallbackContextRip, "thread pool callback thread context instruction pointer", params.Address, []string{"threadpool.callback.context.rip = '1df42ffc1f8'"}, nil, nil},
-	ThreadpoolCallbackContextRipSymbol: {ThreadpoolCallbackContextRipSymbol, "thread pool callback thread context instruction pointer symbol", params.UnicodeString, []string{"threadpool.callback.context.rip.symbol = 'VirtualProtect'"}, nil, nil},
-	ThreadpoolCallbackContextRipModule: {ThreadpoolCallbackContextRipModule, "thread pool callback thread context instruction pointer symbol module", params.UnicodeString, []string{"threadpool.callback.context.rip.module contains 'ntdll.dll'"}, nil, nil},
-	ThreadpoolSubprocessTag:            {ThreadpoolSubprocessTag, "thread pool service identifier", params.Address, []string{"threadpool.subprocess_tag = '10d'"}, nil, nil},
-	ThreadpoolTimerDuetime:             {ThreadpoolTimerDuetime, "thread pool timer due time", params.Uint64, []string{"threadpool.timer.duetime > 10"}, nil, nil},
-	ThreadpoolTimerSubqueue:            {ThreadpoolTimerSubqueue, "thread pool timer subqueue address", params.Address, []string{"threadpool.timer.subqueue = '1db401703e8'"}, nil, nil},
-	ThreadpoolTimer:                    {ThreadpoolTimer, "thread pool timer address", params.Address, []string{"threadpool.timer.address = '3e8'"}, nil, nil},
-	ThreadpoolTimerPeriod:              {ThreadpoolTimerPeriod, "thread pool timer period", params.Uint32, []string{"threadpool.timer.period = 0'"}, nil, nil},
-	ThreadpoolTimerWindow:              {ThreadpoolTimerWindow, "thread pool timer tolerate period", params.Uint32, []string{"threadpool.timer.window = 0'"}, nil, nil},
-	ThreadpoolTimerAbsolute:            {ThreadpoolTimerAbsolute, "indicates if the thread pool timer is absolute or relative", params.Bool, []string{"threadpool.timer.is_absolute = true'"}, nil, nil},
 }
 
 // ArgumentOf returns argument data for the specified field.

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -135,8 +135,6 @@ func (b *BoundField) Accessor(f *filter) Accessor {
 		b.accessor = newMemAccessor()
 	case b.Field.Name.IsDNSField():
 		b.accessor = newDNSAccessor()
-	case b.Field.Name.IsThreadpoolField():
-		b.accessor = newThreadAccessor()
 	}
 	return b.accessor
 }

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -51,14 +51,13 @@ import (
 
 var cfg = &config.Config{
 	EventSource: config.EventSourceConfig{
-		EnableNetEvents:        true,
-		EnableRegistryEvents:   true,
-		EnableFileIOEvents:     true,
-		EnableModuleEvents:     true,
-		EnableThreadEvents:     true,
-		EnableMemEvents:        true,
-		EnableDNSEvents:        true,
-		EnableThreadpoolEvents: true,
+		EnableNetEvents:      true,
+		EnableRegistryEvents: true,
+		EnableFileIOEvents:   true,
+		EnableModuleEvents:   true,
+		EnableThreadEvents:   true,
+		EnableMemEvents:      true,
+		EnableDNSEvents:      true,
 	},
 	Filters: &config.Filters{},
 	PE:      pe.Config{Enabled: true},
@@ -1350,71 +1349,6 @@ func TestDNSFilter(t *testing.T) {
 		matches := f.Eval(evt)
 		if matches != tt.matches {
 			t.Errorf("%d. %q dns filter mismatch: exp=%t got=%t", i, tt.filter, tt.matches, matches)
-		}
-	}
-}
-
-func TestThreadpoolFilter(t *testing.T) {
-	e := &event.Event{
-		Type:      event.SubmitThreadpoolCallback,
-		Tid:       2484,
-		PID:       1023,
-		CPU:       1,
-		Seq:       2,
-		Name:      "SubmitThreadpoolCallback",
-		Timestamp: time.Now(),
-		Category:  event.Threadpool,
-		Params: event.Params{
-			params.ThreadpoolPoolID:           {Name: params.ThreadpoolPoolID, Type: params.Address, Value: uint64(0x20f5fc02440)},
-			params.ThreadpoolTaskID:           {Name: params.ThreadpoolTaskID, Type: params.Address, Value: uint64(0x20f7ecd21f8)},
-			params.ThreadpoolCallback:         {Name: params.ThreadpoolCallback, Type: params.Address, Value: uint64(0x7ffb3138592e)},
-			params.ThreadpoolContext:          {Name: params.ThreadpoolContext, Type: params.Address, Value: uint64(0x14d0d16fed8)},
-			params.ThreadpoolContextRip:       {Name: params.ThreadpoolContextRip, Type: params.Address, Value: uint64(0x143c9b07bd0)},
-			params.ThreadpoolSubprocessTag:    {Name: params.ThreadpoolSubprocessTag, Type: params.Address, Value: uint64(0x10d)},
-			params.ThreadpoolContextRipSymbol: {Name: params.ThreadpoolContextRipSymbol, Type: params.UnicodeString, Value: "VirtualProtect"},
-			params.ThreadpoolContextRipModule: {Name: params.ThreadpoolContextRipModule, Type: params.UnicodeString, Value: "C:\\Windows\\System32\\kernelbase.dll"},
-			params.ThreadpoolCallbackSymbol:   {Name: params.ThreadpoolCallbackSymbol, Type: params.UnicodeString, Value: "RtlDestroyQueryDebugBuffer"},
-			params.ThreadpoolCallbackModule:   {Name: params.ThreadpoolCallbackModule, Type: params.UnicodeString, Value: "C:\\Windows\\System32\\ntdll.dll"},
-			params.ThreadpoolTimerSubqueue:    {Name: params.ThreadpoolTimerSubqueue, Type: params.Address, Value: uint64(0x1db401703e8)},
-			params.ThreadpoolTimerDuetime:     {Name: params.ThreadpoolTimerDuetime, Type: params.Uint64, Value: uint64(18446744073699551616)},
-			params.ThreadpoolTimer:            {Name: params.ThreadpoolTimer, Type: params.Address, Value: uint64(0x3e8)},
-			params.ThreadpoolTimerPeriod:      {Name: params.ThreadpoolTimerPeriod, Type: params.Uint32, Value: uint32(100)},
-			params.ThreadpoolTimerWindow:      {Name: params.ThreadpoolTimerWindow, Type: params.Uint32, Value: uint32(50)},
-			params.ThreadpoolTimerAbsolute:    {Name: params.ThreadpoolTimerAbsolute, Type: params.Bool, Value: true},
-		},
-	}
-
-	var tests = []struct {
-		filter  string
-		matches bool
-	}{
-
-		{`threadpool.id = '20f5fc02440'`, true},
-		{`threadpool.task.id = '20f7ecd21f8'`, true},
-		{`threadpool.callback.address = '7ffb3138592e'`, true},
-		{`threadpool.callback.symbol = 'RtlDestroyQueryDebugBuffer'`, true},
-		{`threadpool.callback.module = 'C:\\Windows\\System32\\ntdll.dll'`, true},
-		{`threadpool.callback.context = '14d0d16fed8'`, true},
-		{`threadpool.callback.context.rip = '143c9b07bd0'`, true},
-		{`threadpool.callback.context.rip.symbol = 'VirtualProtect'`, true},
-		{`threadpool.callback.context.rip.module = 'C:\\Windows\\System32\\kernelbase.dll'`, true},
-		{`threadpool.timer.address = '3e8'`, true},
-		{`threadpool.timer.subqueue = '1db401703e8'`, true},
-		{`threadpool.timer.duetime = 18446744073699551616`, true},
-		{`threadpool.timer.period = 100`, true},
-		{`threadpool.timer.window = 50`, true},
-		{`threadpool.timer.is_absolute = true`, true},
-	}
-
-	for i, tt := range tests {
-		f := New(tt.filter, cfg)
-		err := f.Compile()
-		if err != nil {
-			t.Fatal(err)
-		}
-		matches := f.Eval(e)
-		if matches != tt.matches {
-			t.Errorf("%d. %q threadpool filter mismatch: exp=%t got=%t", i, tt.filter, tt.matches, matches)
 		}
 	}
 }

--- a/pkg/filter/filter_windows.go
+++ b/pkg/filter/filter_windows.go
@@ -82,9 +82,6 @@ func New(expr string, config *config.Config, options ...Option) Filter {
 	if config.EventSource.EnableDNSEvents {
 		accessors = append(accessors, newDNSAccessor())
 	}
-	if config.EventSource.EnableThreadpoolEvents {
-		accessors = append(accessors, newThreadpoolAccessor())
-	}
 
 	var parser *ql.Parser
 	if fconfig.HasMacros() {

--- a/pkg/filter/ql/function.go
+++ b/pkg/filter/ql/function.go
@@ -299,19 +299,18 @@ func (f *Foreach) Desc() functions.FunctionDesc {
 			e := args[2] // expression
 
 			var reserved = map[string]bool{ // reserved bound variable names
-				"$ps":         true,
-				"$pe":         true,
-				"$file":       true,
-				"$image":      true,
-				"$module":     true,
-				"$dll":        true,
-				"$thread":     true,
-				"$threadpool": true,
-				"$registry":   true,
-				"$net":        true,
-				"$mem":        true,
-				"$dns":        true,
-				"$evt":        true,
+				"$ps":       true,
+				"$pe":       true,
+				"$file":     true,
+				"$image":    true,
+				"$module":   true,
+				"$dll":      true,
+				"$thread":   true,
+				"$registry": true,
+				"$net":      true,
+				"$mem":      true,
+				"$dns":      true,
+				"$evt":      true,
 			}
 
 			if reserved[v] {

--- a/pkg/rules/compiler.go
+++ b/pkg/rules/compiler.go
@@ -354,8 +354,6 @@ func (c *compiler) buildCompileResult(filters map[*config.FilterConfig]filter.Fi
 							rs.HasRegistryEvents = true
 						case event.Mem:
 							rs.HasMemEvents = true
-						case event.Threadpool:
-							rs.HasThreadpoolEvents = true
 						}
 						if typ.Subcategory() == event.DNS {
 							rs.HasDNSEvents = true

--- a/pkg/symbolize/symbolizer.go
+++ b/pkg/symbolize/symbolizer.go
@@ -36,7 +36,6 @@ import (
 	pstypes "github.com/rabbitstack/fibratus/pkg/ps/types"
 	"github.com/rabbitstack/fibratus/pkg/sys"
 	"github.com/rabbitstack/fibratus/pkg/util/convert"
-	"github.com/rabbitstack/fibratus/pkg/util/threadcontext"
 	"github.com/rabbitstack/fibratus/pkg/util/va"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
@@ -319,9 +318,6 @@ func (s *Symbolizer) processCallstack(e *event.Event) error {
 		case event.CreateThread:
 			pid = e.Params.MustGetPid()
 			addr = e.Params.TryGetAddress(params.StartAddress)
-		case event.SubmitThreadpoolWork, event.SubmitThreadpoolCallback:
-			pid = e.PID
-			addr = e.Params.TryGetAddress(params.ThreadpoolCallback)
 		}
 
 		// symbolize thread start or thread pool callback address
@@ -338,31 +334,6 @@ func (s *Symbolizer) processCallstack(e *event.Event) error {
 				switch e.Type {
 				case event.CreateThread:
 					e.Params.Append(params.StartAddressSymbol, params.UnicodeString, symbol)
-				case event.SubmitThreadpoolWork, event.SubmitThreadpoolCallback:
-					e.Params.Append(params.ThreadpoolCallbackSymbol, params.UnicodeString, symbol)
-
-					ctx := e.Params.TryGetAddress(params.ThreadpoolContext)
-
-					// if the callback resolves to one of the functions
-					// that receive the CONTEXT structure as a parameter
-					// try to read the thread context and resolve the
-					// function address stored in the instruction pointer
-					if ctx != 0 && threadcontext.IsParamOfFunc(symbol) {
-						rip := threadcontext.Rip(pid, ctx)
-						if rip != 0 {
-							e.Params.Append(params.ThreadpoolContextRip, params.Address, rip.Uint64())
-
-							m := e.PS.FindModuleByVa(rip)
-							if m != nil {
-								e.Params.Append(params.ThreadpoolContextRipModule, params.UnicodeString, m.Name)
-							}
-
-							sym := s.symbolizeAddress(pid, rip, m)
-							if sym != "" && sym != "?" {
-								e.Params.Append(params.ThreadpoolContextRipSymbol, params.UnicodeString, sym)
-							}
-						}
-					}
 				}
 			}
 
@@ -370,8 +341,6 @@ func (s *Symbolizer) processCallstack(e *event.Event) error {
 				switch e.Type {
 				case event.CreateThread:
 					e.Params.Append(params.StartAddressModule, params.UnicodeString, mod.Name)
-				case event.SubmitThreadpoolWork, event.SubmitThreadpoolCallback:
-					e.Params.Append(params.ThreadpoolCallbackModule, params.UnicodeString, mod.Name)
 				}
 			}
 		}

--- a/pkg/symbolize/symbolizer_test.go
+++ b/pkg/symbolize/symbolizer_test.go
@@ -482,30 +482,6 @@ func TestSymbolizeEventParamAddress(t *testing.T) {
 
 	assert.Equal(t, "CreateProcessW", e.GetParamAsString(params.StartAddressSymbol))
 	assert.Equal(t, "C:\\Windows\\System32\\ntdll.dll", e.GetParamAsString(params.StartAddressModule))
-
-	e1 := &event.Event{
-		Type:      event.SubmitThreadpoolCallback,
-		Tid:       2484,
-		PID:       uint32(os.Getpid()),
-		CPU:       1,
-		Seq:       2,
-		Name:      "SubmitThreadpoolCallback",
-		Timestamp: time.Now(),
-		Category:  event.Threadpool,
-		Host:      "archrabbit",
-		Params: event.Params{
-			params.Callstack:          {Name: params.Callstack, Type: params.Slice, Value: []va.Address{0x7ffb5c1d0396}},
-			params.ThreadpoolCallback: {Name: params.ThreadpoolCallback, Type: params.Address, Value: uint64(0x7ffb3138592e)},
-			params.ThreadpoolContext:  {Name: params.ThreadpoolContext, Type: params.Address, Value: uint64(0)},
-		},
-		PS: proc,
-	}
-
-	_, err = s.ProcessEvent(e1)
-	require.NoError(t, err)
-
-	assert.Equal(t, "CreateProcessW", e1.GetParamAsString(params.ThreadpoolCallbackSymbol))
-	assert.Equal(t, "C:\\Windows\\System32\\ntdll.dll", e1.GetParamAsString(params.ThreadpoolCallbackModule))
 }
 
 func init() {

--- a/pkg/sys/etw/types.go
+++ b/pkg/sys/etw/types.go
@@ -42,9 +42,6 @@ var KernelAuditAPICallsGUID = windows.GUID{Data1: 0xe02a841c, Data2: 0x75a3, Dat
 // DNSClientGUID represents the GUID for the Windows DNS Client provider
 var DNSClientGUID = windows.GUID{Data1: 0x1c95126e, Data2: 0x7eea, Data3: 0x49a9, Data4: [8]byte{0xa3, 0xfe, 0xa3, 0x78, 0xb0, 0x3d, 0xdb, 0x4d}}
 
-// ThreadpoolGUID represents the GUID for the thread pool provider
-var ThreadpoolGUID = windows.GUID{Data1: 0xc861d0e2, Data2: 0xa2c1, Data3: 0x4d36, Data4: [8]byte{0x9f, 0x9c, 0x97, 0x0b, 0xab, 0x94, 0x3a, 0x12}}
-
 // WindowsKernelProcessGUID represents the GUID for the Microsoft Windows Kernel Process provider
 var WindowsKernelProcessGUID = windows.GUID{Data1: 0x22fb2cd6, Data2: 0x0e7b, Data3: 0x422b, Data4: [8]byte{0xa0, 0xc7, 0x2f, 0xad, 0x1f, 0xd0, 0xe7, 0x16}}
 

--- a/pkg/sys/etw/types_test.go
+++ b/pkg/sys/etw/types_test.go
@@ -19,10 +19,11 @@
 package etw
 
 import (
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/sys/windows"
 	"testing"
 	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/windows"
 )
 
 func TestReadBuffer(t *testing.T) {
@@ -97,9 +98,4 @@ func TestReadBuffer(t *testing.T) {
 		}
 		tt.assertions(t, ev)
 	}
-}
-
-func TestID(t *testing.T) {
-	ev := &EventRecord{Header: EventHeader{ProviderID: ThreadpoolGUID, EventDescriptor: EventDescriptor{ID: 44}}}
-	assert.Equal(t, uint(14439051552138264620), ev.ID())
 }


### PR DESCRIPTION
### What is the purpose of this PR / why it is needed?

The main reason for capturing thread pool telemetry were aimed at implementing sleep obfuscation and thread pool injection rules. Since we've found a much more robust and cheaper alternative, it doesn't make sense to keep this telemetry source anymore. In any case, it is pretty chatty for the value it could have provided.

### What type of change does this PR introduce?

---

> Uncomment one or more `/kind <>` lines:

> /kind feature (non-breaking change which adds functionality)

> /kind bug-fix (non-breaking change which fixes an issue)

/kind refactor (non-breaking change that restructures the code, while not changing the original functionality)

> /kind breaking (fix or feature that would cause existing functionality to not work as expected

/kind cleanup

> /kind improvement

> /kind design

> /kind documentation

> /kind other (change that doesn't pertain to any of the above categories)


### Any specific area of the project related to this PR?

---

> Uncomment one or more `/area <>` lines:

> /area instrumentation

/area telemetry

> /area rule-engine

> /area filters

> /area yara

> /area event

> /area captures

> /area alertsenders

> /area outputs

> /area rules

> /area filaments

> /area config

> /area cli

> /area tests

> /area ci

> /area build

> /area docs

> /area deps

> /area evasion

> /area other


### Special notes for the reviewer

---

### Does this PR introduce a user-facing change?

---
